### PR TITLE
pass timeout to request, so it is propagated into StreamRead and affects .read method

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 Changes
 -------
 
+0.1.0 (2017-01-12)
+^^^^^^^^^^^^^^^^^^
+* Pass timeout to aiohttp.request to enforce read_timeout #86 (thanks @vharitonsky)
+  (bumped up to next semantic version due to read_timeout enabling change)
+
 0.0.6 (2016-11-19)
 ^^^^^^^^^^^^^^^^^^
 

--- a/aiobotocore/__init__.py
+++ b/aiobotocore/__init__.py
@@ -1,4 +1,4 @@
 from .session import get_session, AioSession
 
-__version__ = '0.0.7'
+__version__ = '0.1.0'
 (get_session, AioSession)  # make pyflakes happy

--- a/aiobotocore/client.py
+++ b/aiobotocore/client.py
@@ -60,8 +60,12 @@ class AioClientCreator(botocore.client.ClientCreator):
 class AioBaseClient(botocore.client.BaseClient):
     @asyncio.coroutine
     def _make_api_call(self, operation_name, api_params):
-        request_context = {}
         operation_model = self._service_model.operation_model(operation_name)
+        request_context = {
+            'client_region': self.meta.region_name,
+            'client_config': self.meta.config,
+            'has_streaming_input': operation_model.has_streaming_input
+        }
         request_dict = self._convert_to_request_dict(
             api_params, operation_model, context=request_context)
 

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -168,8 +168,9 @@ class AioEndpoint(Endpoint):
         headers_ = dict(
             (z[0], text_(z[1], encoding='utf-8')) for z in headers.items())
         resp = yield from self._aio_session.request(method, url=url,
-                                                 headers=headers_, data=data,
-                                                 timeout=self._read_timeout)
+                                                    headers=headers_,
+                                                    data=data,
+                                                    timeout=self._read_timeout)
         return resp
 
     @asyncio.coroutine

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -167,12 +167,9 @@ class AioEndpoint(Endpoint):
         headers['Accept-Encoding'] = 'identity'
         headers_ = dict(
             (z[0], text_(z[1], encoding='utf-8')) for z in headers.items())
-        request_coro = self._aio_session.request(method, url=url,
+        resp = yield from self._aio_session.request(method, url=url,
                                                  headers=headers_, data=data,
                                                  timeout=self._read_timeout)
-        resp = yield from asyncio.wait_for(
-            request_coro, timeout=self._conn_timeout + self._read_timeout,
-            loop=self._loop)
         return resp
 
     @asyncio.coroutine

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -1,15 +1,17 @@
 import asyncio
 import sys
 import warnings
-
+import yarl
 import aiohttp
 import botocore.endpoint
 import botocore.retryhandler
 from aiohttp.client_reqrep import ClientResponse
-from botocore.endpoint import EndpointCreator, Endpoint, DEFAULT_TIMEOUT
+from botocore.endpoint import EndpointCreator, Endpoint, DEFAULT_TIMEOUT, \
+    MAX_POOL_CONNECTIONS
 from botocore.exceptions import EndpointConnectionError, ConnectionClosedError
 from botocore.hooks import first_non_none_response
 from botocore.utils import is_valid_endpoint_url
+from aiohttp import MultiDict
 
 PY_35 = sys.version_info >= (3, 5)
 
@@ -121,12 +123,14 @@ class AioEndpoint(Endpoint):
     def __init__(self, host,
                  endpoint_prefix, event_emitter, proxies=None, verify=True,
                  timeout=DEFAULT_TIMEOUT, response_parser_factory=None,
+                 max_pool_connections=MAX_POOL_CONNECTIONS,
                  loop=None, connector_args=None):
 
         super().__init__(host, endpoint_prefix,
                          event_emitter, proxies=proxies, verify=verify,
                          timeout=timeout,
-                         response_parser_factory=response_parser_factory)
+                         response_parser_factory=response_parser_factory,
+                         max_pool_connections=max_pool_connections)
 
         if isinstance(timeout, (list, tuple)):
             self._conn_timeout, self._read_timeout = timeout
