### PR TITLE
Remove legacy `tests._helpers.py`

### DIFF
--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -1,6 +1,0 @@
-try:
-    from contextlib import AsyncExitStack  # noqa: F401 lgtm[py/unused-import]
-except ImportError:
-    from async_exit_stack import (  # noqa: F401 lgtm[py/unused-import]
-        AsyncExitStack,
-    )

--- a/tests/boto_tests/helpers.py
+++ b/tests/boto_tests/helpers.py
@@ -1,8 +1,9 @@
+from contextlib import AsyncExitStack
+
 from botocore.stub import Stubber
 
 import aiobotocore.session
 from aiobotocore._helpers import asynccontextmanager
-from tests._helpers import AsyncExitStack
 
 
 class StubbedSession(aiobotocore.session.AioSession):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import os
 import random
 import string
 import tempfile
-from contextlib import ExitStack
+from contextlib import AsyncExitStack, ExitStack
 from itertools import chain
 from unittest.mock import patch
 
@@ -14,7 +14,6 @@ import pytest
 
 import aiobotocore.session
 from aiobotocore.config import AioConfig
-from tests._helpers import AsyncExitStack
 
 host = '127.0.0.1'
 

--- a/tests/python3.8/test_eventstreams.py
+++ b/tests/python3.8/test_eventstreams.py
@@ -1,9 +1,9 @@
 import asyncio
+from contextlib import AsyncExitStack
 
 import pytest
 
 import aiobotocore.session
-from tests._helpers import AsyncExitStack
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Description of Change
Remove legacy `tests._helpers.py`

### Assumptions
Content of removed module no longer relevant for supported Python versions.

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
