### PR TITLE
update botocore to latest version; update awscli, boto3 accordingly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 -------
 
+2.7.1 (TBD)
+^^^^^^^^^^^^^^^^^^
+* bump botocore to 1.31.17
+
 2.7.0 (2023-08-17)
 ^^^^^^^^^^^^^^^^^^
 * add support for Python 3.12

--- a/setup.py
+++ b/setup.py
@@ -7,15 +7,15 @@ from setuptools import find_packages, setup
 # NOTE: When updating botocore make sure to update awscli/boto3 versions below
 install_requires = [
     # pegged to also match items in `extras_require`
-    'botocore>=1.31.17,<1.31.18',
+    'botocore>=1.31.58,<1.31.59',
     'aiohttp>=3.7.4.post0,<4.0.0',
     'wrapt>=1.10.10, <2.0.0',
     'aioitertools>=0.5.1,<1.0.0',
 ]
 
 extras_require = {
-    'awscli': ['awscli>=1.29.17,<1.29.18'],
-    'boto3': ['boto3>=1.28.17,<1.28.18'],
+    'awscli': ['awscli>=1.29.58,<1.29.59'],
+    'boto3': ['boto3>=1.28.58,<1.28.59'],
 }
 
 


### PR DESCRIPTION
### Description of Change
Bump botocore to latest version; update awscli, boto3 accordingly. 

aiobotocore dependency on botocore 1.31.17 causes dependency conflict with packages that depend on newer version of botocore. For example, because of this latest versions of s3fs and boto3 conflict.

Fixes #1043.

### Assumptions

This PR bumps botocore to latest version. 

Generally it would be nice to relax version pinning to decrease the frequency of version conflicts and needing to bump versions manually. See issue #1028 and PR #1037 for more details on that.

### Checklist for All Submissions
* [x] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [x] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details): #1043.

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [x] I have ensured that the awscli/boto3 versions match the updated botocore version
