### PR TITLE
Update botocore

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ pytest-cov==2.5.1
 pytest==3.2.2
 sphinx==1.6.3
 aiohttp==2.2.5
-botocore==1.7.12
+botocore==1.7.16
 multidict==3.1.3
 wrapt==1.10.11
 dill==0.2.7.1

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 # https://github.com/aio-libs/aiobotocore/pull/248 will continue working
 # If adding requirements make sure to also add to requirements-dev.txt
 install_requires = [
-    'botocore>=1.7.4, <=1.7.12',
+    'botocore>=1.7.4, <=1.7.16',
     'aiohttp>=2.0.4, <=2.3.0',
     'multidict>=2.1.4',
     'wrapt>=1.10.10',

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -53,7 +53,7 @@ _API_DIGESTS = {
     Endpoint: {'7aa956cf3f28f573384dbaeb2f819b0a05724e65'},
     EndpointCreator: {'00cb4303f8e9e775fe76996ad2f8852df7900398'},
     PageIterator: {'d6d83b5c9314d4346ce021c85986b7c090569a34'},
-    Session: {'0203d047c8e23e648da1c50f9e6fb5dd53b797f7'},
+    Session: {'87b50bbf6caf0d7ae0ed1498032194ec36ca00f5'},
     get_session: {'c47d588f5da9b8bde81ccc26eaef3aee19ddd901'},
 }
 


### PR DESCRIPTION
Safe to bump https://github.com/boto/botocore/compare/1.7.12...1.7.16 
There are some changes in session module (added logging) that we can safely ignore.