### PR TITLE
Remove vendored version of requests in botocore and bump version

### DIFF
--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -11,12 +11,12 @@ from botocore.endpoint import EndpointCreator, Endpoint, DEFAULT_TIMEOUT, \
 from botocore.exceptions import ConnectionClosedError
 from botocore.hooks import first_non_none_response
 from botocore.utils import is_valid_endpoint_url
-from botocore.vendored.requests.structures import CaseInsensitiveDict
 from botocore.history import get_global_history_recorder
 from multidict import MultiDict
 from urllib.parse import urlparse
 
 from aiobotocore.response import StreamingBody
+from aiobotocore.structures import CaseInsensitiveDict
 
 MAX_REDIRECTS = 10
 history_recorder = get_global_history_recorder()

--- a/aiobotocore/structures.py
+++ b/aiobotocore/structures.py
@@ -1,0 +1,79 @@
+import collections
+
+
+# This code is originally from requests.structures, 
+# because botocore remove requests from its library
+# ref: https://github.com/boto/botocore/pull/1829
+class CaseInsensitiveDict(collections.MutableMapping):
+    """
+    A case-insensitive ``dict``-like object.
+
+    Implements all methods and operations of
+    ``collections.MutableMapping`` as well as dict's ``copy``. Also
+    provides ``lower_items``.
+
+    All keys are expected to be strings. The structure remembers the
+    case of the last key to be set, and ``iter(instance)``,
+    ``keys()``, ``items()``, ``iterkeys()``, and ``iteritems()``
+    will contain case-sensitive keys. However, querying and contains
+    testing is case insensitive::
+
+        cid = CaseInsensitiveDict()
+        cid['Accept'] = 'application/json'
+        cid['aCCEPT'] == 'application/json'  # True
+        list(cid) == ['Accept']  # True
+
+    For example, ``headers['content-encoding']`` will return the
+    value of a ``'Content-Encoding'`` response header, regardless
+    of how the header name was originally stored.
+
+    If the constructor, ``.update``, or equality comparison
+    operations are given keys that have equal ``.lower()``s, the
+    behavior is undefined.
+
+    """
+    def __init__(self, data=None, **kwargs):
+        self._store = dict()
+        if data is None:
+            data = {}
+        self.update(data, **kwargs)
+
+    def __setitem__(self, key, value):
+        # Use the lowercased key for lookups, but store the actual
+        # key alongside the value.
+        self._store[key.lower()] = (key, value)
+
+    def __getitem__(self, key):
+        return self._store[key.lower()][1]
+
+    def __delitem__(self, key):
+        del self._store[key.lower()]
+
+    def __iter__(self):
+        return (casedkey for casedkey, mappedvalue in self._store.values())
+
+    def __len__(self):
+        return len(self._store)
+
+    def lower_items(self):
+        """Like iteritems(), but with all lowercase keys."""
+        return (
+            (lowerkey, keyval[1])
+            for (lowerkey, keyval)
+            in self._store.items()
+        )
+
+    def __eq__(self, other):
+        if isinstance(other, collections.Mapping):
+            other = CaseInsensitiveDict(other)
+        else:
+            return NotImplemented
+        # Compare insensitively
+        return dict(self.lower_items()) == dict(other.lower_items())
+
+    # Copy is required
+    def copy(self):
+        return CaseInsensitiveDict(self._store.values())
+
+    def __repr__(self):
+        return str(dict(self.items()))

--- a/aiobotocore/structures.py
+++ b/aiobotocore/structures.py
@@ -1,7 +1,7 @@
 import collections
 
 
-# This code is originally from requests.structures, 
+# This code is originally from requests.structures,
 # because botocore remove requests from its library
 # ref: https://github.com/boto/botocore/pull/1829
 class CaseInsensitiveDict(collections.MutableMapping):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,4 +22,4 @@ aiohttp==3.3.2
 
 botocore==1.13.2
 boto3==1.10.2
-awscli==1.16.262
+awscli==1.16.266

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,6 +20,6 @@ dill==0.3.1.1
 # The following are what give the most headaches
 aiohttp==3.3.2
 
-botocore==1.12.252
-boto3==1.9.252
+botocore==1.13.2
+boto3==1.10.2
 awscli==1.16.262

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def read(f):
 
 
 extras_require = {
-    'awscli': ['awscli==1.13.2'],
+    'awscli': ['awscli==1.16.266'],
     'boto3': ['boto3==1.10.2'],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 # NOTE: When updating botocore make sure to update awscli/boto3 versions below
 install_requires = [
     # pegged to also match items in `extras_require`
-    'botocore>=1.12.252,<1.12.253',
+    'botocore>=1.13.2,<1.13.3',
     'aiohttp>=3.3.1',
     'wrapt>=1.10.10',
     'async_generator>=1.10',  # can remove if we move to py3.6+
@@ -25,8 +25,8 @@ def read(f):
 
 
 extras_require = {
-    'awscli': ['awscli==1.16.262'],
-    'boto3': ['boto3==1.9.252'],
+    'awscli': ['awscli==1.13.2'],
+    'boto3': ['boto3==1.10.2'],
 }
 
 


### PR DESCRIPTION
### Description of Change
New version of botocore remove vendored version of requests, therefore it should remove all code using `botocore.vendored.requests`.

I copied the `CaseInsensitiveDict` from requests to aiobotocore to use this structures. The alternative way it to put requests into requirements, however aiobotocore didn't use other reqeusts function, so I think it is unnecessary.

To reproduces this bug, update botocore to >= 1.13.0, and make requuests with aiobotobore.
The following error will generated.

```
from botocore.vendored.requests.structures import CaseInsensitiveDict
ModuleNotFoundError: No module named 'botocore.vendored.requests.structures'
```

ref:
- https://aws.amazon.com/blogs/developer/removing-the-vendored-version-of-requests-from-botocore/
- https://github.com/boto/botocore/pull/1829

bump version

1. botocore==1.12.252 -> botocore==1.13.2
2. boto3==1.9.252 -> boto3==1.10.2
3. awscli==1.16.262 -> awscli==1.16.266

### Assumptions

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.txt](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.txt)
  * [V ] Detailed description of issue
  * [V ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced 

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
