### PR TITLE
Fix test_load_sso_credentials_without_cache

### DIFF
--- a/tests/boto_tests/test_credentials.py
+++ b/tests/boto_tests/test_credentials.py
@@ -1253,10 +1253,14 @@ def _add_get_role_credentials_response(self):
     )
 
 
-def test_load_sso_credentials_without_cache(self):
-    self._add_get_role_credentials_response()
+@pytest.mark.moto
+@pytest.mark.asyncio
+async def test_load_sso_credentials_without_cache(sso_provider_setup):
+    self = sso_provider_setup
+    _add_get_role_credentials_response(self)
     with self.stubber:
-        credentials = self.provider.load()
+        credentials = await self.provider.load()
+        credentials = await credentials.get_frozen_credentials()
         self.assertEqual(credentials.access_key, 'foo')
         self.assertEqual(credentials.secret_key, 'bar')
         self.assertEqual(credentials.token, 'baz')


### PR DESCRIPTION
### Description of Change
This test appears to have been completely broken since it was written in 2020, but it wasn't marked with any fixtures so it got ignored in CI and you only notice it if running all tests or you look at codecov for the lines in question: https://app.codecov.io/gh/aio-libs/aiobotocore/blob/master/tests%2Fboto_tests%2Ftest_credentials.py#L1256
I simply copied the relevant code from the test below it and it started working, so I assume this is what it was meant to be.

### Assumptions
That this test was intended to ... do something, anything.

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst) - [I don't think this is required?]
* [x] One of several otherwise unrelated issues encountered in #965