@@ -167,7 +171,7 @@ class AioEndpoint(Endpoint):
         # we can remove the following line and take advantage of
         # aws gzip compression.
         headers['Accept-Encoding'] = 'identity'
-        headers_ = dict(
+        headers_ = MultiDict(
             (z[0], text_(z[1], encoding='utf-8')) for z in headers.items())
 
         # For now the request timeout is: read_timeout and max(conn_timeout)
@@ -178,6 +182,7 @@ class AioEndpoint(Endpoint):
             warnings.warn("connection timeout may be reduced due to current "
                           "read timeout")
 
+        url = yarl.URL(url, encoded=True)
         resp = yield from self._aio_session.request(method, url=url,
                                                     headers=headers_,
                                                     data=data,
@@ -201,9 +206,15 @@ class AioEndpoint(Endpoint):
             request.reset_stream()
             # Create a new request when retried (including a new signature).
             request = self.create_request(
-                request_dict, operation_model=operation_model)
+                request_dict, operation_model)
             success_response, exception = yield from self._get_response(
                 request, operation_model, attempts)
+        if success_response is not None and \
+                'ResponseMetadata' in success_response[1]:
+            # We want to share num retries, not num attempts.
+            total_retries = attempts - 1
+            success_response[1]['ResponseMetadata']['RetryAttempts'] = \
+                total_retries
         if exception is not None:
             raise exception
         else:
@@ -242,6 +253,8 @@ class AioEndpoint(Endpoint):
         try:
             # http request substituted too async one
             botocore.endpoint.logger.debug("Sending http request: %s", request)
+
+            # TODO: handle self.proxies
             resp = yield from self._request(
                 request.method, request.url, request.headers, request.body)
             http_response = resp
@@ -277,9 +290,9 @@ class AioEndpoint(Endpoint):
             http_response, operation_model)
         parser = self._response_parser_factory.create_parser(
             operation_model.metadata['protocol'])
-        return ((http_response, parser.parse(response_dict,
-                                             operation_model.output_shape)),
-                None)
+        parsed_response = parser.parse(
+            response_dict, operation_model.output_shape)
+        return (http_response, parsed_response), None
 
 
 class AioEndpointCreator(EndpointCreator):
@@ -290,6 +303,7 @@ class AioEndpointCreator(EndpointCreator):
     def create_endpoint(self, service_model, region_name=None,
                         endpoint_url=None, verify=None,
                         response_parser_factory=None, timeout=DEFAULT_TIMEOUT,
+                        max_pool_connections=MAX_POOL_CONNECTIONS,
                         connector_args=None):
         if not is_valid_endpoint_url(endpoint_url):
             raise ValueError("Invalid endpoint: %s" % endpoint_url)
@@ -301,5 +315,6 @@ class AioEndpointCreator(EndpointCreator):
             proxies=self._get_proxies(endpoint_url),
             verify=self._get_verify_value(verify),
             timeout=timeout,
-            response_parser_factory=response_parser_factory, loop=self._loop,
-            connector_args=connector_args)
+            max_pool_connections=max_pool_connections,
+            response_parser_factory=response_parser_factory,
+            loop=self._loop, connector_args=connector_args)

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -169,8 +169,8 @@ class AioEndpoint(Endpoint):
             (z[0], text_(z[1], encoding='utf-8')) for z in headers.items())
 
         # For now the request timeout is: read_timeout and max(conn_timeout)
-        # So we want to ensure that your conn_timeout won't get truncated by the
-        # read_timeout. This should be removed after
+        # So we want to ensure that your conn_timeout won't get truncated by
+        # the read_timeout. This should be removed after
         # (https://github.com/KeepSafe/aiohttp/issues/1524) is resolved
         if self._read_timeout < self._conn_timeout:
             warnings.warn("connection timeout may be reduced due to current "

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -168,7 +168,8 @@ class AioEndpoint(Endpoint):
         headers_ = dict(
             (z[0], text_(z[1], encoding='utf-8')) for z in headers.items())
         request_coro = self._aio_session.request(method, url=url,
-                                                 headers=headers_, data=data)
+                                                 headers=headers_, data=data,
+                                                 timeout=self._read_timeout)
         resp = yield from asyncio.wait_for(
             request_coro, timeout=self._conn_timeout + self._read_timeout,
             loop=self._loop)

