### PR TITLE
Fix new moto

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
     - pip install -Ur requirements-dev.txt
     - pip install -e .
     - pip install codecov
+    - pip freeze
 
 script:
     - make flake

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,12 @@ vtest:
 	python3 -m pytest -s -v $(FLAGS) ./tests/
 
 cov cover coverage: flake
-	python3 -m pytest -s -v  --cov-report term --cov-report html --cov aiomysql ./tests
+	python3 -m pytest -s -v  --cov-report term --cov-report html --cov aiobotocore ./tests
 	@echo "open file://`pwd`/htmlcov/index.html"
 
 mototest:
 	py.test -v -m moto --cov-report term --cov-report html --cov aiobotocore tests
+	@echo "open file://`pwd`/htmlcov/index.html"
 
 
 clean:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ coverage==4.3.4
 flake8==3.2.1
 ipdb==0.10.1
 ipython==5.1.0
-moto==0.4.27
+moto==0.4.31
 pytest-cov==2.4.0
 pytest==3.0.6
 sphinx==1.5.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+Flask==0.12
 coverage==4.3.4
 flake8==3.2.1
 ipdb==0.10.1


### PR DESCRIPTION
For some reason `moto` library do not include `Flask` anymore as requirement, we need to add it in order to continue use mocking server in tests.