### PR TITLE
Avoid blocking on create_client call

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,9 +36,9 @@ Basic Example
         key = '{}/{}'.format(folder, filename)
 
         session = aiobotocore.get_session(loop=loop)
-        client = session.create_client('s3', region_name='us-west-2',
-                                       aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
-                                       aws_access_key_id=AWS_ACCESS_KEY_ID)
+        client = yield from session.create_client('s3', region_name='us-west-2',
+                                                  aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+                                                  aws_access_key_id=AWS_ACCESS_KEY_ID)
         # upload object to amazon s3
         data = b'\x01'*1024
         resp = yield from client.put_object(Bucket=bucket,

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 from functools import wraps
 import os
 import time
@@ -8,6 +10,7 @@ import shutil
 import unittest
 from unittest import mock
 import contextlib
+
 from botocore.vendored.requests import adapters
 from botocore.vendored.requests.exceptions import ConnectionError
 from botocore.compat import six
@@ -15,7 +18,9 @@ import botocore.auth
 import botocore.credentials
 import botocore.vendored.requests as requests
 from botocore.client import Config
+
 import aiobotocore
+import aiobotocore.endpoint
 
 
 def run_until_complete(fun):
@@ -168,6 +173,12 @@ class BaseS3ClientTest(BaseTest):
             num_uploads, amount_seen))
 
 
+class TestS3Client(BaseS3ClientTest):
+
+    def test_client_endpoint_is_patched(self):
+        self.assertIsInstance(self.client._endpoint, aiobotocore.endpoint.AioEndpoint)
+
+
 class TestS3BaseWithBucket(BaseS3ClientTest):
     def setUp(self):
         super().setUp()
@@ -175,6 +186,7 @@ class TestS3BaseWithBucket(BaseS3ClientTest):
 
 
 class TestS3Buckets(TestS3BaseWithBucket):
+
     @run_until_complete
     def test_can_make_request(self):
         # Basic smoke test to ensure we can talk to s3.


### PR DESCRIPTION
Some credentials providers do blocking IO. Wrap all of them
with a thread so we don't block the event loop.

See issue #2
