### PR TITLE
Remove legacy `asynccontextmanager` import from `_helpers`

### DIFF
--- a/aiobotocore/_helpers.py
+++ b/aiobotocore/_helpers.py
@@ -1,14 +1,5 @@
 import inspect
 
-try:
-    from contextlib import (  # noqa: F401 lgtm[py/unused-import]
-        asynccontextmanager,
-    )
-except ImportError:
-    from async_generator import (  # noqa: F401 E501, lgtm[py/unused-import]
-        asynccontextmanager,
-    )
-
 
 async def resolve_awaitable(obj):
     if inspect.isawaitable(obj):

--- a/aiobotocore/utils.py
+++ b/aiobotocore/utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import functools
 import inspect
 import json
@@ -34,7 +35,6 @@ from botocore.utils import (
 )
 
 import aiobotocore.httpsession
-from aiobotocore._helpers import asynccontextmanager
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +45,7 @@ class _RefCountedSession(aiobotocore.httpsession.AIOHTTPSession):
         self.__ref_count = 0
         self.__lock = None
 
-    @asynccontextmanager
+    @contextlib.asynccontextmanager
     async def acquire(self):
         if not self.__lock:
             self.__lock = asyncio.Lock()

--- a/tests/boto_tests/helpers.py
+++ b/tests/boto_tests/helpers.py
@@ -1,9 +1,8 @@
-from contextlib import AsyncExitStack
+from contextlib import AsyncExitStack, asynccontextmanager
 
 from botocore.stub import Stubber
 
 import aiobotocore.session
-from aiobotocore._helpers import asynccontextmanager
 
 
 class StubbedSession(aiobotocore.session.AioSession):

--- a/tests/boto_tests/test_credentials.py
+++ b/tests/boto_tests/test_credentials.py
@@ -8,6 +8,7 @@ import os
 import sys
 import tempfile
 import uuid
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 from functools import partial
 from typing import Optional
@@ -31,7 +32,6 @@ from botocore.utils import (
 from dateutil.tz import tzlocal, tzutc
 
 from aiobotocore import credentials
-from aiobotocore._helpers import asynccontextmanager
 from aiobotocore.credentials import (
     AioAssumeRoleProvider,
     AioCanonicalNameCredentialSourcer,

--- a/tests/boto_tests/test_utils.py
+++ b/tests/boto_tests/test_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import itertools
 import json
+from contextlib import asynccontextmanager
 from typing import Iterator, Tuple, Union
 
 import pytest
@@ -9,7 +10,6 @@ from botocore.exceptions import ReadTimeoutError
 from botocore.utils import BadIMDSRequestError
 
 from aiobotocore import utils
-from aiobotocore._helpers import asynccontextmanager
 
 # TypeAlias (requires typing_extensions or >=3.10 to annotate)
 Response = Tuple[Union[str, object], int]


### PR DESCRIPTION
### Description of Change
Remove legacy `asynccontextmanager` import from `_helpers`

### Assumptions
`_helpers.py` is not part of the public API

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
