### PR TITLE
Drop obsolete dev dependency `flake8-formatter-abspath`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 FLAGS=
 
 flake: checkrst
-	python -m flake8 --format=abspath
+	python -m flake8
 
 test: flake
 	python -Wd -m pytest -s -vv $(FLAGS) ./tests/

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,7 +1,6 @@
 codecov~=2.1.13
 coverage~=7.2.7
 flake8~=3.9.0
-flake8-formatter-abspath~=1.0.1
 flake8-black~=0.3.3
 flake8-isort~= 4.1.1
 black~=22.6.0


### PR DESCRIPTION
### Description of Change
Removes obsolete dev dependency `flake8-formatter-abspath`

### Assumptions
`flake8-formatter-abspath` may be considered nice-to-have, i.e. it simply improves readability of flake8 results.

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details): closes #1050
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced