### PR TITLE
remove deprecated ssl_context field from connector args

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,9 @@
 Changes
 -------
+2.2.0 (2021-12-23)
+^^^^^^^^^^^^^^^^^^
+* AioConfig: change deprecated ssl_context to ssl
+
 2.1.0 (2021-12-14)
 ^^^^^^^^^^^^^^^^^^
 * bump to botocore 1.23.24

--- a/aiobotocore/config.py
+++ b/aiobotocore/config.py
@@ -47,7 +47,7 @@ class AioConfig(botocore.client.Config):
                     raise ParamValidationError(
                         report='{} value must be a boolean'.format(k))
             # limit is handled by max_pool_connections
-            elif k == 'ssl_context':
+            elif k == 'ssl':
                 import ssl
                 if not isinstance(v, ssl.SSLContext):
                     raise ParamValidationError(

--- a/aiobotocore/httpsession.py
+++ b/aiobotocore/httpsession.py
@@ -73,11 +73,10 @@ class AIOHTTPSession:
         # it also pools by host so we don't need a manager, and can pass proxy via
         # request so don't need proxy manager
 
-        ssl_context = None
-        if bool(verify):
+        if bool(verify) and "ssl" not in connector_args:
             if proxies:
                 proxies_settings = self._proxy_config.settings
-                ssl_context = self._setup_proxy_ssl_context(proxies_settings)
+                connector_args["ssl"] = self._setup_proxy_ssl_context(proxies_settings)
                 # TODO: add support for
                 #    proxies_settings.get('proxy_use_forwarding_for_https')
             else:
@@ -88,10 +87,11 @@ class AIOHTTPSession:
                 if ca_certs:
                     ssl_context.load_verify_locations(ca_certs, None, None)
 
+                connector_args["ssl"] = ssl_context
+
         self._connector = aiohttp.TCPConnector(
             limit=max_pool_connections,
             verify_ssl=bool(verify),
-            ssl=ssl_context,
             **connector_args)
 
     async def __aenter__(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,7 +30,7 @@ def test_connector_args():
 
     with pytest.raises(ParamValidationError):
         # wrong type
-        connector_args = dict(ssl_context="1")
+        connector_args = dict(ssl="1")
         AioConfig(connector_args)
 
     with pytest.raises(ParamValidationError):


### PR DESCRIPTION
### Description of Change
Currently `AioConfig` allows to override ssl context using deprecated `ssl_context` field. This pr renames this field to `ssl`.

Also `AIOHTTPSession` always overrides ssl context before creating `TCPConnector`. It should create ssl context only if is not set in `AioConfig`.
