### PR TITLE
Fixed typo when calling subprocess

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,10 @@
 Changes
 -------
+
+1.0.3 (2020-04-09)
+^^^^^^^^^^^^^^^^^^
+* Fixes typo when using credential process
+
 1.0.2 (2020-04-05)
 ^^^^^^^^^^^^^^^^^^
 * Disable Client.__getattr__ emit for now #789

--- a/aiobotocore/__init__.py
+++ b/aiobotocore/__init__.py
@@ -1,4 +1,4 @@
 from .session import get_session, AioSession
 
 __all__ = ['get_session', 'AioSession']
-__version__ = '1.0.2'
+__version__ = '1.0.3'

--- a/aiobotocore/credentials.py
+++ b/aiobotocore/credentials.py
@@ -425,7 +425,7 @@ class AioProcessProvider(ProcessProvider):
         # We're not using shell=True, so we need to pass the
         # command and all arguments as a list.
         process_list = compat_shell_split(credential_process)
-        p = await self._popen(process_list,
+        p = await self._popen(*process_list,
                               stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE)
         stdout, stderr = await p.communicate()

--- a/tests/botocore/test_credentials.py
+++ b/tests/botocore/test_credentials.py
@@ -931,7 +931,7 @@ def process_provider():
 @pytest.mark.moto
 @pytest.mark.asyncio
 async def test_processprovider_retrieve_refereshable_creds(process_provider):
-    config = {'profiles': {'default': {'credential_process': 'my-process'}}}
+    config = {'profiles': {'default': {'credential_process': 'my-process /somefile'}}}
     invoked_process = mock.AsyncMock()
     stdout = json.dumps({
         'Version': 1,
@@ -955,7 +955,7 @@ async def test_processprovider_retrieve_refereshable_creds(process_provider):
     assert creds.access_key == 'foo'
     assert creds.secret_key == 'bar'
     assert creds.token == 'baz'
-    popen_mock.assert_called_with(['my-process'],
+    popen_mock.assert_called_with('my-process', '/somefile',
                                   stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
 


### PR DESCRIPTION
### Description of Change
Typo, doesnt expand command list when calling `asyncio.create_subprocess_exec`

Fixes #794

### Checklist for All Submissions
* [x] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [x] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced 
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)
