### PR TITLE
feat: add a non-blocking implementation of the adaptive retry strategy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,9 @@
 Changes
 -------
+2.1.1 (2022-02-09)
+^^^^^^^^^^^^^^^^^^
+* implement asynchronous non-blocking adaptive retry strategy
+
 2.1.0 (2021-12-14)
 ^^^^^^^^^^^^^^^^^^
 * bump to botocore 1.23.24

--- a/aiobotocore/__init__.py
+++ b/aiobotocore/__init__.py
@@ -12,4 +12,4 @@ if DEPRECATED_1_4_0_APIS:
 
     __all__ = ['get_session', 'AioSession']
 
-__version__ = '2.1.0'
+__version__ = '2.1.1'

--- a/aiobotocore/retries/adaptive.py
+++ b/aiobotocore/retries/adaptive.py
@@ -1,0 +1,89 @@
+"""An async reimplementation of the blocking elements from botocore.retries.adaptive."""
+import asyncio
+import logging
+
+from botocore.retries import throttling
+from botocore.retries import standard
+
+# The RateClocker from botocore uses a threading.Lock, but in a single-threaded asyncio
+# program, the lock will be acquired then released by the same coroutine without
+# blocking.
+from botocore.retries.adaptive import RateClocker
+
+from . import bucket
+
+
+logger = logging.getLogger(__name__)
+
+
+def register_retry_handler(client):
+    clock = bucket.Clock()
+    rate_adjustor = throttling.CubicCalculator(starting_max_rate=0,
+                                               start_time=clock.current_time())
+    token_bucket = bucket.AsyncTokenBucket(max_rate=1, clock=clock)
+    rate_clocker = RateClocker(clock)
+    throttling_detector = standard.ThrottlingErrorDetector(
+        retry_event_adapter=standard.RetryEventAdapter(),
+    )
+    limiter = AsyncClientRateLimiter(
+        rate_adjustor=rate_adjustor,
+        rate_clocker=rate_clocker,
+        token_bucket=token_bucket,
+        throttling_detector=throttling_detector,
+        clock=clock,
+    )
+    client.meta.events.register(
+        'before-send', limiter.on_sending_request,
+    )
+    client.meta.events.register(
+        'needs-retry', limiter.on_receiving_response,
+    )
+    return limiter
+
+
+class AsyncClientRateLimiter:
+    """An async reimplementation of ClientRateLimiter."""
+    # Most of the code here comes directly from botocore. The main change is making the
+    # callbacks async.
+    # This doesn't inherits from the botocore ClientRateLimiter for two reasons:
+    # * the interface is slightly changed (methods are now async)
+    # * we rewrote the entirety of the class anyway
+
+    _MAX_RATE_ADJUST_SCALE = 2.0
+
+    def __init__(self, rate_adjustor, rate_clocker, token_bucket,
+                 throttling_detector, clock):
+        self._rate_adjustor = rate_adjustor
+        self._rate_clocker = rate_clocker
+        self._token_bucket = token_bucket
+        self._throttling_detector = throttling_detector
+        self._clock = clock
+        self._enabled = False
+        self._lock = asyncio.Lock()
+
+    async def on_sending_request(self, request, **kwargs):
+        if self._enabled:
+            await self._token_bucket.acquire()
+
+    # Hooked up to needs-retry.
+    async def on_receiving_response(self, **kwargs):
+        measured_rate = self._rate_clocker.record()
+        timestamp = self._clock.current_time()
+        async with self._lock:
+            if not self._throttling_detector.is_throttling_error(**kwargs):
+                new_rate = self._rate_adjustor.success_received(timestamp)
+            else:
+                if not self._enabled:
+                    rate_to_use = measured_rate
+                else:
+                    rate_to_use = min(measured_rate, self._token_bucket.max_rate)
+                new_rate = self._rate_adjustor.error_received(
+                    rate_to_use, timestamp)
+                logger.debug("Throttling response received, new send rate: %s "
+                             "measured rate: %s, token bucket capacity "
+                             "available: %s", new_rate, measured_rate,
+                             self._token_bucket.available_capacity)
+                self._enabled = True
+            await self._token_bucket.set_max_rate(
+                min(new_rate, self._MAX_RATE_ADJUST_SCALE * measured_rate)
+            )

