### PR TITLE
Newest botocore (1.4.73) support. Fixing #55, #53 and #52.

### DIFF
--- a/aiobotocore/client.py
+++ b/aiobotocore/client.py
@@ -2,13 +2,13 @@ import asyncio
 import copy
 import sys
 
+import botocore.args
 import botocore.auth
 import botocore.client
 import botocore.parsers
 import botocore.serialize
 import botocore.validate
 
-from botocore.client import ClientEndpointBridge
 from botocore.exceptions import ClientError, OperationNotPageableError
 from botocore.paginate import Paginator
 from botocore.signers import RequestSigner
@@ -34,82 +34,15 @@ class AioClientCreator(botocore.client.ClientCreator):
 
     def _get_client_args(self, service_model, region_name, is_secure,
                          endpoint_url, verify, credentials,
-                         scoped_config, client_config):
-
+                         scoped_config, client_config, endpoint_bridge):
         # This is a near copy of botocore.client.ClientCreator. What's replaced
-        # is Config->AioConfig and EndpointCreator->AioEndpointCreator
-        # We don't re-use the parent's implementations due to weak refs
-
-        service_name = service_model.endpoint_prefix
-        protocol = service_model.metadata['protocol']
-        parameter_validation = True
-        if client_config:
-            parameter_validation = client_config.parameter_validation
-        serializer = botocore.serialize.create_serializer(
-            protocol, parameter_validation)
-
-        event_emitter = copy.copy(self._event_emitter)
-        response_parser = botocore.parsers.create_parser(protocol)
-        endpoint_bridge = ClientEndpointBridge(
-            self._endpoint_resolver, scoped_config, client_config,
-            service_signing_name=service_model.metadata.get('signingName'))
-        endpoint_config = endpoint_bridge.resolve(
-            service_name, region_name, endpoint_url, is_secure)
-
-        # Override the user agent if specified in the client config.
-        user_agent = self._user_agent
-        if client_config is not None:
-            if client_config.user_agent is not None:
-                user_agent = client_config.user_agent
-            if client_config.user_agent_extra is not None:
-                user_agent += ' %s' % client_config.user_agent_extra
-
-        signer = RequestSigner(
-            service_name, endpoint_config['signing_region'],
-            endpoint_config['signing_name'],
-            endpoint_config['signature_version'],
-            credentials, event_emitter)
-
-        # Create a new client config to be passed to the client based
-        # on the final values. We do not want the user to be able
-        # to try to modify an existing client with a client config.
-        config_kwargs = dict(
-            region_name=endpoint_config['region_name'],
-            signature_version=endpoint_config['signature_version'],
-            user_agent=user_agent)
-        if client_config is not None:
-            config_kwargs.update(
-                connect_timeout=client_config.connect_timeout,
-                read_timeout=client_config.read_timeout)
-
-        # Add any additional s3 configuration for client
-        self._inject_s3_configuration(
-            config_kwargs, scoped_config, client_config)
-
-        if isinstance(client_config, AioConfig):
-            connector_args = client_config.connector_args
-        else:
-            connector_args = None
-
-        new_config = AioConfig(connector_args, **config_kwargs)
-        endpoint_creator = AioEndpointCreator(event_emitter, self._loop)
-        endpoint = endpoint_creator.create_endpoint(
-            service_model, region_name=endpoint_config['region_name'],
-            endpoint_url=endpoint_config['endpoint_url'], verify=verify,
-            response_parser_factory=self._response_parser_factory,
-            timeout=(new_config.connect_timeout, new_config.read_timeout),
-            connector_args=new_config.connector_args)
-
-        return {
-            'serializer': serializer,
-            'endpoint': endpoint,
-            'response_parser': response_parser,
-            'event_emitter': event_emitter,
-            'request_signer': signer,
-            'service_model': service_model,
-            'loader': self._loader,
-            'client_config': new_config
-        }
+        # is ClientArgsCreator->AioClientArgsCreator
+        args_creator = AioClientArgsCreator(
+            self._event_emitter, self._user_agent,
+            self._response_parser_factory, self._loader, loop=self._loop)
+        return args_creator.get_client_args(
+            service_model, region_name, is_secure, endpoint_url,
+            verify, credentials, scoped_config, client_config, endpoint_bridge)
 
     def _create_client_class(self, service_name, service_model):
         class_attributes = self._create_methods(service_model)
@@ -132,16 +65,18 @@ class AioBaseClient(botocore.client.BaseClient):
         request_dict = self._convert_to_request_dict(
             api_params, operation_model, context=request_context)
 
-        self.meta.events.emit(
+        handler, event_response = self.meta.events.emit_until_response(
             'before-call.{endpoint_prefix}.{operation_name}'.format(
                 endpoint_prefix=self._service_model.endpoint_prefix,
                 operation_name=operation_name),
             model=operation_model, params=request_dict,
-            request_signer=self._request_signer, context=request_context
-        )
+            request_signer=self._request_signer, context=request_context)
 
