### PR TITLE
bugfix for pagination

### DIFF
--- a/aiobotocore/paginate.py
+++ b/aiobotocore/paginate.py
@@ -63,7 +63,7 @@ class AioPageIterator(PageIterator):
         else:
             self._total_items += num_current_response
             self._next_token = self._get_next_token(parsed)
-            if all(t is None for t in self._next_token):
+            if all(t is None for t in self._next_token.values()):
                 self._is_stop = True
                 return response
             if self._max_items is not None and \


### PR DESCRIPTION
looks like we missed this.  Here's a testcase when you have only one page of data:

```python
import aiobotocore

session = aiobotocore.get_session()
ecs_client = session.create_client('ecs')

@asyncio.coroutine
def paginated(obj, method_name, result_list, **kwargs):
    paginator = obj.get_paginator(method_name).paginate(**kwargs)
    result = []

    while True:
        p = yield from paginator.next_page()
        if p is None: break

        result += p[result_list]

    return result

paginated(ecs_client, 'list_clusters', 'clusterArns')
```