### PR TITLE
TCP_CONNECTOR(ssl_context) deprecated. Change to ssl

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,9 @@
 Changes
 -------
+1.3.1 (2021-04-23)
+^^^^^^^^^^^^^^^^^^
+* TCPConnector: change deprecated ssl_context to ssl
+
 1.3.0 (2021-04-09)
 ^^^^^^^^^^^^^^^^^^
 * Bump to botocore 1.20.49 #856

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -288,7 +288,7 @@ class AioEndpointCreator(EndpointCreator):
         )
 
         verify = self._get_verify_value(verify)
-        ssl = None
+        ssl_context = None
         if client_cert:
             if isinstance(client_cert, str):
                 key_file = None
@@ -299,18 +299,18 @@ class AioEndpointCreator(EndpointCreator):
                 raise TypeError("client_cert must be str or tuple, not %s" %
                                 client_cert.__class__.__name__)
 
-            ssl = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-            ssl.load_cert_chain(cert_file, key_file)
+            ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+            ssl_context.load_cert_chain(cert_file, key_file)
         elif isinstance(verify, (str, pathlib.Path)):
-            ssl = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH,
-                                             cafile=str(verify))
+            ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH,
+                                                     cafile=str(verify))
 
         # TODO: add support for proxies_config
 
         connector = aiohttp.TCPConnector(
             limit=max_pool_connections,
             verify_ssl=bool(verify),
-            ssl=ssl,
+            ssl=ssl_context,
             **connector_args)
 
         aio_session = http_session_cls(

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -288,7 +288,7 @@ class AioEndpointCreator(EndpointCreator):
         )
 
         verify = self._get_verify_value(verify)
-        ssl_context = None
+        ssl = None
         if client_cert:
             if isinstance(client_cert, str):
                 key_file = None
@@ -299,18 +299,18 @@ class AioEndpointCreator(EndpointCreator):
                 raise TypeError("client_cert must be str or tuple, not %s" %
                                 client_cert.__class__.__name__)
 
-            ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-            ssl_context.load_cert_chain(cert_file, key_file)
+            ssl = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+            ssl.load_cert_chain(cert_file, key_file)
         elif isinstance(verify, (str, pathlib.Path)):
-            ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH,
-                                                     cafile=str(verify))
+            ssl = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH,
+                                             cafile=str(verify))
 
         # TODO: add support for proxies_config
 
         connector = aiohttp.TCPConnector(
             limit=max_pool_connections,
             verify_ssl=bool(verify),
-            ssl_context=ssl_context,
+            ssl=ssl,
             **connector_args)
 
         aio_session = http_session_cls(


### PR DESCRIPTION
### Description of Change
Fixed aiohttp.TCPConnector deprecation warning. Must use ssl instead of ssl_context when instantiating one.
