### PR TITLE
Support up-to-date `botocore`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,11 @@
 Changes
 -------
 
-2.8.0 (2023-10-24)
+2.8.0 (2023-10-25)
 ^^^^^^^^^^^^^^^^^^
 * add AioStubber that returns AioAWSResponse()
 * remove confusing `aiobotocore.session.Session` symbol
+* relax botocore dependency specification
 
 2.7.0 (2023-10-17)
 ^^^^^^^^^^^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -7,15 +7,15 @@ from setuptools import find_packages, setup
 # NOTE: When updating botocore make sure to update awscli/boto3 versions below
 install_requires = [
     # pegged to also match items in `extras_require`
-    'botocore>=1.31.16,<1.31.65',
+    'botocore>=1.31.16,<1.31.71',
     'aiohttp>=3.7.4.post0,<4.0.0',
     'wrapt>=1.10.10, <2.0.0',
     'aioitertools>=0.5.1,<1.0.0',
 ]
 
 extras_require = {
-    'awscli': ['awscli>=1.29.16,<1.29.65'],
-    'boto3': ['boto3>=1.28.16,<1.28.65'],
+    'awscli': ['awscli>=1.29.16,<1.29.71'],
+    'boto3': ['boto3>=1.28.16,<1.28.71'],
 }
 
 


### PR DESCRIPTION
### Description of Change
This PR intends to improve general compatibility of `aiobotocore` within the Python ecosystem by relaxing the dependency specification of `botocore`, as well as `boto3` and `awscli`.

### Assumptions
[Upstream diff](https://github.com/boto/botocore/compare/1.31.64..1.31.70) does not contain any changes that require adjustments to the `aiobotocore` codebase. This allows for the proposed widening of the `botocore` dependency specification.

### Checklist for All Submissions
* [x] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)

### Checklist when updating botocore and/or aiohttp versions

* [x] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [x] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [x] I have ensured that the awscli/boto3 versions match the updated botocore version
