### PR TITLE
Fixed pipfile and missing close() on httpsession

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,10 @@
 Changes
 -------
+
+1.4.2 (2021-09-03)
+^^^^^^^^^^^^^^^^^^
+* Fix missing close() method on http session
+
 1.4.1 (2021-08-24)
 ^^^^^^^^^^^^^^^^^^
 * put backwards incompatible changes behind ``AIOBOTOCORE_DEPRECATED_1_4_0_APIS`` env var.  This means that `#876 <https://github.com/aio-libs/aiobotocore/issues/876>`_ will not work unless this env var has been set to 0.

--- a/Pipfile
+++ b/Pipfile
@@ -4,11 +4,11 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-codecov = "2.1.11"
+codecov = "==2.1.11"
 coverage = "==5.5"
 flake8 = "==3.9.0"
 flake8-formatter-abspath = "==1.0.1"
-docker = '5.0.0'
+docker = '==5.0.0'
 moto = {extras = ["server","s3","sqs","lambda","dynamodb","cloudformation", "sns", "batch", "ec2", "rds"],version = "==2.0.8"}
 pytest = "==6.2.4"
 pytest-cov = "==2.11.1"

--- a/aiobotocore/httpsession.py
+++ b/aiobotocore/httpsession.py
@@ -105,6 +105,9 @@ class AIOHTTPSession:
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self._session.__aexit__(exc_type, exc_val, exc_tb)
 
+    async def close(self):
+        await self._session.__aexit__(None, None, None)
+
     def _get_ssl_context(self):
         ssl_context = create_urllib3_context()
         if self._cert_file:


### PR DESCRIPTION
### Description of Change
AioBaseClient.close calls the close method of the internal http session... which doesn't exist.

