### PR TITLE
integration and stream fix

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,8 @@ Changes
 -------
 0.3.2 (XXXX-XX-XX)
 ^^^^^^^^^^^^^^^^^^^^
+* Fix botocore integration
+* Provisional fix for aiohttp 2.x stream support
 
 0.3.1 (2017-04-18)
 ^^^^^^^^^^^^^^^^^^

--- a/aiobotocore/client.py
+++ b/aiobotocore/client.py
@@ -60,7 +60,8 @@ class AioBaseClient(botocore.client.BaseClient):
         request_context = {
             'client_region': self.meta.region_name,
             'client_config': self.meta.config,
-            'has_streaming_input': operation_model.has_streaming_input
+            'has_streaming_input': operation_model.has_streaming_input,
+            'auth_type': operation_model.auth_type,
         }
         request_dict = self._convert_to_request_dict(
             api_params, operation_model, context=request_context)

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -20,9 +20,6 @@ from urllib.parse import urlparse
 PY_35 = sys.version_info >= (3, 5)
 AIOHTTP_2 = StrictVersion(aiohttp.__version__) > StrictVersion('2.0.0')
 
-if AIOHTTP_2:
-    from aiohttp.payload import IOBasePayload
-
 # Monkey patching: We need to insert the aiohttp exception equivalents
 # The only other way to do this would be to have another config file :(
 _aiohttp_retryable_exceptions = [
@@ -49,7 +46,7 @@ def text_(s, encoding='utf-8', errors='strict'):
 if AIOHTTP_2:
     class _IOBaseWrapper(wrapt.ObjectProxy):
         def close(self):
-            # this stream should not be closed by aiohttp, like 1.x
+            # this stream should not be closed by aiohttp, likeh 1.x
             pass
 
 

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -2,7 +2,10 @@ import asyncio
 import sys
 import yarl
 import aiohttp
+import io
+import wrapt
 import botocore.retryhandler
+import aiohttp.http_exceptions
 from aiohttp.client_reqrep import ClientResponse
 from botocore.endpoint import EndpointCreator, Endpoint, DEFAULT_TIMEOUT, \
     MAX_POOL_CONNECTIONS, logger
@@ -10,10 +13,15 @@ from botocore.exceptions import EndpointConnectionError, ConnectionClosedError
 from botocore.hooks import first_non_none_response
 from botocore.utils import is_valid_endpoint_url
 from botocore.vendored.requests.structures import CaseInsensitiveDict
+from distutils.version import StrictVersion
 from multidict import MultiDict
 from urllib.parse import urlparse
 
 PY_35 = sys.version_info >= (3, 5)
+AIOHTTP_2 = StrictVersion(aiohttp.__version__) > StrictVersion('2.0.0')
+
+if AIOHTTP_2:
+    from aiohttp.payload import IOBasePayload
 
 # Monkey patching: We need to insert the aiohttp exception equivalents
 # The only other way to do this would be to have another config file :(
@@ -33,6 +41,15 @@ def text_(s, encoding='utf-8', errors='strict'):
     if isinstance(s, bytes):
         return s.decode(encoding, errors)
     return s  # pragma: no cover
+
+
+# Unfortunately aiohttp changed the behavior of streams: github.com/aio-libs/aiohttp/issues/1907
+# We need this wrapper until we have a final resolution
+if AIOHTTP_2:
+    class _IOBaseWrapper(wrapt.ObjectProxy):
+        def close(self):
+            # this stream should not be closed by aiohttp, like it wasn't in 1.x
+            pass
 
 
 @asyncio.coroutine
@@ -184,6 +201,9 @@ class AioEndpoint(Endpoint):
 
         # botocore does this during the request so we do this here as well
         proxy = self.proxies.get(urlparse(url.lower()).scheme)
+
+        if AIOHTTP_2 and isinstance(data, io.IOBase):
+            data = _IOBaseWrapper(data)
 
         url = yarl.URL(url, encoded=True)
         resp = yield from self._aio_session.request(method, url=url,

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -46,7 +46,7 @@ def text_(s, encoding='utf-8', errors='strict'):
 if AIOHTTP_2:
     class _IOBaseWrapper(wrapt.ObjectProxy):
         def close(self):
-            # this stream should not be closed by aiohttp, likeh 1.x
+            # this stream should not be closed by aiohttp, like 1.x
             pass
 
 

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -43,12 +43,13 @@ def text_(s, encoding='utf-8', errors='strict'):
     return s  # pragma: no cover
 
 
-# Unfortunately aiohttp changed the behavior of streams: github.com/aio-libs/aiohttp/issues/1907
+# Unfortunately aiohttp changed the behavior of streams:
+#   github.com/aio-libs/aiohttp/issues/1907
 # We need this wrapper until we have a final resolution
 if AIOHTTP_2:
     class _IOBaseWrapper(wrapt.ObjectProxy):
         def close(self):
-            # this stream should not be closed by aiohttp, like it wasn't in 1.x
+            # this stream should not be closed by aiohttp, like 1.x
             pass
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ sphinx==1.6.1
 aiohttp==2.0.7
 botocore==1.5.52
 multidict==2.1.5
+wrapt==1.10.10

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ classifiers = [
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
     'Environment :: Web Environment',
     'Development Status :: 3 - Alpha',
     'Framework :: AsyncIO',

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ import sys
 from setuptools import setup, find_packages
 
 
-install_requires = ['botocore>=1.5.0, <=1.5.52', 'aiohttp>=2.0.4',
-                    'multidict>=2.1.4']
+install_requires = ['botocore>=1.5.34, <=1.5.52', 'aiohttp>=2.0.4',
+                    'multidict>=2.1.4', 'wrapt>=1.10.10']
 
 PY_VER = sys.version_info
 


### PR DESCRIPTION
This fixes the last botocore integration and also has a provisional fix for github.com/aio-libs/aiohttp/issues/1907.  I still firmly believe aiohttp should revert back to 1.x behavior for streams.  Until then this will fix retries.