--- a/aiobotocore/retries/bucket.py
+++ b/aiobotocore/retries/bucket.py
@@ -1,0 +1,113 @@
+"""An async reimplementation of the blocking elements from botocore.retries.bucket."""
+import asyncio
+
+from botocore.exceptions import CapacityNotAvailableError
+from botocore.retries.bucket import Clock as Clock  # reexport # noqa
+
+
+class AsyncTokenBucket:
+    """A reimplementation of TokenBucket that doesn't block."""
+    # Most of the code here is pulled straight up from botocore, with slight changes
+    # to the interface to switch to async methods.
+    # This class doesn't inherit from the botocore TokenBucket, as the interface is
+    # different: the `max_rate` setter in the original class is replaced by the
+    # async `set_max_rate`.
+    # (a Python setter can't be async).
+
+    _MIN_RATE = 0.5
+
+    def __init__(self, max_rate, clock, min_rate=_MIN_RATE):
+        self._fill_rate = None
+        self._max_capacity = None
+        self._current_capacity = 0
+        self._clock = clock
+        self._last_timestamp = None
+        self._min_rate = min_rate
+        self._set_max_rate(max_rate)
+        # The main difference between this implementation and the botocore TokenBucket
+        # implementation is replacing a threading.Condition by this asyncio.Condition.
+        self._new_fill_rate_condition = asyncio.Condition()
+
+    @property
+    def max_rate(self):
+        return self._fill_rate
+
+    async def set_max_rate(self, value):
+        async with self._new_fill_rate_condition:
+            self._set_max_rate(value)
+            self._new_fill_rate_condition.notify()
+
+    def _set_max_rate(self, value):
+        # Before we can change the rate we need to fill any pending
+        # tokens we might have based on the current rate.  If we don't
+        # do this it means everything since the last recorded timestamp
+        # will accumulate at the rate we're about to set which isn't
+        # correct.
+        self._refill()
+        self._fill_rate = max(value, self._min_rate)
+        if value >= 1:
+            self._max_capacity = value
+        else:
+            self._max_capacity = 1
+        # If we're scaling down, we also can't have a capacity that's
+        # more than our max_capacity.
+        self._current_capacity = min(
+            self._current_capacity,
+            self._max_capacity
+        )
+
+    @property
+    def max_capacity(self):
+        return self._max_capacity
+
+    @property
+    def available_capacity(self):
+        return self._current_capacity
+
+    async def acquire(self, amount=1, block=True):
+        """Acquire token or return amount of time until next token available.
+
+        If block is True, then this method will return when there's sufficient
+        capacity to acquire the desired amount. This won't block the event loop.
+
+        If block is False, then this method will return True if capacity
+        was successfully acquired, False otherwise.
+        """
+        async with self._new_fill_rate_condition:
+            return await self._acquire(amount=amount, block=block)
+
+    async def _acquire(self, amount, block):
+        self._refill()
+        if amount <= self._current_capacity:
+            self._current_capacity -= amount
+            return True
+        else:
+            if not block:
+                raise CapacityNotAvailableError()
+            # Not enough capacity.
+            sleep_amount = self._sleep_amount(amount)
+            while sleep_amount > 0:
+                try:
+                    await asyncio.wait_for(
+                        self._new_fill_rate_condition.wait(), sleep_amount
+                    )
+                except asyncio.TimeoutError:
+                    pass
+                self._refill()
+                sleep_amount = self._sleep_amount(amount)
+            self._current_capacity -= amount
+            return True
+
+    def _sleep_amount(self, amount):
+        return (amount - self._current_capacity) / self._fill_rate
+
+    def _refill(self):
+        timestamp = self._clock.current_time()
+        if self._last_timestamp is None:
+            self._last_timestamp = timestamp
+            return
+        current_capacity = self._current_capacity
+        fill_amount = (timestamp - self._last_timestamp) * self._fill_rate
+        new_capacity = min(self._max_capacity, current_capacity + fill_amount)
+        self._current_capacity = new_capacity
+        self._last_timestamp = timestamp

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 markers =
     moto
