### PR TITLE
Update for aiohttp 2.0+

### DIFF
--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -190,6 +190,7 @@ class AioEndpoint(Endpoint):
                                                     headers=headers_,
                                                     data=data,
                                                     proxy=proxy,
+                                                    timeout=None,
                                                     allow_redirects=False)
         return resp
 

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -1,6 +1,5 @@
 import asyncio
 import sys
-import warnings
 import yarl
 import aiohttp
 import botocore.retryhandler

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,5 +7,6 @@ moto==0.4.31
 pytest-cov==2.4.0
 pytest==3.0.7
 sphinx==1.5.3
-aiohttp==1.3.3
+aiohttp==2.0.4
 botocore==1.5.29
+multidict==2.1.4

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 
 
-install_requires = ['botocore>=1.5.0, <1.5.30', 'aiohttp>=1.2.0, <2.0.0']
+install_requires = ['botocore>=1.5.0, <1.5.30', 'aiohttp>=2.0.0']
 
 PY_VER = sys.version_info
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 
 
-install_requires = ['botocore>=1.5.0, <1.5.30', 'aiohttp>=2.0.0']
+install_requires = ['botocore>=1.5.0, <1.5.30', 'aiohttp>=2.0.4', 'multidict>=2.1.4']
 
 PY_VER = sys.version_info
 

--- a/tests/test_basic_s3.py
+++ b/tests/test_basic_s3.py
@@ -1,6 +1,6 @@
 import asyncio
 import pytest
-from aiohttp.errors import ProxyConnectionError
+import aiohttp
 
 
 @asyncio.coroutine
@@ -30,7 +30,7 @@ def test_can_make_request(s3_client):
 def test_fail_proxy_request(aa_fail_proxy_config, s3_client):
     # based on test_can_make_request
 
-    with pytest.raises(ProxyConnectionError):
+    with pytest.raises(aiohttp.ClientConnectorError):
         yield from s3_client.list_buckets()
 
 


### PR DESCRIPTION
 * All tests are green.
 * ProxyConnectionError is reported as ClientConnectorError.
 * aiohttp now supports separated read/connection timeouts.