### PR TITLE
add the supported versions of awscli to extras require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def read(f):
     return open(os.path.join(os.path.dirname(__file__), f)).read().strip()
 
 
-extras_require = {}
+extras_require = {'awscli': ['awscli>=1.11.108, <=1.11.115']}
 
 
 def read_version():


### PR DESCRIPTION
Currently the biggest pain-point for me using aiobotocore is that I also use awscli.
Whenever I upgrade aiobotocore I have to go find out what version of botocore it supports,
then what version of awscli supports that version of botocore.

Eg currently I have:

awscli == 1.11.107 # for aiobotocore/botocore version compat
aiobotocore >= 0.4.1, < 0.5.0

but I'd like to have:

aiobotocore[awscli] >= 0.4.1, < 0.5.0