### PR TITLE
fix retry

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,8 @@
 Changes
 -------
-0.9.4 (2018-XX-XX)
+0.9.4 (2018-08-08)
 ^^^^^^^^^^^^^^^^^^
+* Add ClientPayloadError as retryable exception
 
 0.9.3 (2018-07-16)
 ^^^^^^^^^^^^^^^^^^

--- a/aiobotocore/__init__.py
+++ b/aiobotocore/__init__.py
@@ -1,4 +1,4 @@
 from .session import get_session, AioSession
 
 __all__ = ['get_session', 'AioSession']
-__version__ = '0.9.4a0'
+__version__ = '0.9.4'

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -27,6 +27,7 @@ history_recorder = get_global_history_recorder()
 # The only other way to do this would be to have another config file :(
 _aiohttp_retryable_exceptions = [
     aiohttp.ClientConnectionError,
+    aiohttp.ClientPayloadError,
     aiohttp.ServerDisconnectedError,
     aiohttp.http_exceptions.HttpProcessingError,
     asyncio.TimeoutError,


### PR DESCRIPTION
this can be raised instead of ServerDisconnectedError.  This relies on the fact that this currently means that the payload was not sent successfully so it can be retried.