### PR TITLE
Make tests pass with pytest 4.1

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,10 @@
 Changes
 -------
 
+0.10.X (2019-XX-XX)
+^^^^^^^^^^^^^^^^^^^^
+* Make tests pass with pytest 4.1 #669 (thanks @yan12125)
+
 0.10.0 (2018-12-09)
 ^^^^^^^^^^^^^^^^^^^^
 * Update to botocore 1.12.49 #639 (thanks @terrycain)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,8 +9,8 @@ Flask==1.0.2
 git+git://github.com/spulec/moto.git@80929292584ee78affc07643d16fae6bb31b4014#egg=moto
 
 pytest-cov==2.5.1
-pytest==3.6.2
-pytest-asyncio==0.8.0
+pytest==4.1.1
+pytest-asyncio==0.10.0
 sphinx==1.7.5
 yarl==1.2.6
 aiohttp==3.3.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -373,10 +373,13 @@ def aio_session(request, event_loop):
     event_loop.run_until_complete(session.close())
 
 
-def pytest_namespace():
-    return {'aio': {'assert_status_code': assert_status_code,
-                    'assert_num_uploads_found': assert_num_uploads_found},
-            }
+def pytest_configure():
+    class AIOUtils:
+        def __init__(self):
+            self.assert_status_code = assert_status_code
+            self.assert_num_uploads_found = assert_num_uploads_found
+
+    pytest.aio = AIOUtils()
 
 
 @pytest.fixture


### PR DESCRIPTION
By using pytest_configure as suggested in [1].

`pytest_namespace` is removed in 4.1.0 [2][3]. Here's an example run with pytest==4.1.1 and pytest-asyncio==0.10.0 in requirements-dev.txt, and py37 added to tox.ini:

```
GLOB sdist-make: /home/yen/Projects/aiobotocore/setup.py
py37 inst-nodeps: /home/yen/Projects/aiobotocore/.tox/.tmp/package/1/aiobotocore-0.10.0.zip
py37 installed: aiobotocore==0.10.0,aiohttp==3.3.2,alabaster==0.7.12,asn1crypto==0.24.0,async-timeout==3.0.1,atomicwrites==1.2.1,attrs==18.2.0,aws-xray-sdk==0.95,Babel==2.6.0,boto==2.49.0,boto3==1.9.49,botocore==1.12.49,certifi==2018.11.29,cffi==1.11.5,chardet==3.0.4,Click==7.0,cookies==2.2.1,coverage==4.5.1,cryptography==2.5,dill==0.2.8.2,docker==3.7.0,docker-pycreds==0.4.0,docutils==0.14,ecdsa==0.13,flake8==3.5.0,Flask==1.0.2,future==0.17.1,idna==2.8,imagesize==1.1.0,itsdangerous==1.1.0,Jinja2==2.10,jmespath==0.9.3,jsondiff==1.1.1,jsonpickle==1.1,MarkupSafe==1.1.0,mccabe==0.6.1,mock==2.0.0,more-itertools==5.0.0,moto==1.3.3,multidict==4.3.0,packaging==19.0,pbr==5.1.1,pluggy==0.8.1,py==1.7.0,pyaml==18.11.0,pycodestyle==2.3.1,pycparser==2.19,pycryptodome==3.7.3,pyflakes==1.6.0,Pygments==2.3.1,pyparsing==2.3.1,pytest==4.1.1,pytest-asyncio==0.10.0,pytest-cov==2.5.1,python-dateutil==2.7.5,python-jose==2.0.2,pytz==2018.9,PyYAML==3.13,requests==2.21.0,responses==0.10.5,s3transfer==0.1.13,six==1.12.0,snowballstemmer==1.2.1,Sphinx==1.7.5,sphinxcontrib-websupport==1.1.0,urllib3==1.24.1,websocket-client==0.54.0,Werkzeug==0.14.1,wrapt==1.10.11,xmltodict==0.11.0,yarl==1.2.6
py37 run-test-pre: PYTHONHASHSEED='2621456940'
py37 runtests: commands[0] | python3 -m pytest -v -m moto tests
===================================================== test session starts ======================================================
platform linux -- Python 3.7.2, pytest-4.1.1, py-1.7.0, pluggy-0.8.1 -- /home/yen/Projects/aiobotocore/.tox/py37/bin/python3
cachedir: .tox/py37/.pytest_cache
rootdir: /home/yen/Projects/aiobotocore, inifile:
plugins: cov-2.5.1, asyncio-0.10.0
collecting 56 items                                                                                                            INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/home/yen/Projects/aiobotocore/.tox/py37/lib/python3.7/site-packages/_pytest/main.py", line 203, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>   File "/home/yen/Projects/aiobotocore/.tox/py37/lib/python3.7/site-packages/_pytest/main.py", line 242, in _main
INTERNALERROR>     config.hook.pytest_collection(session=session)
INTERNALERROR>   File "/home/yen/Projects/aiobotocore/.tox/py37/lib/python3.7/site-packages/pluggy/hooks.py", line 284, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/home/yen/Projects/aiobotocore/.tox/py37/lib/python3.7/site-packages/pluggy/manager.py", line 68, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/home/yen/Projects/aiobotocore/.tox/py37/lib/python3.7/site-packages/pluggy/manager.py", line 62, in <lambda>
INTERNALERROR>     firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
INTERNALERROR>   File "/home/yen/Projects/aiobotocore/.tox/py37/lib/python3.7/site-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/home/yen/Projects/aiobotocore/.tox/py37/lib/python3.7/site-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/home/yen/Projects/aiobotocore/.tox/py37/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/home/yen/Projects/aiobotocore/.tox/py37/lib/python3.7/site-packages/_pytest/main.py", line 252, in pytest_collection
INTERNALERROR>     return session.perform_collect()
INTERNALERROR>   File "/home/yen/Projects/aiobotocore/.tox/py37/lib/python3.7/site-packages/_pytest/main.py", line 466, in perform_collect
INTERNALERROR>     self.config.pluginmanager.check_pending()
INTERNALERROR>   File "/home/yen/Projects/aiobotocore/.tox/py37/lib/python3.7/site-packages/pluggy/manager.py", line 251, in check_pending
INTERNALERROR>     % (name, hookimpl.plugin),
INTERNALERROR> pluggy.manager.PluginValidationError: unknown hook 'pytest_namespace' in plugin <module 'conftest' from '/home/yen/Projects/aiobotocore/tests/conftest.py'>

================================================== 2 warnings in 1.07 seconds ==================================================
ERROR: InvocationError for command '/home/yen/Projects/aiobotocore/.tox/py37/bin/python3 -m pytest -v -m moto tests' (exited with code 3)
___________________________________________________________ summary ____________________________________________________________
ERROR:   py37: commands failed
```

[1] https://docs.pytest.org/en/latest/deprecations.html#pytest-namespace
[2] https://github.com/pytest-dev/pytest/blob/master/CHANGELOG.rst#pytest-410-2019-01-05
[3] pytest-dev/pytest#4421