### PR TITLE
AioSession defaults to asyncio current loop

### DIFF
--- a/aiobotocore/session.py
+++ b/aiobotocore/session.py
@@ -12,7 +12,7 @@ from .parsers import AioResponseParserFactory
 class AioSession(botocore.session.Session):
 
     def __init__(self, *args, loop=None, **kwargs):
-        self._loop = loop
+        self._loop = loop or asyncio.get_event_loop()
 
         super().__init__(*args, **kwargs)
 
@@ -87,5 +87,4 @@ def get_session(*, env_vars=None, loop=None):
     """
     Return a new session object.
     """
-    loop = loop or asyncio.get_event_loop()
     return AioSession(env_vars, loop=loop)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -90,3 +90,9 @@ async def test_connector_timeout2(event_loop):
         with pytest.raises(ReadTimeoutError):
             resp = await s3_client.get_object(Bucket='foo', Key='bar')
             await resp["Body"].read()
+
+
+@pytest.mark.moto
+def test_default_event_loop():
+    session = AioSession()
+    assert session._loop == asyncio.get_event_loop()


### PR DESCRIPTION
- apply the default in the class initializer rather
  than the utility function that wraps it.