+    config_kwargs
+    patch_attributes

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -1,0 +1,202 @@
+# The following tests are the adaptation of the unit tests for the original (sync)
+# ClientRateLimiter and TokenBucket in botocore.
+# see: https://github.com/boto/botocore:
+# `/tests/unit/retries/test_bucket.py` and `/tests/unit/retries/test_adaptive.py`.
+
+from unittest import mock
+
+import pytest
+from aiobotocore.retries import adaptive
+from aiobotocore.retries import bucket
+from botocore.retries import throttling
+from botocore.retries import standard
+from botocore.exceptions import CapacityNotAvailableError
+
+
+class _SleepMethodCalled(Exception):
+    """Raised to explicitly fail a test for calling the blocking `sleep` method."""
+    pass
+
+
+class FakeClock(bucket.Clock):
+    def __init__(self, timestamp_sequences):
+        self.timestamp_sequences = timestamp_sequences
+        self.sleep_call_amounts = []
+
+    def sleep(self, amount):
+        raise _SleepMethodCalled(
+            "sleep method should never be called, non-blocking behavior expected"
+        )
+
+    def current_time(self):
+        return self.timestamp_sequences.pop(0)
+
+
+class TestAsyncClientRateLimiter:
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        self.timestamp_sequences = [0]
+        self.clock = FakeClock(self.timestamp_sequences)
+        self.token_bucket = mock.Mock(spec=bucket.AsyncTokenBucket)
+        self.rate_adjustor = mock.Mock(spec=throttling.CubicCalculator)
+        self.rate_clocker = mock.Mock(spec=adaptive.RateClocker)
+        self.throttling_detector = mock.Mock(
+            spec=standard.ThrottlingErrorDetector)
+
+    def create_client_limiter(self):
+        rate_limiter = adaptive.AsyncClientRateLimiter(
+            rate_adjustor=self.rate_adjustor,
+            rate_clocker=self.rate_clocker,
+            token_bucket=self.token_bucket,
+            throttling_detector=self.throttling_detector,
+            clock=self.clock,
+        )
+        return rate_limiter
+
+    @pytest.mark.asyncio
+    async def test_bucket_bucket_acquisition_only_if_enabled(self):
+        rate_limiter = self.create_client_limiter()
+        await rate_limiter.on_sending_request(request=mock.sentinel.request)
+        assert not self.token_bucket.acquire.called
+
+    @pytest.mark.asyncio
+    async def test_token_bucket_enabled_on_throttling_error(self):
+        rate_limiter = self.create_client_limiter()
+        self.throttling_detector.is_throttling_error.return_value = True
+        self.rate_clocker.record.return_value = 21
+        self.rate_adjustor.error_received.return_value = 17
+        await rate_limiter.on_receiving_response()
+        # Now if we call on_receiving_response we should try to acquire
+        # token.
+        self.timestamp_sequences.append(1)
+        await rate_limiter.on_sending_request(request=mock.sentinel.request)
+        assert self.token_bucket.acquire.called
+
+    @pytest.mark.asyncio
+    async def test_max_rate_updated_on_success_response(self):
+        rate_limiter = self.create_client_limiter()
+        self.throttling_detector.is_throttling_error.return_value = False
+        self.rate_adjustor.success_received.return_value = 20
+        self.rate_clocker.record.return_value = 21
+        await rate_limiter.on_receiving_response()
+        assert await self.token_bucket.set_max_rate.called_with(20)
+
+    @pytest.mark.asyncio
+    async def test_max_rate_cant_exceed_20_percent_max(self):
+        rate_limiter = self.create_client_limiter()
+        self.throttling_detector.is_throttling_error.return_value = False
+        # So if our actual measured sending rate is 20 TPS
+        self.rate_clocker.record.return_value = 20
+        # But the rate adjustor is telling us to go up to 100 TPS
+        self.rate_adjustor.success_received.return_value = 100
+
+        # The most we should go up is 2.0 * 20
+        await rate_limiter.on_receiving_response()
+        assert await self.token_bucket.set_max_rate.called_with(2.0 * 20)
+
+
+class TestAsyncTokenBucket:
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        self.timestamp_sequences = [0]
+        self.clock = FakeClock(self.timestamp_sequences)
+
+    def create_token_bucket(self, max_rate=10, min_rate=0.1):
+        return bucket.AsyncTokenBucket(
+            max_rate=max_rate,
+            clock=self.clock,
+            min_rate=min_rate
+        )
+
+    @pytest.mark.asyncio
+    async def test_can_acquire_amount(self):
+        self.timestamp_sequences.extend([
+            # Requests tokens every second, which is well below our
+            # 10 TPS fill rate.
+            1,
+            2,
+            3,
+            4,
+            5,
+        ])
+        token_bucket = self.create_token_bucket(max_rate=10)
+        for _ in range(5):
+            assert await token_bucket.acquire(1, block=False)
+
+    @pytest.mark.asyncio
+    async def test_can_change_max_capacity_lower(self):
+        # Requests at 1 TPS.
+        self.timestamp_sequences.extend([1, 2, 3, 4, 5])
+        token_bucket = self.create_token_bucket(max_rate=10)
+        # Request the first 5 tokens with max_rate=10
+        for _ in range(5):
+            assert await token_bucket.acquire(1, block=False)
+        # Now scale the max_rate down to 1 on the 5th second.
+        self.timestamp_sequences.append(5)
+        await token_bucket.set_max_rate(1)
+        # And then from seconds 6-10 we request at one per second.
+        self.timestamp_sequences.extend([6, 7, 8, 9, 10])
+        for _ in range(5):
+            assert await token_bucket.acquire(1, block=False)
+
+    @pytest.mark.asyncio
+    async def test_max_capacity_is_at_least_one(self):
+        token_bucket = self.create_token_bucket()
+        self.timestamp_sequences.append(1)
+        await token_bucket.set_max_rate(0.5)
+        assert token_bucket._fill_rate == 0.5
+        assert token_bucket._max_capacity == 1
+
+    @pytest.mark.asyncio
+    async def test_acquire_fails_on_non_block_mode_returns_false(self):
+        self.timestamp_sequences.extend([
+            # Initial creation time.
+            0,
+            # Requests a token 1 second later.
+            1
+        ])
+        token_bucket = self.create_token_bucket(max_rate=10)
+        with pytest.raises(CapacityNotAvailableError):
+            await token_bucket.acquire(100, block=False)
+
+    @pytest.mark.asyncio
+    async def test_can_retrieve_at_max_send_rate(self):
+        self.timestamp_sequences.extend([
+            # Request a new token every 100ms (10 TPS) for 2 seconds.
+            1 + 0.1 * i for i in range(20)
+        ])
+        token_bucket = self.create_token_bucket(max_rate=10)
+        for _ in range(20):
+            assert await token_bucket.acquire(1, block=False)
+
+    @pytest.mark.asyncio
+    async def test_acquiring_blocks_when_capacity_reached(self):
+        # This is 1 token every 0.1 seconds.
+        token_bucket = self.create_token_bucket(max_rate=10)
+        self.timestamp_sequences.extend([
+            # The first acquire() happens after .1 seconds.
+            0.1,
+            # The second acquire() will fail because we get tokens at
+            # 1 per 0.1 seconds.  We will then sleep for 0.05 seconds until we
+            # get a new token.
+            0.15,
+            # And at 0.2 seconds we get our token.
+            0.2,
+            # And at 0.3 seconds we have no issues getting a token.
+            # Because we're using such small units (to avoid bloating the
+            # test run time), we have to go slightly over 0.3 seconds here.
+            0.300001,
+        ])
+        assert await token_bucket.acquire(1, block=False)
+        assert token_bucket._current_capacity == 0
+        assert await token_bucket.acquire(1, block=True)
+        assert token_bucket._current_capacity == 0
+        assert await token_bucket.acquire(1, block=False)
+
+    @pytest.mark.asyncio
+    async def test_rate_cant_go_below_min(self):
+        token_bucket = self.create_token_bucket(max_rate=1, min_rate=0.2)
+        self.timestamp_sequences.append(1)
+        await token_bucket.set_max_rate(0.1)
+        assert token_bucket._fill_rate == 0.2
+        assert token_bucket._current_capacity == 1

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -41,6 +41,8 @@ from botocore.credentials import Credentials, RefreshableCredentials, \
 from botocore.handlers import inject_presigned_url_ec2, inject_presigned_url_rds
 from botocore.httpsession import URLLib3Session
 from botocore.discovery import EndpointDiscoveryManager, EndpointDiscoveryHandler
