### PR TITLE
Remove deprecated yield_fixture (#762)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -236,21 +236,21 @@ async def recursive_delete(s3_client, bucket_name):
     assert_status_code(resp, 204)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 @async_generator
 async def bucket_name(region, create_bucket):
     name = await create_bucket(region)
     await yield_(name)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 @async_generator
 async def table_name(create_table):
     name = await create_table()
     await yield_(name)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 @async_generator
 async def create_bucket(s3_client):
     _bucket_name = None
@@ -277,7 +277,7 @@ async def create_bucket(s3_client):
         await recursive_delete(s3_client, _bucket_name)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 @async_generator
 async def create_table(dynamodb_client):
     _table_name = None
@@ -374,7 +374,7 @@ def create_multipart_upload(request, s3_client, bucket_name, event_loop):
     return _f
 
 
-@pytest.yield_fixture
+@pytest.fixture
 @async_generator
 async def aio_session(event_loop):
     async with aiohttp.ClientSession(loop=event_loop) as session:

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -95,35 +95,35 @@ class AIOServer(multiprocessing.Process):
         pytest.fail('unable to start and connect to aiohttp server')
 
 
-@pytest.yield_fixture
+@pytest.fixture
 @async_generator
 async def s3_server():
     async with MotoService('s3') as svc:
         await yield_(svc.endpoint_url)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 @async_generator
 async def dynamodb2_server():
     async with MotoService('dynamodb2') as svc:
         await yield_(svc.endpoint_url)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 @async_generator
 async def cloudformation_server():
     async with MotoService('cloudformation') as svc:
         await yield_(svc.endpoint_url)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 @async_generator
 async def sns_server():
     async with MotoService('sns') as svc:
         await yield_(svc.endpoint_url)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 @async_generator
 async def sqs_server():
     async with MotoService('sqs') as svc:


### PR DESCRIPTION
Fix #762 

See also https://docs.pytest.org/en/latest/yieldfixture.html

This PR applies:

```
sed -i -e 's/pytest.yield_fixture/pytest.fixture/g' \
    tests/conftest.py \
    tests/mock_server.py
```

After this PR:
```
$ git grep 'yield_fixture' | echo "none"
none
```