### PR TITLE
Run CI for Python 3.13

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         include:
           - aiohttp-version: '==3.9.2'
           - aiohttp-version: '<4.0.0'


### PR DESCRIPTION
### Description of Change
Python 3.13 is being finalized and the [final beta has just been released](https://discuss.python.org/t/python-3-13-0b4-now-available/58565):

> We strongly encourage maintainers of third-party Python projects to test with 3.13 during the beta phase...

Note: This PR neither drops support for Python 3.8 not does it declare support for Python 3.13, i.e. in docs or PyPI trove classifiers. Both should be addressed separately, preferable around the time the final version of Python 3.13 is released.

### Assumptions
Compatibility of `aiobotocore` with Python 3.13 should be tested ahead of its final launch.