### PR TITLE
revert accidental dupe of _register_s3_events

### DIFF
--- a/aiobotocore/client.py
+++ b/aiobotocore/client.py
@@ -37,9 +37,6 @@ class AioClientCreator(ClientCreator):
         self._register_s3_events(
             service_client, endpoint_bridge, endpoint_url, client_config,
             scoped_config)
-        self._register_s3_events(
-            service_client, endpoint_bridge, endpoint_url, client_config,
-            scoped_config)
         self._register_endpoint_discovery(
             service_client, endpoint_url, client_config
         )


### PR DESCRIPTION
This looks to have been accidentally inserted in https://github.com/aio-libs/aiobotocore/commit/3faf885644e01b01cffd945a63e079d6fd446ffa — on the basis that the line is identical to the next one.

This actually causes failures for me down in the bowels of botocore, as it tries to rewrite to 'virtual' urls or something and I get a failure `s3-accelerate.amazonaws.com` cannot be found.... this is because my bucket subdomain has been stripped out (there's no DNS entry for `s3-accelerate.amazonaws.com` which becomes the target after the second `_register_s3_events` call; the bucket is stripped from the URL)

FYI In a previous debug session when I thought the problem was in botocore, I traced the problem to some operations that were introduced in https://github.com/boto/botocore/commit/28b8831f5f8518bef5accf994fc377c58a3569f7