### PR TITLE
Replace aiohttp with httpx

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -167,10 +167,11 @@ secret accessible via environment variables:
 ::
 
     $ pip install pip-tools
-    $ pip-compile requirements-dev.txt
+    $ pip-compile requirements-dev.in
     $ pip-sync requirements-dev.txt
     $ export AWS_ACCESS_KEY_ID=xxx
     $ export AWS_SECRET_ACCESS_KEY=xxx
+    $ export AWS_DEFAULT_REGION=xxx # e.g. us-west-2
 
 Execute tests suite:
 

--- a/aiobotocore/_endpoint_helpers.py
+++ b/aiobotocore/_endpoint_helpers.py
@@ -1,22 +1,22 @@
-import asyncio
+# import asyncio
 
-import aiohttp.http_exceptions
+# import aiohttp.http_exceptions
 import botocore.retryhandler
 import wrapt
 
 # Monkey patching: We need to insert the aiohttp exception equivalents
 # The only other way to do this would be to have another config file :(
-_aiohttp_retryable_exceptions = [
-    aiohttp.ClientConnectionError,
-    aiohttp.ClientPayloadError,
-    aiohttp.ServerDisconnectedError,
-    aiohttp.http_exceptions.HttpProcessingError,
-    asyncio.TimeoutError,
-]
-
-botocore.retryhandler.EXCEPTION_MAP['GENERAL_CONNECTION_ERROR'].extend(
-    _aiohttp_retryable_exceptions
-)
+# _aiohttp_retryable_exceptions = [
+#    aiohttp.ClientConnectionError,
+#    aiohttp.ClientPayloadError,
+#    aiohttp.ServerDisconnectedError,
+#    aiohttp.http_exceptions.HttpProcessingError,
+#    asyncio.TimeoutError,
+# ]
+#
+# botocore.retryhandler.EXCEPTION_MAP['GENERAL_CONNECTION_ERROR'].extend(
+#    _aiohttp_retryable_exceptions
+# )
 
 
 def _text(s, encoding='utf-8', errors='strict'):

--- a/aiobotocore/awsrequest.py
+++ b/aiobotocore/awsrequest.py
@@ -1,4 +1,5 @@
 import botocore.utils
+import httpx
 from botocore.awsrequest import AWSResponse
 
 
@@ -10,7 +11,10 @@ class AioAWSResponse(AWSResponse):
 
         if self._content is None:
             # NOTE: this will cache the data in self.raw
-            self._content = await self.raw.read() or b''
+            if isinstance(self.raw, httpx.Response):
+                self._content = await self.raw.aread() or b''
+            else:
+                self._content = await self.raw.read() or b''
 
         return self._content
 

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -15,6 +15,6 @@ dill~=0.3.3
 # this is needed when running setup.py check -rms
 Pygments
 
-aiohttp${AIOHTTP_VERSION}
+httpx
 
 -e .[awscli,boto3]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 install_requires = [
     # pegged to also match items in `extras_require`
     'botocore>=1.33.2,<1.34.28',
-    'aiohttp>=3.7.4.post0,<4.0.0',
+    'httpx',
     'wrapt>=1.10.10, <2.0.0',
     'aioitertools>=0.5.1,<1.0.0',
 ]
@@ -39,7 +39,7 @@ def read_version():
 setup(
     name='aiobotocore',
     version=read_version(),
-    description='Async client for aws services using botocore and aiohttp',
+    description='Async client for aws services using botocore and httpx',
     long_description='\n\n'.join((read('README.rst'), read('CHANGES.rst'))),
     long_description_content_type='text/x-rst',
     classifiers=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from contextlib import ExitStack
 from itertools import chain
 from unittest.mock import patch
 
-import aiohttp
+import httpx
 
 # Third Party
 import pytest
@@ -503,9 +503,9 @@ def create_multipart_upload(request, s3_client, bucket_name, event_loop):
 
 
 @pytest.fixture
-async def aio_session():
-    async with aiohttp.ClientSession() as session:
-        yield session
+async def httpx_async_client():
+    async with httpx.AsyncClient() as client:
+        yield client
 
 
 def pytest_configure():


### PR DESCRIPTION
First step of #749 as described in https://github.com/aio-libs/aiobotocore/issues/749#issuecomment-1698255533

I was tasked with implementing this, but it's been a bit of a struggle not being very familiar with aiohttp, httpx or aiobotocore - and there being ~zero in-line types. But I think I've fixed enough of the major problems that it's probably useful to share my progress.

There's a bunch of random types added. I can split those off into a separate PR or remove if requested. Likewise for `from __future__ import annotations`.

TODO:

* [ ] exceptions
  * retryable_exceptions: mostly just need to go through all httpx exceptions and decide which ones are fine
  * replace all aiohttp exceptions in httpsession.send
* [ ] proxy support
  * this was previously handled per-request, but AFAICT you can only configure proxies per-client in httpx. So need to move the logic for it, and cannot use `botocore.httpsession.ProxyConfiguration.proxy_[url,headers]_for(request.url)`
  * raising of ProxyConnectionError is very ugly atm, and probably not "correct"?
  * BOTO_EXPERIMENTAL__ADD_PROXY_HOST_HEADER
    * seems not possible to do when configuring proxies per-client?
* [ ] wrap io.IOBase data in a non-sync-iterable async iterable
* [ ] url's were previously wrapped with `yarl.URL(url, encoding=True)`. httpx does not support yarl, but does encoding still need to be done? I have not managed to figure out what this previously accomplished.
* [ ] The following connector_args I have yet to fix:
  * `use_dns_cache`: did not find any mentions of dns caches on a quick skim of httpx docs
  * `force_close`: same. Can maybe find out more by digging into docs on what this option does in aiohttp.
  * `resolver`: this is an `aiohttp.abc.AbstractResolver` which is obviously a no-go.
    * raise error for code passing this
    * figure out equivalent functionality for httpx
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [ ] `test_patches` previously cared about aiohttp. That can probably be retired?
* [ ] replace aiohttp with httpx in `tests.mock_server.AIOServer`?

It would also be very good if tests were added that checked the above functionality. I do have 5 tests failing currently (at least locally), 2 are for retries, the other three I haven't fully figured out yet.


### Checklist when updating botocore and/or aiohttp versions

TODO: Fix the above template
* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
