### PR TITLE
Update to botocore 1.12.49

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,9 @@ cov cover coverage: flake
 	python3 -m pytest -s -v --cov-report term --cov-report html --cov aiobotocore ./tests
 	@echo "open file://`pwd`/htmlcov/index.html"
 
+# BOTO_CONFIG solves https://github.com/travis-ci/travis-ci/issues/7940
 mototest:
-	python3 -m pytest -v -m moto --cov-report term --cov-report html --cov aiobotocore tests
+	BOTO_CONFIG=/dev/null python3 -m pytest -v -m moto --cov-report term --cov-report html --cov aiobotocore tests
 	@echo "open file://`pwd`/htmlcov/index.html"
 
 

--- a/aiobotocore/args.py
+++ b/aiobotocore/args.py
@@ -42,10 +42,11 @@ class AioClientArgsCreator(botocore.args.ClientArgsCreator):
 
         event_emitter = copy.copy(self._event_emitter)
         signer = RequestSigner(
-            service_name, signing_region,
+            service_model.service_id, signing_region,
             endpoint_config['signing_name'],
             endpoint_config['signature_version'],
-            credentials, event_emitter)
+            credentials, event_emitter
+        )
 
         config_kwargs['s3'] = s3_config
 

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -13,9 +13,10 @@ async def go(loop):
     key = '{}/{}'.format(folder, filename)
 
     session = aiobotocore.get_session(loop=loop)
-    async with session.create_client('s3', region_name='us-west-2',
-                                     aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
-                                     aws_access_key_id=AWS_ACCESS_KEY_ID) as client:
+    async with session.create_client(
+            's3', region_name='us-west-2',
+            aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+            aws_access_key_id=AWS_ACCESS_KEY_ID) as client:
         # upload object to amazon s3
         data = b'\x01' * 1024
         resp = await client.put_object(Bucket=bucket,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,8 +14,8 @@ pytest-asyncio==0.8.0
 sphinx==1.7.5
 yarl==1.2.6
 aiohttp==3.3.2
-botocore==1.12.24
-boto3==1.9.24
+botocore==1.12.49
+boto3==1.9.49
 multidict==4.3.0
 wrapt==1.10.11
 dill==0.2.8.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,8 +14,8 @@ pytest-asyncio==0.8.0
 sphinx==1.7.5
 yarl==1.2.6
 aiohttp==3.3.2
-botocore==1.10.58
-boto3==1.7.58
+botocore==1.12.24
+boto3==1.9.24
 multidict==4.3.0
 wrapt==1.10.11
 dill==0.2.8.2

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 # NOTE: When updating botocore make sure to update awscli/boto3 versions below
 install_requires = [
     # pegged to also match items in `extras_require`
-    'botocore>=1.12.24,<1.12.25',
+    'botocore>=1.12.49,<1.12.50',
     'aiohttp>=3.3.1',
     'wrapt>=1.10.10',
 ]
@@ -24,8 +24,8 @@ def read(f):
 
 
 extras_require = {
-    'awscli': ['awscli==1.16.34'],
-    'boto3': ['boto3==1.9.24'],
+    'awscli': ['awscli==1.16.59'],
+    'boto3': ['boto3==1.9.49'],
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 # NOTE: When updating botocore make sure to update awscli/boto3 versions below
 install_requires = [
     # pegged to also match items in `extras_require`
-    'botocore>=1.10.58,<1.10.59',
+    'botocore>=1.12.24,<1.12.25',
     'aiohttp>=3.3.1',
     'wrapt>=1.10.10',
 ]
@@ -24,8 +24,8 @@ def read(f):
 
 
 extras_require = {
-    'awscli': ['awscli==1.15.59'],
-    'boto3': ['boto3==1.7.58'],
+    'awscli': ['awscli==1.16.34'],
+    'boto3': ['boto3==1.9.24'],
 }
 
 

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -39,7 +39,7 @@ _API_DIGESTS = {
     Endpoint: {'29827aaa421d462ab7b9e200d7203ba9e412633c'},
     EndpointCreator: {'633337fe0bda97e57c7f0b9596c5a158a03e8e36'},
     PageIterator: {'5a14db3ee7bc8773974b36cfdb714649b17a6a42'},
-    Session: {'52240fc442b0b50586cad07cc9cff43904e0e744'},
+    Session: {'a8132407e250b652c89db15a9002f41664638a3f'},
     get_session: {'c47d588f5da9b8bde81ccc26eaef3aee19ddd901'},
     NormalizedOperationMethod: {'ee88834b123c6c77dfea0b4208308cd507a6ba36'},
 }

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -31,15 +31,15 @@ _AIOHTTP_DIGESTS = {
 
 # These are guards to our main patches
 _API_DIGESTS = {
-    ClientArgsCreator: {'a8d2e4159469622afcf938805b17ca76aefec7e7'},
-    ClientCreator: {'29a45581cadace0265620f925f76504be97f6fa0'},
-    BaseClient: {'ae1eb5158a6044e6616363c525275110fac311da'},
-    Config: {'c9261822caa7509d7b30b7738a9f034674061e35'},
+    ClientArgsCreator: {'c316001114ff0b91900004e2fc56b71a07509f16'},
+    ClientCreator: {'f68202aca8c908d14b3d7b2446875d297c46671b'},
+    BaseClient: {'63fc3b6ae4cdb265b5363c093832890074f52e18'},
+    Config: {'b84933bb901b4f18641dffe75cc62d55affd390a'},
     convert_to_response_dict: {'2c73c059fa63552115314b079ae8cbf5c4e78da0'},
-    Endpoint: {'5c5d568e23de1169916de6bcc58c72925f5a1adc'},
-    EndpointCreator: {'00cb4303f8e9e775fe76996ad2f8852df7900398'},
+    Endpoint: {'29827aaa421d462ab7b9e200d7203ba9e412633c'},
+    EndpointCreator: {'633337fe0bda97e57c7f0b9596c5a158a03e8e36'},
     PageIterator: {'5a14db3ee7bc8773974b36cfdb714649b17a6a42'},
-    Session: {'a9a06fe8dcacf3954e91e48509882b5aae31344c'},
+    Session: {'52240fc442b0b50586cad07cc9cff43904e0e744'},
     get_session: {'c47d588f5da9b8bde81ccc26eaef3aee19ddd901'},
     NormalizedOperationMethod: {'ee88834b123c6c77dfea0b4208308cd507a6ba36'},
 }


### PR DESCRIPTION
Botocore hasn't changed much between 1.10.58 to 1.12.24. The main ones are the changes to the event names emitted, and that botocore now use a urllib session class, so some arguments are no longer supported in the endpoint base class.

There's some weird travis bug at the moment (https://github.com/travis-ci/travis-ci/issues/7940), added in `BOTO_CONFIG` env var to solve that until its fixed properly.