### PR TITLE
Use botocore and boto3 compatible with AWS Lambda

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ coverage = "==5.0.3"
 flake8 = "==3.7.9"
 flake8-formatter-abspath = "==1.0.1"
 docker = '<4'  # fix: client version 1.39 is too new. Maximum supported API version is 1.38
-moto = {extras = ["server"],version = "==1.3.14"}
+moto = {extras = ["server"],version = "==1.3.16"}
 idna = "==2.8"  # broken pipenv resolver
 pytest = "==5.3.5"
 pytest-cov = "==2.8.1"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 # NOTE: When updating botocore make sure to update awscli/boto3 versions below
 install_requires = [
     # pegged to also match items in `extras_require`
-    'botocore>=1.17.44,<1.17.45',
+    'botocore~=1.17.40',
     'aiohttp>=3.3.1',
     'wrapt>=1.10.10',
     'aioitertools>=0.5.1',
@@ -19,8 +19,8 @@ def read(f):
 
 
 extras_require = {
-    'awscli': ['awscli==1.18.121'],
-    'boto3': ['boto3==1.14.44'],
+    'awscli': ['awscli~=1.18.121'],
+    'boto3': ['boto3~=1.14.40']
 }
 
 


### PR DESCRIPTION
Partial fix for #833 but it doesn't modify any CI matrix settings.

This PR might get replaced by #835 but this PR is smaller and tries to use the current packaging setup.