### PR TITLE
bump moto

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ language: python
 dist: xenial
 
 python:
-    - 3.5.9
     - 3.6.10
     - 3.7.6
     - 3.8.1
+# moto is incompatible with 3.5 because it relies on the key order of its regex rules
+#    - 3.5.9
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ language: python
 dist: xenial
 
 python:
-    - 3.5
-    - 3.6
-    - 3.7
-    - 3.8
+    - 3.5.9
+    - 3.6.10
+    - 3.7.6
+    - 3.8.1
 
 matrix:
   include:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 FLAGS=
 
 flake: checkrst
-	python3 -m flake8
+	python3 -m flake8 --format=abspath
 
 test: flake
 	python3 -m pytest -s $(FLAGS) ./tests/
@@ -20,7 +20,7 @@ cov cover coverage: flake
 
 # BOTO_CONFIG solves https://github.com/travis-ci/travis-ci/issues/7940
 mototest:
-	BOTO_CONFIG=/dev/null python3 -m pytest -v -m moto --cov-report term --cov-report html --cov aiobotocore tests
+	BOTO_CONFIG=/dev/null python3 -m pytest -v -m moto -n auto --cov-report term --cov-report html --cov aiobotocore tests
 	@echo "open file://`pwd`/htmlcov/index.html"
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,18 +1,19 @@
 -e .
-coverage==4.5.4
+coverage==5.0.3
 flake8==3.7.8
-
+flake8-formatter-abspath==1.0.1
 # we specify flask directly and don't use moto[server] as we want to fix the flask version
 Flask==1.1.1
 
 moto==1.3.14
 
-pytest==5.2.1
+pytest==5.3.5
 pytest-cov==2.8.1
 pytest-asyncio==0.10.0
-sphinx==2.2.0
-yarl==1.3.0
-multidict==4.5.2
+pytest-xdist==1.31.0
+sphinx==2.4.1
+yarl==1.4.2
+multidict==4.7.4
 wrapt==1.11.2
 dill==0.3.1.1
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,8 +5,7 @@ flake8==3.7.8
 # we specify flask directly and don't use moto[server] as we want to fix the flask version
 Flask==1.1.1
 
-# We need: https://github.com/spulec/moto/pull/2436
-moto==1.3.14.dev326
+moto==1.3.14
 
 pytest==5.2.1
 pytest-cov==2.8.1

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -6,6 +6,7 @@ import aiohttp
 import aiohttp.web
 from aiohttp.web import StreamResponse
 import pytest
+from async_generator import async_generator, yield_
 
 # aiobotocore
 from tests.moto_server import host, MotoService, get_free_tcp_port
@@ -95,30 +96,35 @@ class AIOServer(multiprocessing.Process):
 
 
 @pytest.yield_fixture
+@async_generator
 async def s3_server():
     async with MotoService('s3') as svc:
-        yield svc.endpoint_url
+        await yield_(svc.endpoint_url)
 
 
 @pytest.yield_fixture
+@async_generator
 async def dynamodb2_server():
     async with MotoService('dynamodb2') as svc:
-        yield svc.endpoint_url
+        await yield_(svc.endpoint_url)
 
 
 @pytest.yield_fixture
+@async_generator
 async def cloudformation_server():
     async with MotoService('cloudformation') as svc:
-        yield svc.endpoint_url
+        await yield_(svc.endpoint_url)
 
 
 @pytest.yield_fixture
+@async_generator
 async def sns_server():
     async with MotoService('sns') as svc:
-        yield svc.endpoint_url
+        await yield_(svc.endpoint_url)
 
 
 @pytest.yield_fixture
+@async_generator
 async def sqs_server():
     async with MotoService('sqs') as svc:
-        yield svc.endpoint_url
+        await yield_(svc.endpoint_url)

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -1,31 +1,20 @@
 import asyncio
+import multiprocessing
+
+# Third Party
 import aiohttp
 import aiohttp.web
 from aiohttp.web import StreamResponse
 import pytest
