### PR TITLE
Decompress gzipped responses

### DIFF
--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -3,6 +3,7 @@ import asyncio
 import functools
 import sys
 import io
+import zlib
 import wrapt
 import botocore.retryhandler
 import aiohttp.http_exceptions
@@ -77,6 +78,13 @@ def convert_to_response_dict(http_response, operation_model):
     else:
         body = yield from http_response.read()
         response_dict['body'] = body
+
+    if response_dict['headers'].get('content-encoding', '').lower() == 'gzip' \
+            and isinstance(response_dict['body'], (bytes, bytearray)):
+        response_dict['body'] = zlib.decompress(
+            response_dict['body'],
+            16 + zlib.MAX_WBITS)
+
     return response_dict
 
 


### PR DESCRIPTION
With aiobotocore 0.5.0 it now also accepts content encoding 'gzip' but doesn't use aiohttp auto_decompress which makes larger responses from AWS end up compressed when passed to botocore parsers.

In my case I got this issue after upgrading to 0.5.0 and when doing a `list_topics()` call on an SNS aiobotocore client and had lots of topics in the response data.

```
File ".../lib/python3.5/site-packages/aiobotocore/client.py", line 80, in _make_api_call
  operation_model, request_dict)
File ".../lib/python3.5/site-packages/aiobotocore/endpoint.py", line 264, in _send_request
  request, operation_model, attempts)
File ".../lib/python3.5/site-packages/aiobotocore/endpoint.py", line 356, in _get_response
  response_dict, operation_model.output_shape)
File ".../lib/python3.5/site-packages/botocore/parsers.py", line 212, in parse
  parsed = self._do_parse(response, shape)
File ".../lib/python3.5/site-packages/botocore/parsers.py", line 454, in _do_parse
  root = self._parse_xml_string_to_dom(xml_contents)
File ".../lib/python3.5/site-packages/botocore/parsers.py", line 390, in _parse_xml_string_to_dom
  "invalid XML received:\n%s" % (e, xml_string))
botocore.parsers.ResponseParserError: Unable to parse response (not well-formed (invalid token): line 1, column 0), invalid XML received:
b'\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x00\xcd\x9aMs\x9b0\x10\x86\xef\xf9\x15\x99 ... \xbf\x01[G\xbd\xdf\x11)\x00\x00'
```