### PR TITLE
Avoid deprecated use of aiohttp in tests

### DIFF
--- a/tests/moto_server.py
+++ b/tests/moto_server.py
@@ -128,7 +128,7 @@ class MotoService:
                     async with session.get(
                         self.endpoint_url + '/static',
                         timeout=_CONNECT_TIMEOUT,
-                        verify_ssl=False,
+                        ssl=False,
                     ):
                         pass
                     break


### PR DESCRIPTION
### Description of Change
Replace deprecated aiohttp `session.get()` argument `verify_ssl` by `ssl` in tests. This should have been part of #1081.

### Assumptions
None

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
