### PR TITLE
enable a lot more s3 tests with moto

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,8 @@ Changes
 -------
 0.7.1a0 (XXXX-XX-XX)
 ^^^^^^^^^^^^^^^^^^^^
+* Fix pagination #573 (thanks @adamrothman)
+* Enabled several s3 tests via moto
 
 0.7.0 (2018-05-01)
 ^^^^^^^^^^^^^^^^^^

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ Changes
 ^^^^^^^^^^^^^^^^^^^^
 * Fix pagination #573 (thanks @adamrothman)
 * Enabled several s3 tests via moto
+* Bring botocore up to date
 
 0.7.0 (2018-05-01)
 ^^^^^^^^^^^^^^^^^^

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,6 @@
 Changes
 -------
-0.7.1a0 (XXXX-XX-XX)
+0.8.0a0 (XXXX-XX-XX)
 ^^^^^^^^^^^^^^^^^^^^
 * Fix pagination #573 (thanks @adamrothman)
 * Enabled several s3 tests via moto

--- a/aiobotocore/__init__.py
+++ b/aiobotocore/__init__.py
@@ -1,4 +1,4 @@
 from .session import get_session, AioSession
 
 __all__ = ['get_session', 'AioSession']
-__version__ = '0.7.0a0'
+__version__ = '0.8.0a0'

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -11,7 +11,8 @@ from aiohttp.client import URL
 from aiohttp.client_reqrep import ClientResponse
 from botocore.endpoint import EndpointCreator, Endpoint, DEFAULT_TIMEOUT, \
     MAX_POOL_CONNECTIONS, logger
-from botocore.exceptions import EndpointConnectionError, ConnectionClosedError
+from botocore.exceptions import EndpointConnectionError, ConnectionClosedError,\
+    IncompleteReadError
 from botocore.hooks import first_non_none_response
 from botocore.utils import is_valid_endpoint_url
 from botocore.vendored.requests.structures import CaseInsensitiveDict
@@ -53,6 +54,38 @@ class _IOBaseWrapper(wrapt.ObjectProxy):
         pass
 
 
+# similar to botocore.response.StreamingBody
+class StreamingBody(wrapt.ObjectProxy):
+    def __init__(self, raw_stream, content_length):
+        super().__init__(raw_stream)
+        self._self_content_length = content_length
+        self._self_amount_read = 0
+
+    async def read(self, amt=-1):
+        """Read at most amt bytes from the stream.
+
+        If the amt argument is omitted, read all data.
+        """
+        chunk = await self.__wrapped__.read(amt)
+        self._self_amount_read += len(chunk)
+        if amt is None or (not chunk and amt > 0):
+            # If the server sends empty contents or
+            # we ask to read all of the contents, then we know
+            # we need to verify the content length.
+            self._verify_content_length()
+        return chunk
+
+    def _verify_content_length(self):
+        # See: https://github.com/kennethreitz/requests/issues/1855
+        # Basically, our http library doesn't do this for us, so we have
+        # to do this ourself.
+        if self._self_content_length is not None and \
+                self._self_amount_read != int(self._self_content_length):
+            raise IncompleteReadError(
+                actual_bytes=self._self_amount_read,
+                expected_bytes=int(self._self_content_length))
+
+
 async def convert_to_response_dict(http_response, operation_model):
     response_dict = {
         # botocore converts keys to str, so make sure that they are in
@@ -63,16 +96,20 @@ async def convert_to_response_dict(http_response, operation_model):
             {k.decode('utf-8').lower(): v.decode('utf-8')
              for k, v in http_response.raw_headers}),
         'status_code': http_response.status_code,
+        'context': {
+            'operation_name': operation_model.name,
+        }
     }
 
     if response_dict['status_code'] >= 300:
-        body = await http_response.read()
-        response_dict['body'] = body
-    elif operation_model.has_streaming_output:
+        response_dict['body'] = await http_response.read()
+    elif operation_model.has_event_stream_output:
         response_dict['body'] = http_response.raw
+    elif operation_model.has_streaming_output:
+        length = response_dict['headers'].get('content-length')
+        response_dict['body'] = StreamingBody(http_response.raw, length)
     else:
-        body = await http_response.read()
-        response_dict['body'] = body
+        response_dict['body'] = await http_response.read()
     return response_dict
 
 
@@ -84,12 +121,13 @@ class ClientResponseContentProxy(wrapt.ObjectProxy):
 
     def __init__(self, response):
         super().__init__(response.__wrapped__.content)