+from botocore.retries.adaptive import ClientRateLimiter, register_retry_handler
+from botocore.retries.bucket import TokenBucket
 
 
 # This file ensures that our private patches will work going forward.  If a
@@ -88,6 +90,9 @@ _API_DIGESTS = {
         {'2eb9009d83a3999c77ecf2fd3335dab94348182e'},
     ClientCreator._get_client_args: {'555e1e41f93df7558c8305a60466681e3a267ef3'},
     ClientCreator._register_s3_events: {'accf68c9e3e45b114310e8c635270ccb5fc4926e'},
+    ClientCreator._register_retries: {'16d3064142e5f9e45b0094bbfabf7be30183f255'},
+    ClientCreator._register_v2_adaptive_retries:
+        {'665ecd77d36a5abedffb746d83a44bb0a64c660a'},
 
     BaseClient._make_api_call: {'0c59329d4c8a55b88250b512b5e69239c42246fb'},
     BaseClient._make_request: {'033a386f7d1025522bea7f2bbca85edc5c8aafd2'},
@@ -317,6 +322,17 @@ _API_DIGESTS = {
         {'b2f1b29177cf30f299e61b85ddec09eaa070e54e'},
     EndpointDiscoveryManager._refresh_current_endpoints:
         {'f8a51047c8f395d9458a904e778a3ac156a11911'},
+
+    # retries/adaptive.py
+    # See comments in AsyncTokenBucket: we completely replace the ClientRateLimiter
+    # implementation from botocore.
+    ClientRateLimiter: {'d4ba74b924cdccf705adeb89f2c1885b4d21ce02'},
+    register_retry_handler: {'d662512878511e72d1202d880ae181be6a5f9d37'},
+
+    # retries/bucket.py
+    # See comments in AsyncTokenBucket: we completely replace the TokenBucket
+    # implementation from botocore.
+    TokenBucket: {'9d543c15de1d582fe99a768fd6d8bde1ed8bb930'},
 }
 
 


### PR DESCRIPTION
### Description of Change

Fix #912. Includes the test from #913. 

This is a draft pull request. I still need to add unit tests for the new Async classes introduced here.
If my understanding is correct, I don't need to update test_patches (these changes don't depend on any private attribute), although I rely on RateClocker not blocking despite using a `threading.Lock`.

Current tests (through `make cov` and `make mototest`) already pass.

### Assumptions
*Replace this text with any assumptions made (if any)*

### Checklist for All Submissions
* [x] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [x] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced 
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
