### PR TITLE
re-ordered example so it runs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,21 +55,21 @@ Basic Example
             resp = await client.get_object_acl(Bucket=bucket, Key=key)
             print(resp)
 
-            # delete object from s3
-            resp = await client.delete_object(Bucket=bucket, Key=key)
-            print(resp)
+            # get object from s3
+            response = await client.get_object(Bucket=bucket, Key=key)
+            # this will ensure the connection is correctly re-used/closed
+            async with response['Body'] as stream:
+                assert await stream.read() == data
 
             # list s3 objects using paginator
             paginator = client.get_paginator('list_objects')
             async for result in paginator.paginate(Bucket=bucket, Prefix=folder):
                 for c in result.get('Contents', []):
                     print(c)
-
-            # get object from s3
-            response = await client.get_object(Bucket=bucket, Key=key)
-            # this will ensure the connection is correctly re-used/closed
-            async with response['Body'] as stream:
-                data = await stream.read()
+                    
+            # delete object from s3
+            resp = await client.delete_object(Bucket=bucket, Key=key)
+            print(resp)
 
     loop = asyncio.get_event_loop()
     loop.run_until_complete(go(loop))


### PR DESCRIPTION
Previously, `get_object` was run after `delete_object` raising a Key Error as the resource no longer exists.