-        self.__response = response
+        self._self_response = response
 
     def set_socket_timeout(self, timeout):
-        """Set the timeout seconds on the socket."""
-        # TODO: see if we can do this w/o grabbing _protocol
-        self.__response._protocol.set_timeout(timeout)
+        """Set the timeout on the socket."""
+        # TODO: see if we can do this w/o grabbing _protocol and if we can
+        #       move this to StreamingBody where it belongs
+        self._self_response._protocol.set_timeout(timeout)
 
     # Note: we don't have a __del__ method as the ClientResponse has a __del__
     # which will warn the user if they didn't close/release the response
@@ -97,14 +135,14 @@ class ClientResponseContentProxy(wrapt.ObjectProxy):
     # (which could be very large), and a close would mean being unable to re-
     # use the connection, so the user MUST chose.  Default is to warn + close
     async def __aenter__(self):
-        await self.__response.__aenter__()
+        await self._self_response.__aenter__()
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        return await self.__response.__aexit__(exc_type, exc_val, exc_tb)
+        return await self._self_response.__aexit__(exc_type, exc_val, exc_tb)
 
     def close(self):
-        self.__response.close()
+        self._self_response.close()
 
 
 class ClientResponseProxy(wrapt.ObjectProxy):
@@ -234,7 +272,7 @@ class AioEndpoint(Endpoint):
             loop=self._loop,
             auto_decompress=False)
 
-    async def _request(self, method, url, headers, data, stream):
+    async def _request(self, method, url, headers, data, verify, stream):
         # Note: When using aiobotocore with dynamodb, requests fail on crc32
         # checksum computation as soon as the response data reaches ~5KB.
         # When AWS response is gzip compressed:
@@ -260,7 +298,7 @@ class AioEndpoint(Endpoint):
         url = URL(url, encoded=True)
         resp = await self._aio_session.request(
             method, url=url, headers=headers_, data=data, proxy=proxy,
-            timeout=None)
+            verify_ssl=verify, timeout=None)
 
         # If we're not streaming, read the content so we can retry any timeout
         #  errors, see:
@@ -336,9 +374,14 @@ class AioEndpoint(Endpoint):
                 'url': request.url,
                 'body': request.body
             })
+            streaming = any([
+                operation_model.has_streaming_output,
+                operation_model.has_event_stream_output
+            ])
             http_response = await self._request(
                 request.method, request.url, request.headers, request.body,
-                operation_model.has_streaming_output)
+                verify=self.verify,
+                stream=streaming)
         except aiohttp.ClientConnectionError as e:
             e.request = request  # botocore expects the request property
 
@@ -373,8 +416,8 @@ class AioEndpoint(Endpoint):
             operation_model.has_streaming_output
         history_recorder.record('HTTP_RESPONSE', http_response_record_dict)
 
-        parser = self._response_parser_factory.create_parser(
-            operation_model.metadata['protocol'])
+        protocol = operation_model.metadata['protocol']
+        parser = self._response_parser_factory.create_parser(protocol)
         parsed_response = parser.parse(
             response_dict, operation_model.output_shape)
         history_recorder.record('PARSED_RESPONSE', parsed_response)

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -61,6 +61,13 @@ class StreamingBody(wrapt.ObjectProxy):
         self._self_content_length = content_length
         self._self_amount_read = 0
 
