### PR TITLE
fix AioPageIterator search method

### DIFF
--- a/aiobotocore/paginate.py
+++ b/aiobotocore/paginate.py
@@ -3,6 +3,7 @@ from botocore.paginate import Paginator, PageIterator
 from botocore.utils import set_value_from_jmespath, merge_dicts
 from botocore.compat import six
 
+import jmespath
 import aioitertools
 
 
@@ -129,6 +130,15 @@ class AioPageIterator(PageIterator):
             complete_result['NextToken'] = self.resume_token
         return complete_result
 
+    async def search(self, expression):
+        compiled = jmespath.compile(expression)
+        async for page in self:
+            results = compiled.search(page)
+            if isinstance(results, list):
+                for element in results:
+                    yield element
+            else:
+                yield results
 
 class AioPaginator(Paginator):
     PAGE_ITERATOR_CLS = AioPageIterator

--- a/aiobotocore/paginate.py
+++ b/aiobotocore/paginate.py
@@ -140,6 +140,7 @@ class AioPageIterator(PageIterator):
             else:
                 yield results
 
+
 class AioPaginator(Paginator):
     PAGE_ITERATOR_CLS = AioPageIterator
 

--- a/tests/test_basic_s3.py
+++ b/tests/test_basic_s3.py
@@ -109,6 +109,22 @@ async def test_can_paginate_with_page_size(
 
 @pytest.mark.asyncio
 @pytest.mark.moto
+async def test_can_search_paginate(
+        s3_client, bucket_name, create_object):
+    keys = []
+    for i in range(5):
+        key_name = 'key%s' % i
+        keys.append(key_name)
+        await create_object(key_name)
+
+    paginator = s3_client.get_paginator('list_objects')
+    page_iter = paginator.paginate(Bucket=bucket_name)
+    async for key_name in page_iter.search('Contents[*].Key'):
+        assert key_name in keys
+
+
+@pytest.mark.asyncio
+@pytest.mark.moto
 async def test_can_paginate_iterator(s3_client, bucket_name, create_object):
     for i in range(5):
         key_name = 'key%s' % i


### PR DESCRIPTION
### Description of Change
the Base class PageIterator has a search method that does jmespath query on the result. The original search method can not be called from AioPageIterator instances. this is mirroring the behavior from PageIterator.

### Assumptions
*Replace this text with any assumptions made (if any)*

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced 
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)
