### PR TITLE
Bump aws versions, remove vendored dependency

### DIFF
--- a/aiobotocore/args.py
+++ b/aiobotocore/args.py
@@ -11,9 +11,9 @@ from .endpoint import AioEndpointCreator
 
 class AioClientArgsCreator(botocore.args.ClientArgsCreator):
     def __init__(self, event_emitter, user_agent, response_parser_factory,
-                 loader, exceptions_factory, loop=None):
-        super().__init__(event_emitter, user_agent,
-                         response_parser_factory, loader, exceptions_factory)
+                 loader, exceptions_factory, loop=None, config_store=None):
+        super().__init__(event_emitter, user_agent, response_parser_factory,
+                         loader, exceptions_factory, config_store)
         self._loop = loop or asyncio.get_event_loop()
 
     # NOTE: we override this so we can pull out the custom AioConfig params and

--- a/aiobotocore/client.py
+++ b/aiobotocore/client.py
@@ -36,7 +36,7 @@ class AioClientCreator(botocore.client.ClientCreator):
         args_creator = AioClientArgsCreator(
             self._event_emitter, self._user_agent,
             self._response_parser_factory, self._loader,
-            self._exceptions_factory, loop=self._loop)
+            self._exceptions_factory, loop=self._loop, config_store=self._config_store)
         return args_creator.get_client_args(
             service_model, region_name, is_secure, endpoint_url,
             verify, credentials, scoped_config, client_config, endpoint_bridge)

--- a/aiobotocore/client.py
+++ b/aiobotocore/client.py
@@ -36,7 +36,8 @@ class AioClientCreator(botocore.client.ClientCreator):
         args_creator = AioClientArgsCreator(
             self._event_emitter, self._user_agent,
             self._response_parser_factory, self._loader,
-            self._exceptions_factory, loop=self._loop, config_store=self._config_store)
+            self._exceptions_factory, loop=self._loop,
+            config_store=self._config_store)
         return args_creator.get_client_args(
             service_model, region_name, is_secure, endpoint_url,
             verify, credentials, scoped_config, client_config, endpoint_bridge)

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -11,7 +11,7 @@ from botocore.endpoint import EndpointCreator, Endpoint, DEFAULT_TIMEOUT, \
 from botocore.exceptions import ConnectionClosedError
 from botocore.hooks import first_non_none_response
 from botocore.utils import is_valid_endpoint_url
-from botocore.vendored.requests.structures import CaseInsensitiveDict
+from requests.structures import CaseInsensitiveDict
 from botocore.history import get_global_history_recorder
 from multidict import MultiDict
 from urllib.parse import urlparse

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,6 +20,6 @@ dill==0.3.1.1
 # The following are what give the most headaches
 aiohttp==3.3.2
 
-botocore==1.12.252
-boto3==1.9.252
-awscli==1.16.262
+botocore==1.13.13
+boto3==1.10.12
+awscli==1.16.277

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,11 @@ from setuptools import setup, find_packages
 # NOTE: When updating botocore make sure to update awscli/boto3 versions below
 install_requires = [
     # pegged to also match items in `extras_require`
-    'botocore>=1.12.252,<1.12.253',
+    'botocore>=1.13.13,<1.14.0',
     'aiohttp>=3.3.1',
     'wrapt>=1.10.10',
     'async_generator>=1.10',  # can remove if we move to py3.6+
+    'requests>=2.22.0',
 ]
 
 PY_VER = sys.version_info
@@ -25,8 +26,8 @@ def read(f):
 
 
 extras_require = {
-    'awscli': ['awscli==1.16.262'],
-    'boto3': ['boto3==1.9.252'],
+    'awscli': ['awscli==1.16.277'],
+    'boto3': ['boto3==1.10.12'],
 }
 
 

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -51,15 +51,15 @@ _AIOHTTP_DIGESTS = {
 
 # If you're changing these, most likely need to update setup.py as well.
 _API_DIGESTS = {
-    ClientArgsCreator: {'6af0ae851aac2c7e9ff908e04af998f64345784f'},
-    ClientCreator: {'6808f991fc4b67db191110aaadb4de00603c0f57'},
+    ClientArgsCreator: {'a23c040b65096dd26abdaa321ba58612fbbfb4fe'},
+    ClientCreator: {'c4abf80fa41d9f4713b9c83d504c759ed905992e'},
     BaseClient: {'d2e69f0184ae83df5b82284194ed1b72191f0161'},
     Config: {'72129553174455492825ec92ea5d6e66307ed74f'},
     convert_to_response_dict: {'2c73c059fa63552115314b079ae8cbf5c4e78da0'},
     Endpoint: {'6839b062c5223d94aaf894dce6ade8606c388b4f'},
     EndpointCreator: {'633337fe0bda97e57c7f0b9596c5a158a03e8e36'},
     PageIterator: {'0409f7878b3493566be5761f5799ed93563f3e20'},
-    Session: {'ba1ec6c08e41f28490e7cf2f7b7bf03f6c424151'},
+    Session: {'16b4a08b3b5792d5d9c639b7a07d01902205b238'},
     get_session: {'c47d588f5da9b8bde81ccc26eaef3aee19ddd901'},
     NormalizedOperationMethod: {'ee88834b123c6c77dfea0b4208308cd507a6ba36'},
 }


### PR DESCRIPTION
### Description of Change
Removing the vendored version of the requests library, new dependency added for requests. Bumped AWS versions. Fixed signature of the ClientArgsCreator.

### Assumptions
*Replace this text with any assumptions made (if any)*

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.txt](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.txt)
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced 
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [x] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [x] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [x] I have ensured that the awscli/boto3 versions match the updated botocore version
