### PR TITLE
Fixes get_frozen_credentials not being async

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,10 @@
 Changes
 -------
+
+1.0.1 (2020-04-01)
+^^^^^^^^^^^^^^^^^^
+* Fixed signing requests with explict credentials
+
 1.0.0 (2020-03-31)
 ^^^^^^^^^^^^^^^^^^
 * API breaking: The result of create_client is now a required async context class

--- a/aiobotocore/__init__.py
+++ b/aiobotocore/__init__.py
@@ -1,4 +1,4 @@
 from .session import get_session, AioSession
 
 __all__ = ['get_session', 'AioSession']
-__version__ = '1.0.0'
+__version__ = '1.0.1'

--- a/aiobotocore/session.py
+++ b/aiobotocore/session.py
@@ -117,6 +117,9 @@ class AioSession(Session):
                 'credential_provider').load_credentials())
         return self._credentials
 
+    def set_credentials(self, access_key, secret_key, token=None):
+        self._credentials = AioCredentials(access_key, secret_key, token)
+
     async def get_service_model(self, service_name, api_version=None):
         service_description = await self.get_service_data(service_name, api_version)
         return ServiceModel(service_description, service_name=service_name)


### PR DESCRIPTION
### Description of Change
If credentials are passed explicitly, the session calls self.set_credentials, which assigns `botocore.credentials.Credentials` to `self._credentials`. Later on when `session.get_credentials()` is called, a `botocore.credentials.Credentials` object will be passed to the signer, which will try and call `await creds.get_frozen_credentials()` which fails as `get_frozen_credentials` is not async.

### Checklist for All Submissions
* [x] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced 
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [x] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [x] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [x] I have ensured that the awscli/boto3 versions match the updated botocore version
