### PR TITLE
Add asyncio trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ classifiers = [
     'Programming Language :: Python :: 3.5',
     'Environment :: Web Environment',
     'Development Status :: 3 - Alpha',
+    'Framework :: AsyncIO',
 ]
 
 


### PR DESCRIPTION
The `Framework :: AsyncIO` [trove classifier](https://pypi.python.org/pypi?%3Aaction=list_classifiers) has recently been added to PyPI. It can help people discover asyncio related packages.