-import requests
-import signal
-import subprocess as sp
-import sys
-import time
-import socket
-import multiprocessing
+
+# aiobotocore
+from tests.moto_server import host, MotoService, get_free_tcp_port
 
 
 _proxy_bypass = {
   "http": None,
   "https": None,
 }
-
-host = "localhost"
-
-
-def get_free_tcp_port():
-    sckt = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sckt.bind((host, 0))
-    addr, port = sckt.getsockname()
-    sckt.close()
-    return port
 
 
 # This runs in a subprocess for a variety of reasons
@@ -40,7 +29,7 @@ class AIOServer(multiprocessing.Process):
     def __init__(self):
         super().__init__(target=self._run)
         self._loop = None
-        self._port = get_free_tcp_port()
+        self._port = get_free_tcp_port(True)
         self.endpoint_url = 'http://{}:{}'.format(host, self._port)
         self.daemon = True  # die when parent dies
 
@@ -69,7 +58,8 @@ class AIOServer(multiprocessing.Process):
             pytest.fail("Unable to shut down server")
             raise
 
-    async def ok(self, request):
+    @staticmethod
+    async def ok(request):
         return aiohttp.web.Response()
 
     async def stream_handler(self, request):
@@ -104,106 +94,31 @@ class AIOServer(multiprocessing.Process):
         pytest.fail('unable to start and connect to aiohttp server')
 
 
-def start_service(service_name, host, port):
-    args = [sys.executable, "-m", "moto.server", "-H", host,
-            "-p", str(port), service_name]
-
-    # If test fails stdout/stderr will be shown
-    process = sp.Popen(args, stdin=sp.PIPE)
-    url = "http://{host}:{port}".format(host=host, port=port)
-
-    for i in range(0, 30):
-        if process.poll() is not None:
-            process.communicate()
-            pytest.fail("service failed starting up: {}".format(service_name))
-            break
-
-        try:
-            # we need to bypass the proxies due to monkeypatches
-            requests.get(url, timeout=0.5, proxies=_proxy_bypass)
-            break
-        except requests.exceptions.ConnectionError:
-            time.sleep(0.5)
-    else:
-        stop_process(process)  # pytest.fail doesn't call stop_process
-        pytest.fail("Can not start service: {}".format(service_name))
-
-    return process
+@pytest.yield_fixture
+async def s3_server():
+    async with MotoService('s3') as svc:
+        yield svc.endpoint_url
 
 
-def stop_process(process):
-    try:
-        process.send_signal(signal.SIGTERM)
-        process.communicate(timeout=20)
-    except sp.TimeoutExpired:
-        process.kill()
-        outs, errors = process.communicate(timeout=20)
-        exit_code = process.returncode
-        msg = "Child process finished {} not in clean way: {} {}" \
-            .format(exit_code, outs, errors)
-        raise RuntimeError(msg)
+@pytest.yield_fixture
+async def dynamodb2_server():
+    async with MotoService('dynamodb2') as svc:
+        yield svc.endpoint_url
 
 
-@pytest.yield_fixture(scope="session")
-def s3_server():
-    host = "localhost"
-    port = 5000
-    url = "http://{host}:{port}".format(host=host, port=port)
-    process = start_service('s3', host, port)
-
-    try:
-        yield url
-    finally:
-        stop_process(process)
+@pytest.yield_fixture
+async def cloudformation_server():
+    async with MotoService('cloudformation') as svc:
+        yield svc.endpoint_url
 
 
-@pytest.yield_fixture(scope="session")
-def dynamodb2_server():
-    host = "localhost"
-    port = 5001
-    url = "http://{host}:{port}".format(host=host, port=port)
-    process = start_service('dynamodb2', host, port)
-
-    try:
-        yield url
-    finally:
-        stop_process(process)
+@pytest.yield_fixture
+async def sns_server():
+    async with MotoService('sns') as svc:
+        yield svc.endpoint_url
 
 
-@pytest.yield_fixture(scope="session")
-def cloudformation_server():
-    host = "localhost"
-    port = 5002
-    url = "http://{host}:{port}".format(host=host, port=port)
-    process = start_service('cloudformation', host, port)
-
-    try:
-        yield url
-    finally:
-        stop_process(process)
-
-
-@pytest.yield_fixture(scope="session")
-def sns_server():
-    host = "localhost"
-    port = 5003
-    url = "http://{host}:{port}".format(host=host, port=port)
-    process = start_service('sns', host, port)
-
-    try:
-        yield url
-    finally:
-        stop_process(process)
-
-
-@pytest.yield_fixture(scope="session")
-def sqs_server():
-    host = "localhost"
-    port = 5004
-    url = "http://{host}:{port}".format(host=host, port=port)
-    process = start_service('sqs', host, port)
-
-    try:
-        yield url
-    finally:
-        stop_process(process)
+@pytest.yield_fixture
+async def sqs_server():
+    async with MotoService('sqs') as svc:
+        yield svc.endpoint_url

