### PR TITLE
Normalize headers and handle redirections by botocore

### DIFF
--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -193,7 +193,8 @@ class AioEndpoint(Endpoint):
                                                     headers=headers_,
                                                     data=data,
                                                     proxy=proxy,
-                                                    timeout=self._read_timeout)
+                                                    timeout=self._read_timeout,
+                                                    allow_redirects=False)
         return resp
 
     @asyncio.coroutine
@@ -298,6 +299,16 @@ class AioEndpoint(Endpoint):
             operation_model.metadata['protocol'])
         parsed_response = parser.parse(
             response_dict, operation_model.output_shape)
+
+        # Workaround to provide lowercase headers to botocore for redirects
+        # TODO: remove this code block when
+        # https://github.com/boto/botocore/pull/1145 is merged
+        if 300 <= resp.status_code < 400:  # pragma: no cover
+            parsed_response['ResponseMetadata']['HTTPHeaders'] = {
+                k.lower(): v for k, v in
+                parsed_response['ResponseMetadata']['HTTPHeaders'].items()
+            }
+
         return (http_response, parsed_response), None
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,12 @@ def random_tablename():
 
 
 def random_name():
-    table_name = 'aiobotocoretest_{}'
+    """Return a string with presumably unique contents
+
+    The string contains only symbols allowed for s3 buckets
+    (alpfanumeric, dot and hyphen).
+    """
+    table_name = 'aiobotocoretest-{}'
     t = time.time()
     return table_name.format(int(t))
 
@@ -139,6 +144,11 @@ def region():
 
 
 @pytest.fixture
+def alternative_region():
+    return 'us-west-2'
+
+
+@pytest.fixture
 def signature_version():
     return 's3'
 
@@ -170,6 +180,22 @@ def s3_client(request, session, region, config, s3_server, mocking_test):
     if mocking_test:
         kw = moto_config(s3_server)
     client = create_client('s3', request, session, region, config, **kw)
+    return client
+
+
+@pytest.fixture
+def alternative_s3_client(request, session, alternative_region,
+                          signature_version, s3_server,
+                          mocking_test):
+    kw = {}
+    if mocking_test:
+        kw = moto_config(s3_server)
+
+    config = AioConfig(
+        region_name=alternative_region, signature_version=signature_version,
+        read_timeout=5, connect_timeout=5)
+    client = create_client(
+        's3', request, session, alternative_region, config, **kw)
     return client
 
 


### PR DESCRIPTION
S3 may return 307 code with redirection to another server in case of high load or maintenance.

I did not manage to reproduce this issue but it is simulated by creating an object in one region and fetching it from another. In this case S3 returns 301 response. I would appreciate if you advise how to reproduce it with `moto`.

S3 do not provide `Location` or `URI` header, so the redirection should be handled by the application (`botocore` in our case).

An example of the response headers:

    HTTP/1.1 301 Moved Permanently
    x-amz-bucket-region: us-east-1
    x-amz-request-id: CD12xxxxxxxxxxxx
    x-amz-id-2: IVdExxxxxxxxxxxxxxxxxxxxxxx
    Content-Type: application/xml
    Transfer-Encoding: chunked
    Date: Mon, 30 Jan 2017 13:07:10 GMT
    Server: AmazonS3

As you can see, no `Location` or `URI` header is provided. All redirect information is listed in the body:

    <Error>
      <Code>PermanentRedirect</Code>
      <Message>The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.</Message>
      <Bucket>foo</Bucket>
      <Endpoint>s3.amazonaws.com</Endpoint>
      <RequestId>CD12xxxxxxxxxxxx</RequestId>
      <HostId>IVdExxxxxxxxxxxxxxxxxxxxxxx</HostId>
    </Error>

For 307 error the response is similar:

    <Error>
      <Code>TemporaryRedirect</Code>
      <Message>Please re-send this request to the specified temporary endpoint. Continue to use the original request endpoint for future requests.</Message>
      <RequestId>63B2xxxxxxxxxxxx</RequestId>
      <Bucket>foo</Bucket>
      <HostId>S3nuxxxxxxxxxxxxxxxxxxxxxxx</HostId>
      <Endpoint>s3-us-west-2.amazonaws.com</Endpoint>
    </Error>

There are 2 issues with `aiobotocore`:
* `allow_redirects` is set to `True` in `aiohttp` (the default value) so that it fails because can't find redirect location in the headers.
* `multidict` tries to use case-insensitive strings for headers but `botocore` converts them to regular strings. That strings are in mixed case while `botocore` expects headers to be in lower case.
