### PR TITLE
Await call to async method AioAssumeRoleProvider._load_creds_via_assu…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,9 @@
 Changes
 -------
+1.2.2 (2021-03-11)
+^^^^^^^^^^^^^^^^^^
+* Await call to async method _load_creds_via_assume_role #851 (thanks @puzza007)
+
 1.2.1 (2021-02-10)
 ^^^^^^^^^^^^^^^^^^
 * verify strings are now correctly passed to aiohttp.TCPConnector #851 (thanks @FHTMitchell)

--- a/aiobotocore/__init__.py
+++ b/aiobotocore/__init__.py
@@ -1,4 +1,4 @@
 from .session import get_session, AioSession
 
 __all__ = ['get_session', 'AioSession']
-__version__ = '1.2.1'
+__version__ = '1.2.2'

--- a/aiobotocore/credentials.py
+++ b/aiobotocore/credentials.py
@@ -629,7 +629,7 @@ class AioAssumeRoleProvider(AssumeRoleProvider):
                 )
             return credentials
 
-        return self._load_creds_via_assume_role(profile_name)
+        return await self._load_creds_via_assume_role(profile_name)
 
     def _resolve_static_credentials_from_profile(self, profile):
         try:


### PR DESCRIPTION
Fixes #854

### Description of Change

Fix async method call which wasn't awaited and results in

```
    frozen_credentials = await self._source_credentials.get_frozen_credentials()
AttributeError: 'coroutine' object has no attribute 'get_frozen_credentials'
```

### Assumptions
*Replace this text with any assumptions made (if any)*

### Checklist for All Submissions
* [x] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [x] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [x] Detailed description of issue
  * [x] Alternative methods considered (if any)
  * [x] How issue is being resolved
  * [ ] How issue can be reproduced 
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [x] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