--- a/aiobotocore/session.py
+++ b/aiobotocore/session.py
@@ -3,7 +3,7 @@ import botocore.credentials
 import botocore.session
 
 from botocore import retryhandler, translate
-
+from botocore.exceptions import PartialCredentialsError
 from .client import AioClientCreator
 
 
@@ -20,12 +20,17 @@ class AioSession(botocore.session.Session):
                       aws_session_token=None, config=None):
 
         default_client_config = self.get_default_client_config()
-
+        # If a config is provided and a default config is set, then
+        # use the config resulting from merging the two.
         if config is not None and default_client_config is not None:
             config = default_client_config.merge(config)
+        # If a config was not provided then use the default
+        # client config from the session
         elif default_client_config is not None:
             config = default_client_config
 
+        # Figure out the user-provided region based on the various
+        # configuration options.
         if region_name is None:
             if config and config.region_name is not None:
                 region_name = config.region_name
@@ -37,15 +42,25 @@ class AioSession(botocore.session.Session):
         if verify is None:
             verify = self.get_config_variable('ca_bundle')
 
+        if api_version is None:
+            api_version = self.get_config_variable('api_versions').get(
+                service_name, None)
+
         loader = self.get_component('data_loader')
         event_emitter = self.get_component('event_emitter')
         response_parser_factory = self.get_component(
             'response_parser_factory')
-        if aws_secret_access_key is not None:
+        if aws_access_key_id is not None and aws_secret_access_key is not None:
             credentials = botocore.credentials.Credentials(
                 access_key=aws_access_key_id,
                 secret_key=aws_secret_access_key,
                 token=aws_session_token)
+        elif self._missing_cred_vars(aws_access_key_id,
+                                     aws_secret_access_key):
+            raise PartialCredentialsError(
+                provider='explicit',
+                cred_var=self._missing_cred_vars(aws_access_key_id,
+                                                 aws_secret_access_key))
         else:
             credentials = self.get_credentials()
         endpoint_resolver = self.get_component('endpoint_resolver')
@@ -54,8 +69,9 @@ class AioSession(botocore.session.Session):
             loader, endpoint_resolver, self.user_agent(), event_emitter,
             retryhandler, translate, response_parser_factory, loop=self._loop)
         client = client_creator.create_client(
-            service_name, region_name, use_ssl, endpoint_url, verify,
-            credentials, scoped_config=self.get_scoped_config(),
+            service_name=service_name, region_name=region_name,
+            is_secure=use_ssl, endpoint_url=endpoint_url, verify=verify,
+            credentials=credentials, scoped_config=self.get_scoped_config(),
             client_config=config, api_version=api_version)
         return client
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ install_requires = ['botocore>=1.4.29, <=1.4.73', 'aiohttp>=0.22.5']
 PY_VER = sys.version_info
 
 if not PY_VER >= (3, 4, 1):
-    raise RuntimeError("aiobotocore doesn't suppport Python earllier than 3.4")
+    raise RuntimeError("aiobotocore doesn't support Python earlier than 3.4")
 
 
 def read(f):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 
 
-install_requires = ['botocore>=1.4.29, <=1.4.73', 'aiohttp>=0.22.5']
+install_requires = ['botocore>=1.4.29, <=1.4.73', 'aiohttp>=1.2.0']
 
 PY_VER = sys.version_info
 


### PR DESCRIPTION
Currently StreamReader returned by aiohttp is not affected by read timeout passed into client, so .read method has 300 seconds timeout by default, we should pass the read timeout into request so it is set on StreamReader