### PR TITLE
Support moto by allowing non-awaitable content

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,9 @@
 Changes
 -------
+2.5.1 (2023-04-05)
+^^^^^^^^^^^^^^^^^^
+* Add support for moto by allowing non-awaitable content
+
 2.5.0 (2023-03-06)
 ^^^^^^^^^^^^^^^^^^
 * bump botocore to 1.29.76 (thanks @jakob-keller #999)

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -1,4 +1,5 @@
 import asyncio
+from inspect import isawaitable
 
 from botocore.endpoint import (
     DEFAULT_TIMEOUT,
@@ -53,14 +54,20 @@ async def convert_to_response_dict(http_response, operation_model):
         },
     }
     if response_dict['status_code'] >= 300:
-        response_dict['body'] = await http_response.content
+        if isawaitable(http_response.content):
+            response_dict['body'] = await http_response.content
+        else:
+            response_dict['body'] = http_response.content
     elif operation_model.has_event_stream_output:
         response_dict['body'] = http_response.raw
     elif operation_model.has_streaming_output:
         length = response_dict['headers'].get('content-length')
         response_dict['body'] = StreamingBody(http_response.raw, length)
     else:
-        response_dict['body'] = await http_response.content
+        if isawaitable(http_response.content):
+            response_dict['body'] = await http_response.content
+        else:
+            response_dict['body'] = http_response.content
     return response_dict
 
 


### PR DESCRIPTION
### Description of Change
PR adds a patch to `endpoint.convert_to_response_dict` such that it can work with moto while not changing the expected behavior of the method. Tests are added

# Issue (#979)
The primary problem with moto integration is [this](https://github.com/aio-libs/aiobotocore/blob/72b8dd5d7d4ef2f1a49a0ae0c37b47e5280e2070/aiobotocore/endpoint.py#L23) method. There are 2 main issues with that method
1. It expects `raw` to have `raw_headers` just to convert the headers to lowercase. 
2. Moto passes [MockRawResponse](https://github.com/getmoto/moto/blob/79616e11e64add6b732006952abdef5c5d0914ef/moto/core/botocore_stubber.py#L9) which is not awaitable causing the breaks with lines containing `await`. 

## How to reproduce the error
```
# test_response.py

@pytest.fixture
def aws_credentials():
    """Mocked AWS Credentials for moto."""
    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
    os.environ["AWS_SECURITY_TOKEN"] = "testing"
    os.environ["AWS_SESSION_TOKEN"] = "testing"


@pytest.fixture
def s3(aws_credentials):
    with mock_s3():
        conn = boto3.resource("s3")
        conn.create_bucket(Bucket='testbucket')
        yield conn


def test_moto(s3):
    for i in range(3):
        s3.Bucket('testbucket').put_object(
            Key=f'glob_{i}.txt', Body=f"test glob file {i}"
        )
    path = 's3://testbucket/glob_*.txt'
    fs = s3fs.S3FileSystem()
    files = fs.glob(path) # Fails 
    assert len(files) == 3
```

## Resolution
It's a two part solution
1. The first part will be a addressed on moto repo
2. The second part of the problem can be addressed in this repo by only `await`ing for awaitable objects. 


## Assumptions
1. Assigning non-awaitable objects to [response_dict['body']](https://github.com/akshara08/aiobotocore/blob/8c622779052b8a2ef90179586e1b202b1c2aa5cd/aiobotocore/endpoint.py#L49) without await is not expected to break any current behavior

## Alternative methods considered 
I tried consolidating all the changes in just one repo (see: #1004) but it's not possible


### Checklist for All Submissions
* [x] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [x] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [x] Detailed description of issue
  * [x] Alternative methods considered (if any)
  * [x] How issue is being resolved
  * [x] How issue can be reproduced
* [x] (NA) If this is providing a new feature  (can be provided via link to issue with these details):
  * [x] Detailed description of new feature
  * [x] Why needed
  * [x] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [x] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [x] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [x] I have ensured that the awscli/boto3 versions match the updated botocore version