### PR TITLE
Add RTD config file and update docs build

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,7 @@ Changes
 ^^^^^^^^^^^^^^^^^^^^
 * Make tests pass with pytest 4.1 #669 (thanks @yan12125)
 * Support Python 3.7 #671 (thanks to @yan12125)
+* Update RTD build config #672 (thanks @willingc)
 
 0.10.0 (2018-12-09)
 ^^^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,9 @@ aiobotocore
     :target: https://travis-ci.com/aio-libs/aiobotocore
 .. image:: https://codecov.io/gh/aio-libs/aiobotocore/branch/master/graph/badge.svg
     :target: https://codecov.io/gh/aio-libs/aiobotocore
+.. image:: https://readthedocs.org/projects/aiobotocore/badge/?version=latest
+    :target: https://aiobotocore.readthedocs.io/en/latest/?badge=latest
+    :alt: Documentation Status
 .. image:: https://img.shields.io/pypi/v/aiobotocore.svg
     :target: https://pypi.python.org/pypi/aiobotocore
 .. image:: https://badges.gitter.im/Join%20Chat.svg

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,11 @@
+name: aiobotocore
+type: sphinx
+requirements_file: requirements-dev.txt
+build:
+  image: latest
+python:
+  version: 3.6
+  setup_py_install: true
+formats:
+  - htmlzip
+  - epub


### PR DESCRIPTION
### Description of Change
Adds a ReadTheDocs configuration file to build docs with a Python version greater than 3.5.3. RTD's
stock version of Python 3 is less than aiobotocore's requirements. Enables config to be done more consistently than through the RTD UI.

Corrects currently [failing doc build](https://readthedocs.org/projects/aiobotocore/builds/8453966/). See [rendered test docs](https://test-aiobotocore.readthedocs.io/en/doc-build/)

Closes #641 

### Assumptions

### Checklist for All Submissions
* [x] I have added change info to [CHANGES.txt](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.txt)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
