### PR TITLE
Moto integration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,9 @@
 Changes
 -------
+2.5.1 (2023-04-05)
+^^^^^^^^^^^^^^^^^^
+* integrate moto
+
 2.5.0 (2023-03-06)
 ^^^^^^^^^^^^^^^^^^
 * bump botocore to 1.29.76 (thanks @jakob-keller #999)

--- a/Pipfile
+++ b/Pipfile
@@ -18,7 +18,6 @@ pytest = "==6.2.4"
 pytest-cov = "==2.11.1"
 pytest-asyncio = "==0.14.0"
 pytest-xdist = "==2.2.1"
-s3fs = "==2023.3.0"
 
 # this is needed for test_patches
 dill = "==0.3.3"

--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,7 @@ pytest = "==6.2.4"
 pytest-cov = "==2.11.1"
 pytest-asyncio = "==0.14.0"
 pytest-xdist = "==2.2.1"
+s3fs = "==2023.3.0"
 
 # this is needed for test_patches
 dill = "==0.3.3"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ import aiohttp
 
 # Third Party
 import pytest
+from moto import mock_s3
 
 import aiobotocore.session
 from aiobotocore.config import AioConfig
@@ -581,6 +582,13 @@ async def sqs_queue_url(sqs_client):
 async def exit_stack():
     async with AsyncExitStack() as es:
         yield es
+
+
+@pytest.fixture
+async def moto_client(session):
+    with mock_s3():
+        async with session.create_client('s3') as client:
+            yield client
 
 
 pytest_plugins = ['tests.mock_server']

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -211,17 +211,6 @@ def s3(aws_credentials):
         yield conn
 
 
-def test_moto_ok(s3):
-    for i in range(3):
-        s3.Bucket('testbucket').put_object(
-            Key=f'glob_{i}.txt', Body=f"test glob file {i}"
-        )
-    path = 's3://testbucket/glob_*.txt'
-    fs = s3fs.S3FileSystem()
-    files = fs.glob(path)
-    assert len(files) == 3
-
-
 @patch('s3fs.core.aiobotocore.endpoint.isawaitable', return_value=True)
 def test_moto_fail(mock_inspect, s3):
     with pytest.raises(TypeError) as e:
@@ -233,3 +222,14 @@ def test_moto_fail(mock_inspect, s3):
         fs = s3fs.S3FileSystem()
         fs.glob(path)
     assert "can't be used in 'await' expression" in str(e)
+
+
+def test_moto_ok(s3):
+    for i in range(3):
+        s3.Bucket('testbucket').put_object(
+            Key=f'glob_{i}.txt', Body=f"test glob file {i}"
+        )
+    path = 's3://testbucket/glob_*.txt'
+    fs = s3fs.S3FileSystem()
+    files = fs.glob(path)
+    assert len(files) == 3

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -195,10 +195,19 @@ async def test_streaming_line_empty_body():
 @patch('aiobotocore.endpoint.isawaitable', return_value=True)
 @pytest.mark.asyncio
 @pytest.mark.moto
-async def test_moto_fail(mock_awaitable, moto_client):
+async def test_moto_fail_await(mock_awaitable, moto_client):
     with pytest.raises(TypeError) as e:
         await moto_client.create_bucket(Bucket='testbucket')
         assert "can't be used in 'await' expression" in str(e)
+
+
+@patch('aiobotocore.endpoint.isinstance', return_value=False)
+@pytest.mark.asyncio
+@pytest.mark.moto
+async def test_moto_fail_raw_headers(mock_isinstance, moto_client):
+    with pytest.raises(AttributeError) as e:
+        await moto_client.create_bucket(Bucket='testbucket')
+    assert "object has no attribute 'raw_headers" in str(e)
 
 
 @patch('aiobotocore.endpoint.convert_to_response_dict')


### PR DESCRIPTION
### Description of Change
PR adds a patch to `endpoint.convert_to_response_dict` such that it can work with moto while not changing the expected behavior of the method. I also added tests to replicate the problem and fix the issue.

# Issue (#979)
The primary problem with moto integration is [this](https://github.com/aio-libs/aiobotocore/blob/72b8dd5d7d4ef2f1a49a0ae0c37b47e5280e2070/aiobotocore/endpoint.py#L23) method. There are 2 main issues with that method
1. It expects `raw` to have `raw_headers` just to convert the headers to lowercase. 
2. Moto passes [MockRawResponse](https://github.com/getmoto/moto/blob/79616e11e64add6b732006952abdef5c5d0914ef/moto/core/botocore_stubber.py#L9) which is not awaitable causing the breaks with lines containing `await`. 

## How to reproduce the error
```
# test_response.py

@pytest.fixture
def aws_credentials():
    """Mocked AWS Credentials for moto."""
    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
    os.environ["AWS_SECURITY_TOKEN"] = "testing"
    os.environ["AWS_SESSION_TOKEN"] = "testing"


@pytest.fixture
def s3(aws_credentials):
    with mock_s3():
        conn = boto3.resource("s3")
        conn.create_bucket(Bucket='testbucket')
        yield conn


def test_moto(s3):
    for i in range(3):
        s3.Bucket('testbucket').put_object(
            Key=f'glob_{i}.txt', Body=f"test glob file {i}"
        )
    path = 's3://testbucket/glob_*.txt'
    fs = s3fs.S3FileSystem()
    files = fs.glob(path) # Fails 
    assert len(files) == 3
```

## Resolution
It's a two part solution
~~1. Remove the need for `raw_headers` and use the headers directly using `botocore.utils.lowercase_dict`~~
1. Since `raw_headers` are necessary, I've created a check to use headers if the `httpresponse` came from moto
2. Only `await` for `awaitable` objects. This check can be done using `inspect.isawaitable`


## Assumptions
~~1. This [patch](https://github.com/aio-libs/aiobotocore/blob/72b8dd5d7d4ef2f1a49a0ae0c37b47e5280e2070/aiobotocore/endpoint.py#L44) was added only to convert to lowercase and this [botocore util](https://github.com/boto/botocore/blob/29343bffa3150dfbd45ab2e5785a5b225d97f172/botocore/utils.py#L817) does the same~~
^Not valid anymore since `raw_headers` remain
1. Assigning non-awaitable objects to [response_dict['body']](https://github.com/akshara08/aiobotocore/blob/8c622779052b8a2ef90179586e1b202b1c2aa5cd/aiobotocore/endpoint.py#L49) without await is not expected to break any current behavior

## Alternative methods considered 
I considered added a raw_headers to [MockRawResponse](https://github.com/getmoto/moto/blob/79616e11e64add6b732006952abdef5c5d0914ef/moto/core/botocore_stubber.py#L9) but it seemed unnecessary especially if the point to convert to lowercase based on the [comment](https://github.com/aio-libs/aiobotocore/blob/72b8dd5d7d4ef2f1a49a0ae0c37b47e5280e2070/aiobotocore/endpoint.py#L40)


### Checklist for All Submissions
* [x] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [x] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [x] Detailed description of issue
  * [x] Alternative methods considered (if any)
  * [x] How issue is being resolved
  * [x] How issue can be reproduced
* [x] (NA) If this is providing a new feature  (can be provided via link to issue with these details):
  * [x] Detailed description of new feature
  * [x] Why needed
  * [x] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [x] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [x] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [x] I have ensured that the awscli/boto3 versions match the updated botocore version

# ‼️ Note ‼️ 
I've been getting `botocore.exceptions.NoCredentialsError: Unable to locate credentials` for some of the tests (5 to be exact). Ive got them even before I made changes, so I'm unsure if I'm breaking anything with this PR