### PR TITLE
fix non-streaming body timeout retries

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,9 @@
 Changes
 -------
+0.6.1a0 (2018-XX-XX)
+^^^^^^^^^^^^^^^^^^
+* fix non-streaming body timeout retries
+
 0.6.0 (2018-03-04)
 ^^^^^^^^^^^^^^^^^^
 * Upgrade to aiohttp>=3.0.0 #536 (thanks @Gr1N)


### PR DESCRIPTION
brings parity with botocore so that timeouts while requesting the body of non-streaming requests will retry