+    # https://github.com/GrahamDumpleton/wrapt/issues/73
+    async def __aenter__(self):
+        return await self.__wrapped__.__aenter__()
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return await self.__wrapped__.__aexit__(exc_type, exc_val, exc_tb)
+
     async def read(self, amt=-1):
         """Read at most amt bytes from the stream.
 

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -11,8 +11,8 @@ from aiohttp.client import URL
 from aiohttp.client_reqrep import ClientResponse
 from botocore.endpoint import EndpointCreator, Endpoint, DEFAULT_TIMEOUT, \
     MAX_POOL_CONNECTIONS, logger
-from botocore.exceptions import EndpointConnectionError, ConnectionClosedError,\
-    IncompleteReadError
+from botocore.exceptions import EndpointConnectionError, \
+    ConnectionClosedError, IncompleteReadError
 from botocore.hooks import first_non_none_response
 from botocore.utils import is_valid_endpoint_url
 from botocore.vendored.requests.structures import CaseInsensitiveDict

--- a/aiobotocore/paginate.py
+++ b/aiobotocore/paginate.py
@@ -94,7 +94,7 @@ class AioPageIterator(PageIterator):
         if self._is_stop:
             raise StopAsyncIteration  # noqa
 
-        return self.next_page()
+        return await self.next_page()
 
     def result_key_iters(self):
         raise NotImplementedError

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,10 @@ coverage==4.5.1
 flake8==3.5.0
 # we specify flask directly and don't use moto[server] as we want to fix the flask version
 Flask==0.12.2
-moto==1.2.0
+
+# until https://github.com/spulec/moto/pull/1611 is released
+git+git://github.com/thehesiod/moto.git@fix-copy-source-query#egg=moto
+
 pytest-cov==2.5.1
 pytest==3.4.1
 pytest-asyncio==0.8.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ pytest-asyncio==0.8.0
 sphinx==1.7.1
 yarl==1.1.1
 aiohttp==3.1.3
-botocore==1.8.21
+botocore==1.10.12
 multidict==4.1.0
 wrapt==1.10.11
 dill==0.2.7.1

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ from setuptools import setup, find_packages
 # https://github.com/aio-libs/aiobotocore/pull/248 will continue working
 # If adding requirements make sure to also add to requirements-dev.txt
 install_requires = [
-    'botocore>=1.8.0, <=1.8.21',
+    # pegged to also match items in `extras_require`
+    'botocore>=1.10.12, <1.10.13',
 
     # for now we depend on internals of aiohttp so this range can't be open
     'aiohttp>=3.1.0, <3.2.0',
@@ -28,8 +29,8 @@ def read(f):
 
 
 extras_require = {
-    'awscli': ['awscli>=1.12.0, <=1.14.17'],
-    'boto3': ['boto3==1.5.7'],
+    'awscli': ['awscli>=1.15.12, <1.15.13'],
+    'boto3': ['boto3==1.7.12, <1.7.13'],
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,7 +109,7 @@ def signature_version():
 @pytest.fixture
 def config(region, signature_version):
     return AioConfig(region_name=region, signature_version=signature_version,
-                     read_timeout=None, connect_timeout=None)
+                     read_timeout=5, connect_timeout=5)
 
 
 @pytest.fixture

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -104,16 +104,15 @@ def start_service(service_name, host, port):
     moto_svr_path = shutil.which("moto_server")
     args = [sys.executable, moto_svr_path, service_name, "-H", host,
             "-p", str(port)]
-    # stdout = stderr = None
-    stdout = stderr = sp.PIPE
-    process = sp.Popen(args, stdin=sp.PIPE, stdout=stdout, stderr=stderr)
+
+    # If test fails stdout/stderr will be shown
+    process = sp.Popen(args, stdin=sp.PIPE)
     url = "http://{host}:{port}".format(host=host, port=port)
 
     for i in range(0, 30):
         if process.poll() is not None:
-            stdout, stderr = process.communicate()
-            pytest.fail("service failed starting up: {}  stdout: {} stderr: {}"
-                        "".format(service_name, stdout, stderr))
+            process.communicate()
+            pytest.fail("service failed starting up: {}".format(service_name))
             break
 
         try:

--- a/tests/test_basic_s3.py
+++ b/tests/test_basic_s3.py
@@ -2,6 +2,7 @@ import pytest
 import aiohttp
 import asyncio
 
+
 async def fetch_all(pages):
     responses = []
     while True:

--- a/tests/test_basic_s3.py
+++ b/tests/test_basic_s3.py
@@ -1,6 +1,6 @@
 import pytest
 import aiohttp
-
+import asyncio
 
 async def fetch_all(pages):
     responses = []
@@ -41,7 +41,7 @@ async def test_succeed_proxy_request(aa_succeed_proxy_config, s3_client):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize('mocking_test', [False])
+@pytest.mark.moto
 async def test_can_get_bucket_location(s3_client, bucket_name):
     result = await s3_client.get_bucket_location(Bucket=bucket_name)
     assert 'LocationConstraint' in result
@@ -72,7 +72,7 @@ async def test_can_delete_urlencoded_object(s3_client, bucket_name,
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize('mocking_test', [False])
+@pytest.mark.moto
 async def test_can_paginate(s3_client, bucket_name, create_object):
     for i in range(5):
         key_name = 'key%s' % i
@@ -88,7 +88,7 @@ async def test_can_paginate(s3_client, bucket_name, create_object):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize('mocking_test', [False])
+@pytest.mark.moto
 async def test_can_paginate_with_page_size(
         s3_client, bucket_name, create_object):
     for i in range(5):
@@ -107,7 +107,7 @@ async def test_can_paginate_with_page_size(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize('mocking_test', [False])
+@pytest.mark.moto
 async def test_can_paginate_iterator(s3_client, bucket_name, create_object):
     for i in range(5):
         key_name = 'key%s' % i
@@ -117,6 +117,7 @@ async def test_can_paginate_iterator(s3_client, bucket_name, create_object):
     responses = []
     async for page in paginator.paginate(
             PaginationConfig={'PageSize': 1}, Bucket=bucket_name):
+        assert not asyncio.iscoroutine(page)
         responses.append(page)
     assert len(responses) == 5, responses
     data = [r for r in responses]
@@ -171,7 +172,7 @@ async def test_get_object_stream_context(s3_client, create_object,
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize('mocking_test', [False])
+@pytest.mark.moto
 async def test_paginate_max_items(
         s3_client, create_multipart_upload, bucket_name, event_loop):
     await create_multipart_upload('foo/key1')
@@ -186,12 +187,12 @@ async def test_paginate_max_items(
     # Verify when we have MaxItems=None, we get back all 8 uploads.
     await pytest.aio.assert_num_uploads_found(
         s3_client, bucket_name, 'list_multipart_uploads', max_items=None,
-        num_uploads=8, loop=event_loop)
+        num_uploads=8, event_loop=event_loop)
 
     # Verify when we have MaxItems=1, we get back 1 upload.
     await pytest.aio.assert_num_uploads_found(
         s3_client, bucket_name, 'list_multipart_uploads', max_items=1,
-        num_uploads=1, loop=event_loop)
+        num_uploads=1, event_loop=event_loop)
 
     paginator = s3_client.get_paginator('list_multipart_uploads')
     # Works similar with build_full_result()
@@ -348,6 +349,23 @@ async def test_can_copy_with_dict_form(s3_client, create_object, bucket_name):
 
 @pytest.mark.moto
 @pytest.mark.asyncio
+async def test_can_copy_with_dict_form_with_version(s3_client, create_object, bucket_name):
+    key_name = 'a+b/foo?versionId=abcd'
+    response = await create_object(key_name=key_name)
+    key_name2 = key_name + 'bar'
+    await s3_client.copy_object(
+        Bucket=bucket_name, Key=key_name2,
+        CopySource={'Bucket': bucket_name, 'Key': key_name, 'VersionId': response["VersionId"]})
+
+    # Now verify we can retrieve the copied object.
+    resp = await s3_client.get_object(Bucket=bucket_name, Key=key_name2)
+    data = await resp['Body'].read()
+    resp['Body'].close()
+    assert data == b'foo'
+
+
+@pytest.mark.moto
+@pytest.mark.asyncio
 async def test_copy_with_s3_metadata(s3_client, create_object, bucket_name):
     key_name = 'foo.txt'
     await create_object(key_name=key_name)
@@ -361,8 +379,8 @@ async def test_copy_with_s3_metadata(s3_client, create_object, bucket_name):
 
 
 @pytest.mark.parametrize('region', ['us-east-1'])
-@pytest.mark.parametrize('mocking_test', [False])
 @pytest.mark.parametrize('signature_version', ['s3'])
+@pytest.mark.parametrize('mocking_test', [False])  # 'Content-Disposition' not supported by moto yet
 @pytest.mark.asyncio
 async def test_presign_with_existing_query_string_values(
         s3_client, bucket_name, aio_session, create_object):
@@ -378,14 +396,14 @@ async def test_presign_with_existing_query_string_values(
 
     resp = await aio_session.get(presigned_url)
     data = await resp.read()
-    resp.close()
+    await resp.close()
     assert resp.headers['Content-Disposition'] == content_disposition
     assert data == b'foo'
 
 
 @pytest.mark.parametrize('region', ['us-east-1'])
-@pytest.mark.parametrize('mocking_test', [False])
 @pytest.mark.parametrize('signature_version', ['s3v4'])
+@pytest.mark.parametrize('mocking_test', [False])  # moto host will be localhost
 @pytest.mark.asyncio
 async def test_presign_sigv4(s3_client, bucket_name, aio_session,
                              create_object):
@@ -440,8 +458,8 @@ async def test_bucket_redirect(
 
 
 @pytest.mark.parametrize('signature_version', ['s3v4'])
-@pytest.mark.parametrize('mocking_test', [False])
 @pytest.mark.asyncio
+@pytest.mark.moto
 async def test_head_object_keys(s3_client, create_object, bucket_name):
     await create_object('foobarbaz')
 
@@ -451,5 +469,5 @@ async def test_head_object_keys(s3_client, create_object, bucket_name):
     # this is to ensure things like:
     # https://github.com/aio-libs/aiobotocore/issues/131 don't happen again
     assert set(resp.keys()) == {
-        'AcceptRanges', 'ETag', 'ContentType', 'Metadata', 'LastModified',
-        'ResponseMetadata', 'ContentLength'}
+        'ETag', 'ContentType', 'Metadata', 'LastModified',
+        'ResponseMetadata', 'ContentLength', 'VersionId'}

--- a/tests/test_basic_s3.py
+++ b/tests/test_basic_s3.py
@@ -349,13 +349,15 @@ async def test_can_copy_with_dict_form(s3_client, create_object, bucket_name):
 
 @pytest.mark.moto
 @pytest.mark.asyncio
-async def test_can_copy_with_dict_form_with_version(s3_client, create_object, bucket_name):
+async def test_can_copy_with_dict_form_with_version(
+        s3_client, create_object, bucket_name):
     key_name = 'a+b/foo?versionId=abcd'
     response = await create_object(key_name=key_name)
     key_name2 = key_name + 'bar'
     await s3_client.copy_object(
         Bucket=bucket_name, Key=key_name2,
-        CopySource={'Bucket': bucket_name, 'Key': key_name, 'VersionId': response["VersionId"]})
+        CopySource={'Bucket': bucket_name, 'Key': key_name,
+                    'VersionId': response["VersionId"]})
 
     # Now verify we can retrieve the copied object.
     resp = await s3_client.get_object(Bucket=bucket_name, Key=key_name2)
@@ -380,7 +382,8 @@ async def test_copy_with_s3_metadata(s3_client, create_object, bucket_name):
 
 @pytest.mark.parametrize('region', ['us-east-1'])
 @pytest.mark.parametrize('signature_version', ['s3'])
-@pytest.mark.parametrize('mocking_test', [False])  # 'Content-Disposition' not supported by moto yet
+# 'Content-Disposition' not supported by moto yet
+@pytest.mark.parametrize('mocking_test', [False])
 @pytest.mark.asyncio
 async def test_presign_with_existing_query_string_values(
         s3_client, bucket_name, aio_session, create_object):
@@ -403,7 +406,8 @@ async def test_presign_with_existing_query_string_values(
 
 @pytest.mark.parametrize('region', ['us-east-1'])
 @pytest.mark.parametrize('signature_version', ['s3v4'])
-@pytest.mark.parametrize('mocking_test', [False])  # moto host will be localhost
+# moto host will be localhost
+@pytest.mark.parametrize('mocking_test', [False])
 @pytest.mark.asyncio
 async def test_presign_sigv4(s3_client, bucket_name, aio_session,
                              create_object):

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -50,11 +50,11 @@ _READ_TIMEOUT_DIGESTS = {
 # These are guards to our main patches
 _API_DIGESTS = {
     ClientArgsCreator: {'a8d2e4159469622afcf938805b17ca76aefec7e7'},
-    ClientCreator: {'9eef0e5fbd62fc495a5eee2dab118e36ae496dce'},
-    BaseClient: {'23756d283379717b1320315c98399ba284b2d17c'},
+    ClientCreator: {'29a45581cadace0265620f925f76504be97f6fa0'},
+    BaseClient: {'85e3d643193d71e6e7f43192cc1d8c9cf861fa59'},
     Config: {'c9261822caa7509d7b30b7738a9f034674061e35'},
-    convert_to_response_dict: {'ed634b3f0c24f8858aee8ed745051397270b1e46'},
-    Endpoint: {'f1effcb1966ab690953f62a5cd48f510294a0440'},
+    convert_to_response_dict: {'2c73c059fa63552115314b079ae8cbf5c4e78da0'},
+    Endpoint: {'5c5d568e23de1169916de6bcc58c72925f5a1adc'},
     EndpointCreator: {'00cb4303f8e9e775fe76996ad2f8852df7900398'},
     PageIterator: {'5a14db3ee7bc8773974b36cfdb714649b17a6a42'},
     Session: {'87b50bbf6caf0d7ae0ed1498032194ec36ca00f5'},


### PR DESCRIPTION
also pulls in @adamrothman 's pagination fix: https://github.com/aio-libs/aiobotocore/issues/573

dependency tree of changes:
- get_page missing await -> unittests were disabled for moto
- disabled unittests needed latest moto (latest moto has bugs so use private repo until new release with fix available)
- latest moto needs latest botocore