--- a/tests/moto_server.py
+++ b/tests/moto_server.py
@@ -3,7 +3,7 @@ import functools
 import logging
 import socket
 import threading
-from typing import Dict, Any, Optional
+from typing import Optional
 
 # Third Party
 import aiohttp
@@ -30,7 +30,7 @@ class MotoService:
     Service is ref-counted so there will only be one per process. Real Service will
     be returned by `__aenter__`."""
 
-    _services: Dict[str, Any] = dict()  # {name: instance}
+    _services = dict()  # {name: instance}
 
     def __init__(self, service_name: str, port: int = None):
         self._service_name = service_name

--- a/tests/moto_server.py
+++ b/tests/moto_server.py
@@ -3,7 +3,6 @@ import functools
 import logging
 import socket
 import threading
-from typing import Optional
 
 # Third Party
 import aiohttp
@@ -45,7 +44,7 @@ class MotoService:
         self._logger = logging.getLogger('MotoService')
         self._refcount = None
         self._ip_address = host
-        self._server: Optional[werkzeug.serving.ThreadedWSGIServer] = None
+        self._server = None
 
     @property
     def endpoint_url(self):

--- a/tests/moto_server.py
+++ b/tests/moto_server.py
@@ -48,7 +48,7 @@ class MotoService:
 
     @property
     def endpoint_url(self):
-        return f'http://{self._ip_address}:{self._port}'
+        return 'http://{}:{}'.format(self._ip_address, self._port)
 
     def __call__(self, func):
         async def wrapper(*args, **kwargs):

--- a/tests/moto_server.py
+++ b/tests/moto_server.py
@@ -1,0 +1,128 @@
+import asyncio
+import functools
+import logging
+import socket
+import threading
+from typing import Dict, Any, Optional
+
+# Third Party
+import aiohttp
+import moto.server
+import werkzeug.serving
+
+
+host = 'localhost'
+
+
+def get_free_tcp_port(release_socket: bool = False):
+    sckt = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sckt.bind(('', 0))
+    addr, port = sckt.getsockname()
+    if release_socket:
+        sckt.close()
+        return port
+
+    return sckt, port
+
+
+class MotoService:
+    """ Will Create MotoService.
+    Service is ref-counted so there will only be one per process. Real Service will
+    be returned by `__aenter__`."""
+
+    _services: Dict[str, Any] = dict()  # {name: instance}
+
+    def __init__(self, service_name: str, port: int = None):
+        self._service_name = service_name
+
+        if port:
+            self._socket = None
+            self._port = port
+        else:
+            self._socket, self._port = get_free_tcp_port()
+
+        self._thread = None
+        self._logger = logging.getLogger('MotoService')
+        self._refcount = None
+        self._ip_address = host
+        self._server: Optional[werkzeug.serving.ThreadedWSGIServer] = None
+
+    @property
+    def endpoint_url(self):
+        return f'http://{self._ip_address}:{self._port}'
+
+    def __call__(self, func):
+        async def wrapper(*args, **kwargs):
+            await self._start()
+            try:
+                result = await func(*args, **kwargs)
+            finally:
+                await self._stop()
+            return result
+
+        functools.update_wrapper(wrapper, func)
+        wrapper.__wrapped__ = func
+        return wrapper
+
+    async def __aenter__(self):
+        svc = self._services.get(self._service_name)
+        if svc is None:
+            self._services[self._service_name] = self
+            self._refcount = 1
+            await self._start()
+            return self
+        else:
+            svc._refcount += 1
+            return svc
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self._refcount -= 1
+
+        if self._socket:
+            self._socket.close()
+            self._socket = None
+
+        if self._refcount == 0:
+            del self._services[self._service_name]
+            await self._stop()
+
+    def _server_entry(self):
+        self._main_app = moto.server.DomainDispatcherApplication(
+            moto.server.create_backend_app, service=self._service_name)
+        self._main_app.debug = True
+
+        if self._socket:
+            self._socket.close()  # release right before we use it
+            self._socket = None
+
+        self._server = werkzeug.serving.make_server(
+            self._ip_address, self._port, self._main_app, True)
+        self._server.serve_forever()
+
+    async def _start(self):
+        self._thread = threading.Thread(target=self._server_entry, daemon=True)
+        self._thread.start()
+
+        async with aiohttp.ClientSession() as session:
+            for i in range(0, 10):
+                if not self._thread.is_alive():
+                    break
+
+                try:
+                    # we need to bypass the proxies due to monkeypatches
+                    async with session.get(self.endpoint_url + '/static/',
+                                           timeout=0.5):
+                        pass
+                    break
+                except (asyncio.TimeoutError, aiohttp.ClientConnectionError):
+                    await asyncio.sleep(0.5)
+            else:
+                await self._stop()  # pytest.fail doesn't call stop_process
+                raise Exception("Can not start service: {}".format(
+                    self._service_name))
+
+    async def _stop(self):
+        if self._server:
+            self._server.shutdown()
+
+        self._thread.join()

--- a/tests/test_sns.py
+++ b/tests/test_sns.py
@@ -2,7 +2,32 @@ import json
 import pytest
 import botocore
 
-from moto.sns.models import DEFAULT_TOPIC_POLICY
+
+def _get_topic_policy(topic_arn: str):
+    return {
+        "Version": "2008-10-17",
+        "Id": "__default_policy_ID",
+        "Statement": [{
+            "Effect": "Allow",
+            "Sid": "__default_statement_ID",
+            "Principal": {
+                "AWS": "*"
+            },
+            "Action": [
+                "SNS:GetTopicAttributes",
+                "SNS:SetTopicAttributes",
+                "SNS:AddPermission",
+                "SNS:RemovePermission",
+                "SNS:DeleteTopic",
+                "SNS:Subscribe",
+                "SNS:ListSubscriptionsByTopic",
+                "SNS:Publish",
+                "SNS:Receive",
+            ],
+            'Resource': topic_arn,
+            'Condition': {'StringEquals': {'AWS:SourceOwner': '123456789012'}},
+        }]
+    }
 
 
 @pytest.mark.moto
@@ -17,7 +42,7 @@ async def test_topic_attributes(sns_client, topic_arn):
     attributes = topic_properties['Attributes']
 
     assert arn1 == topic_arn
-    assert json.loads(attributes['Policy']) == DEFAULT_TOPIC_POLICY
+    assert json.loads(attributes['Policy']) == _get_topic_policy(topic_arn)
     assert attributes['DisplayName'] == ''
 
     display_name = 'My display name'


### PR DESCRIPTION
- bump moto
- run tests in parallel
- disable testing 3.5 because moto relies on stable sort order of dictionary keys when processing its url rules so it can occasionally think a bucket path is a key path