### PR TITLE
Closing aiohttp session should be awaited

### DIFF
--- a/aiobotocore/client.py
+++ b/aiobotocore/client.py
@@ -205,9 +205,6 @@ class AioBaseClient(botocore.client.BaseClient):
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self._endpoint._aio_session.__aexit__(exc_type, exc_val, exc_tb)
 
-    def close(self):
-        """Close all http connections. This is coroutine, and should be
-        awaited. Method will be coroutine (instead returning Future) once
-        aiohttp does that.
-        """
-        return self._endpoint._aio_session.close()
+    async def close(self):
+        """Close all http connections."""
+        return await self._endpoint._aio_session.close()


### PR DESCRIPTION
Looks like aiohttp close method is a coroutine.
I guess we can make this change now.

### Description of Change
*Replace this text with why this change is required and how it was accomplished*

### Assumptions
*Replace this text with any assumptions made (if any)*

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.txt](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.txt)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
