### PR TITLE
client + endpoint updates

### DIFF
--- a/aiobotocore/client.py
+++ b/aiobotocore/client.py
@@ -1,5 +1,6 @@
 import asyncio
 import copy
+import sys
 
 import botocore.auth
 import botocore.client
@@ -16,6 +17,8 @@ from botocore.utils import get_service_module_name
 from .config import AioConfig
 from .endpoint import AioEndpointCreator
 from .paginate import AioPageIterator
+
+PY_35 = sys.version_info >= (3, 5)
 
 
 class AioClientCreator(botocore.client.ClientCreator):
@@ -182,6 +185,16 @@ class AioBaseClient(botocore.client.BaseClient):
                 getattr(self, operation_name),
                 self._cache['page_config'][actual_operation_name])
             return paginator
+
+    if PY_35:
+        @asyncio.coroutine
+        def __aenter__(self):
+            yield from self._endpoint._aio_session.__aenter__()
+            return self
+
+        @asyncio.coroutine
+        def __aexit__(self, exc_type, exc_val, exc_tb):
+            yield from self._endpoint._aio_session.__aexit__(exc_type, exc_val, exc_tb)
 
     def close(self):
         """Close all http connections"""

--- a/aiobotocore/client.py
+++ b/aiobotocore/client.py
@@ -194,7 +194,8 @@ class AioBaseClient(botocore.client.BaseClient):
 
         @asyncio.coroutine
         def __aexit__(self, exc_type, exc_val, exc_tb):
-            yield from self._endpoint._aio_session.__aexit__(exc_type, exc_val, exc_tb)
+            yield from self._endpoint._aio_session.__aexit__(exc_type,
+                                                             exc_val, exc_tb)
 
     def close(self):
         """Close all http connections"""

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -69,7 +69,8 @@ class ClientResponseContentProxy:
 
         @asyncio.coroutine
         def __aexit__(self, exc_type, exc_val, exc_tb):
-            return (yield from self.__response.__aexit__(exc_type, exc_val, exc_tb))
+            return (yield from self.__response.__aexit__(exc_type,
+                                                         exc_val, exc_tb))
 
     def close(self):
         self.__response.close()

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -150,7 +150,8 @@ class AioEndpoint(Endpoint):
         request_coro = self._aio_session.request(method, url=url,
                                                  headers=headers_, data=data)
         resp = yield from asyncio.wait_for(
-            request_coro, timeout=self._conn_timeout + self._read_timeout, loop=self._loop)
+            request_coro, timeout=self._conn_timeout + self._read_timeout,
+            loop=self._loop)
         return resp
 
     @asyncio.coroutine
@@ -235,8 +236,9 @@ class AioEndpoint(Endpoint):
             else:
                 return None, e
         except Exception as e:
-            # logger.debug("Exception received when sending HTTP request.",
-            #              exc_info=True)
+            botocore.endpoint.logger.debug("Exception received when sending "
+                                           "HTTP request.",
+                                           exc_info=True)
             return None, e
 
         # This returns the http_response and the parsed_data.

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -97,15 +97,17 @@ class ClientResponseProxy(ClientResponse):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def __getattr__(self, item):
-        if item == 'status_code':
-            return self.status
-        if item == 'content':
-            return self._content
-        if item == 'raw':
-            return ClientResponseContentProxy(self)
+    @property
+    def status_code(self):
+        return self.status
 
-        raise AttributeError
+    @property
+    def content(self):
+        return self._content
+
+    @property
+    def raw(self):
+        return ClientResponseContentProxy(self)
 
 
 class AioEndpoint(Endpoint):


### PR DESCRIPTION
* adds "async with" support to client
* enables aiohttp retry-able exceptions
* removes ClientResponseContentProxy \__del__ since ClientResponse will close + warn user
* fixes "async with" support for ClientResponseContentProxy (missing yield from)
* fixes endpoint's \_get_response to handler aiohttp exceptions and put logging back
* fixes endpoint's request timeout to be connect + read timeout

this continues https://github.com/aio-libs/aiobotocore/pull/44
