### PR TITLE
Allow keepalive_timeout to be None

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,9 @@
 Changes
 -------
+2.2.1 (2022-05-03)
+^^^^^^^^^^^^^^^^^^
+* AioConfig: allow keepalive_timeout to be None
+
 2.2.0 (2022-03-16)
 ^^^^^^^^^^^^^^^^^^
 * remove deprecated APIs

--- a/aiobotocore/config.py
+++ b/aiobotocore/config.py
@@ -38,9 +38,9 @@ class AioConfig(botocore.client.Config):
                     raise ParamValidationError(
                         report='{} value must be a boolean'.format(k))
             elif k in ['keepalive_timeout']:
-                if not isinstance(v, (float, int)):
+                if v is not None and not isinstance(v, (float, int)):
                     raise ParamValidationError(
-                        report='{} value must be a float/int'.format(k))
+                        report='{} value must be a float/int or None'.format(k))
             elif k == 'force_close':
                 if not isinstance(v, bool):
                     raise ParamValidationError(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,6 +30,11 @@ def test_connector_args():
 
     with pytest.raises(ParamValidationError):
         # wrong type
+        connector_args = dict(keepalive_timeout="1")
+        AioConfig(connector_args)
+
+    with pytest.raises(ParamValidationError):
+        # wrong type
         connector_args = dict(ssl_context="1")
         AioConfig(connector_args)
 
@@ -43,10 +48,11 @@ def test_connector_args():
         connector_args = dict(foo="1")
         AioConfig(connector_args)
 
-    # Test valid config:
+    # Test valid configs:
     AioConfig({
         "resolver": aiohttp.resolver.DefaultResolver()
     })
+    AioConfig({'keepalive_timeout': None})
 
     # test merge
     cfg = Config(read_timeout=75)


### PR DESCRIPTION
There was a bug in the library in that we could not both:

  * set `keepalive_timeout` as `None`
  * set `force_close` to `True`

Validation was wrong in that it expects `keepalive_timeout` to have to be
one of `float` or `int`, but it should also allow `None` since `aiohttp`
requires `keepalive_timeout` to be `None` if `force_close` is set to
`True`.

Closes #932

### Description of Change

Started to allow `None` as value for `keepalive_timeout`. Added tests accordingly.

### Assumptions

`aiohttp` requires `keepalive_timeout` to be `None` when `force_close` is `True`, so assumed validation in `aiobotocore` needed to reflect that.

### Checklist for All Submissions
* [x] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)

Closes #932 