-        http, parsed_response = yield from self._endpoint.make_request(
-            operation_model, request_dict)
+        if event_response is not None:
+            http, parsed_response = event_response
+        else:
+            http, parsed_response = yield from self._endpoint.make_request(
+                operation_model, request_dict)
 
         self.meta.events.emit(
             'after-call.{endpoint_prefix}.{operation_name}'.format(
@@ -202,3 +137,63 @@ class AioBaseClient(botocore.client.BaseClient):
         # ClientSession.close() from aiohttp returns asyncio.Future here so
         # this method could be used with yield from/await
         return self._endpoint._aio_session.close()
+
+
+class AioClientArgsCreator(botocore.args.ClientArgsCreator):
+    def __init__(self, event_emitter, user_agent, response_parser_factory, loader, loop=None):
+        super().__init__(event_emitter, user_agent, response_parser_factory, loader)
+        self._loop = loop or asyncio.get_event_loop()
+
+    def get_client_args(self, service_model, region_name, is_secure,
+                        endpoint_url, verify, credentials, scoped_config,
+                        client_config, endpoint_bridge):
+        final_args = self.compute_client_args(
+            service_model, client_config, endpoint_bridge, region_name,
+            endpoint_url, is_secure, scoped_config)
+
+        service_name = final_args['service_name']
+        parameter_validation = final_args['parameter_validation']
+        endpoint_config = final_args['endpoint_config']
+        protocol = final_args['protocol']
+        config_kwargs = final_args['config_kwargs']
+        s3_config = final_args['s3_config']
+        partition = endpoint_config['metadata'].get('partition', None)
+
+        event_emitter = copy.copy(self._event_emitter)
+        signer = RequestSigner(
+            service_name, endpoint_config['signing_region'],
+            endpoint_config['signing_name'],
+            endpoint_config['signature_version'],
+            credentials, event_emitter)
+
+        config_kwargs['s3'] = s3_config
+
+        if isinstance(client_config, AioConfig):
+            connector_args = client_config.connector_args
+        else:
+            connector_args = None
+
+        new_config = AioConfig(connector_args, **config_kwargs)
+        endpoint_creator = AioEndpointCreator(event_emitter, self._loop)
+
+        endpoint = endpoint_creator.create_endpoint(
+            service_model, region_name=endpoint_config['region_name'],
+            endpoint_url=endpoint_config['endpoint_url'], verify=verify,
+            response_parser_factory=self._response_parser_factory,
+            timeout=(new_config.connect_timeout, new_config.read_timeout),
+            connector_args=new_config.connector_args)
+
+        serializer = botocore.serialize.create_serializer(
+            protocol, parameter_validation)
+        response_parser = botocore.parsers.create_parser(protocol)
+        return {
+            'serializer': serializer,
+            'endpoint': endpoint,
+            'response_parser': response_parser,
+            'event_emitter': event_emitter,
+            'request_signer': signer,
+            'service_model': service_model,
+            'loader': self._loader,
+            'client_config': new_config,
+            'partition': partition
+        }

--- a/aiobotocore/client.py
+++ b/aiobotocore/client.py
@@ -140,8 +140,10 @@ class AioBaseClient(botocore.client.BaseClient):
 
 
 class AioClientArgsCreator(botocore.args.ClientArgsCreator):
-    def __init__(self, event_emitter, user_agent, response_parser_factory, loader, loop=None):
-        super().__init__(event_emitter, user_agent, response_parser_factory, loader)
+    def __init__(self, event_emitter, user_agent, response_parser_factory,
+                 loader, loop=None):
+        super().__init__(event_emitter, user_agent,
+                         response_parser_factory, loader)
         self._loop = loop or asyncio.get_event_loop()
 
     def get_client_args(self, service_model, region_name, is_secure,

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -118,7 +118,6 @@ class ClientResponseProxy:
 
 
 class AioEndpoint(Endpoint):
-
     def __init__(self, host,
                  endpoint_prefix, event_emitter, proxies=None, verify=True,
                  timeout=DEFAULT_TIMEOUT, response_parser_factory=None,
@@ -182,7 +181,8 @@ class AioEndpoint(Endpoint):
         success_response, exception = yield from self._get_response(
             request, operation_model, attempts)
         while (yield from self._needs_retry(attempts, operation_model,
-                                request_dict, success_response, exception)):
+                                            request_dict, success_response,
+                                            exception)):
             attempts += 1
             # If there is a stream associated with the request, we need
             # to reset it before attempting to send the request again.
@@ -273,7 +273,6 @@ class AioEndpoint(Endpoint):
 
 
 class AioEndpointCreator(EndpointCreator):
-
     def __init__(self, event_emitter, loop):
         super().__init__(event_emitter)
         self._loop = loop
@@ -282,7 +281,6 @@ class AioEndpointCreator(EndpointCreator):
                         endpoint_url=None, verify=None,
                         response_parser_factory=None, timeout=DEFAULT_TIMEOUT,
                         connector_args=None):
-
         if not is_valid_endpoint_url(endpoint_url):
             raise ValueError("Invalid endpoint: %s" % endpoint_url)
 

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -181,8 +181,8 @@ class AioEndpoint(Endpoint):
         request = self.create_request(request_dict, operation_model)
         success_response, exception = yield from self._get_response(
             request, operation_model, attempts)
-        while (yield from self._needs_retry(attempts, operation_model, request_dict,
-                                            success_response, exception)):
+        while (yield from self._needs_retry(attempts, operation_model,
+                                request_dict, success_response, exception)):
             attempts += 1
             # If there is a stream associated with the request, we need
             # to reset it before attempting to send the request again.
@@ -201,8 +201,8 @@ class AioEndpoint(Endpoint):
 
     # NOTE: The only line changed here changing time.sleep to asyncio.sleep
     @asyncio.coroutine
-    def _needs_retry(self, attempts, operation_model, request_dict, response=None,
-                     caught_exception=None):
+    def _needs_retry(self, attempts, operation_model, request_dict,
+                     response=None, caught_exception=None):
         event_name = 'needs-retry.%s.%s' % (self._endpoint_prefix,
                                             operation_model.name)
         responses = self._event_emitter.emit(

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -181,7 +181,7 @@ class AioEndpoint(Endpoint):
         request = self.create_request(request_dict, operation_model)
         success_response, exception = yield from self._get_response(
             request, operation_model, attempts)
-        while (yield from self._needs_retry(attempts, operation_model,
+        while (yield from self._needs_retry(attempts, operation_model, request_dict,
                                             success_response, exception)):
             attempts += 1
             # If there is a stream associated with the request, we need
@@ -201,14 +201,14 @@ class AioEndpoint(Endpoint):
 
     # NOTE: The only line changed here changing time.sleep to asyncio.sleep
     @asyncio.coroutine
-    def _needs_retry(self, attempts, operation_model, response=None,
+    def _needs_retry(self, attempts, operation_model, request_dict, response=None,
                      caught_exception=None):
         event_name = 'needs-retry.%s.%s' % (self._endpoint_prefix,
                                             operation_model.name)
         responses = self._event_emitter.emit(
             event_name, response=response, endpoint=self,
             operation=operation_model, attempts=attempts,
-            caught_exception=caught_exception)
+            caught_exception=caught_exception, request_dict=request_dict)
         handler_response = first_non_none_response(responses)
         if handler_response is None:
             return False

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 
 
-install_requires = ['botocore>=1.4.0, <=1.4.28', 'aiohttp>=0.21.2']
+install_requires = ['botocore>=1.4.0, <=1.4.73', 'aiohttp>=0.21.2']
 
 PY_VER = sys.version_info
 


### PR DESCRIPTION
When I tried to use aiobotocore for sending SMS through SNS I've got an error: 
```
ParamValidationErrorbotocore.validate in serialize_to_request
errorParameter validation failed: Unknown parameter in input: "PhoneNumber", must be one of: TopicArn, TargetArn, Message, Subject, MessageStructure, MessageAttributes
```
That's because botocore dependency version was pinned to >=1.4.0 <=1.4.28 because of issues #55, #53 and #52. But support for a `PhoneNumber` parameter in `sns.publish()` was added later. But I really needed the `aiobotocore` library because I'm using Multipart Upload to S3 from `aiohttp` web server.

So I spent an evening to compare the newest `botocore==1.4.73` source code with current aiobotocore modules and have fixed some incompatibilities.

Now I have perfectly working aibotocore in my project. I'm using `aiohttp==1.1.1`, `botocore==1.4.73` and `Python 3.5.2` (with flawless async/await) to upload multipart files to S3 and SNS features (push notifications, SMS). Everything works great.

I've run included tests and got 18 out of 20 passed. As you see below, 2 failed tests are related to DynamoDB and hardcoded ARN's, so I can't test them. This is related to #65 I think. But all Travis tests are passed successfully :)
```
botocore.exceptions.ClientError: An error occurred (AccessDeniedException) when calling the DeleteTable operation: User: arn:aws:iam::9999999999:user/vas3k is not authorized to perform: dynamodb:DeleteTable on resource: arn:aws:dynamodb:us-east-1:641171361437:table/aiobotocoretest_1479318016

===== 18 passed, 1 skipped, 1 xfailed, 2 error in 67.98 seconds ======
```

I hope my pull request will be helpful and I've not missed any important places in code.
