### PR TITLE
Remove remaining references to Travis CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,10 @@ cov cover coverage: pre-commit
 	python -Wd -m pytest -s -vv --cov-report term --cov-report html --cov aiobotocore ./tests
 	@echo "open file://`pwd`/htmlcov/index.html"
 
-# BOTO_CONFIG solves https://github.com/travis-ci/travis-ci/issues/7940
 mototest:
 	docker pull alpine
 	docker pull lambci/lambda:python3.8
-	BOTO_CONFIG=/dev/null python -Wd -X tracemalloc=5 -X faulthandler -m pytest -vv -m moto -n auto --cov-report term --cov-report html --cov-report xml --cov=aiobotocore --cov=tests --log-cli-level=DEBUG $(FLAGS) aiobotocore tests
+	python -Wd -X tracemalloc=5 -X faulthandler -m pytest -vv -m moto -n auto --cov-report term --cov-report html --cov-report xml --cov=aiobotocore --cov=tests --log-cli-level=DEBUG $(FLAGS) aiobotocore tests
 	@echo "open file://`pwd`/htmlcov/index.html"
 
 clean:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,8 +5,8 @@
 
 aiobotocore's documentation!
 ============================
-.. image:: https://travis-ci.org/aio-libs/aiobotocore.svg?branch=master
-    :target: https://travis-ci.org/aio-libs/aiobotocore
+.. image:: https://github.com/aio-libs/aiobotocore/actions/workflows/python-package.yml/badge.svg?branch=master
+    :target: https://github.com/aio-libs/aiobotocore/actions/workflows/python-package.yml
 .. image:: https://codecov.io/gh/aio-libs/aiobotocore/branch/master/graph/badge.svg
     :target: https://codecov.io/gh/aio-libs/aiobotocore
 .. image:: https://img.shields.io/pypi/v/aiobotocore.svg

--- a/tests/boto_tests/test_credentials.py
+++ b/tests/boto_tests/test_credentials.py
@@ -864,9 +864,7 @@ async def test_createcredentialresolver(mock_session):
     assert isinstance(resolver, credentials.AioCredentialResolver)
 
 
-# Disabled on travis as we cant easily disable the tests properly and
-#  travis has an IAM role which can't be applied to the mock session
-# @pytest.mark.moto
+@pytest.mark.moto
 @pytest.mark.asyncio
 async def test_get_credentials(mock_session):
     session = mock_session()


### PR DESCRIPTION
### Description of Change
Remove remaining references to Travis CI

### Assumptions
Travis CI has not been used in four years and any references may safely be removed at this point.

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
