### PR TITLE
bump deps botocore,boto3,awscli

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,13 +1,10 @@
 Changes
 -------
 
-0.10.5 (2019-10-14)
-^^^^^^^^^^^^^^^^^^^
-* Bump awscli, boto3, botocore
-
-0.10.4 (2019-XX-XX)
+0.10.4 (2019-10-14)
 ^^^^^^^^^^^^^^^^^^^
 * Pin aws-xray-sdk to aiobotocore
+* Bump awscli, boto3, botocore
 
 0.10.3 (2019-07-17)
 ^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,10 @@
 Changes
 -------
 
+0.10.5 (2019-10-14)
+^^^^^^^^^^^^^^^^^^^
+* Bump awscli, boto3, botocore
+
 0.10.4 (2019-XX-XX)
 ^^^^^^^^^^^^^^^^^^^
 * Pin aws-xray-sdk to aiobotocore

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ vtest:
 	python3 -m pytest -s -v $(FLAGS) ./tests/
 
 checkrst:
-	python setup.py check -rms
+	python3 setup.py check -rms
 
 cov cover coverage: flake
 	python3 -m pytest -s -v --cov-report term --cov-report html --cov aiobotocore ./tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,6 +18,6 @@ dill==0.2.8.2
 # The following are what give the most headaches
 aiohttp==3.3.2
 
-botocore==1.12.189
-boto3==1.9.189
-awscli==1.16.199
+botocore==1.12.248
+boto3==1.9.233
+awscli==1.16.258

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 # NOTE: When updating botocore make sure to update awscli/boto3 versions below
 install_requires = [
     # pegged to also match items in `extras_require`
-    'botocore>=1.12.189,<1.12.190',
+    'botocore>=1.12.248,<1.12.249',
     'aiohttp>=3.3.1',
     'wrapt>=1.10.10',
     'async_generator>=1.10',  # can remove if we move to py3.6+
@@ -25,9 +25,9 @@ def read(f):
 
 
 extras_require = {
-    'awscli': ['awscli==1.16.199'],
+    'awscli': ['awscli==1.16.258'],
     'aws-xray-sdk': ['aws-xray-sdk==2.4.2'],
-    'boto3': ['boto3==1.9.189'],
+    'boto3': ['boto3==1.9.233'],
 }
 
 


### PR DESCRIPTION
### Description of Change
bump dependencies because of project conflicts with amazon polly (boto3). Looking to close out two issues.

https://github.com/aio-libs/aiobotocore/issues/732
and
https://github.com/home-assistant/home-assistant/issues/27418



### Assumptions
I did a build but didn't actually try the code. Build went okay.

### Checklist for All Submissions
* [x] I have added change info to [CHANGES.txt](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.txt)

### Checklist when updating botocore and/or aiohttp versions

* [x] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate
* [x] I have ensured that the awscli/boto3 versions match the updated botocore version
