### PR TITLE
Rename CI/CD action to conform to aio-libs standard

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI/CD
 
 on:
   push:

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 aiobotocore
 ===========
-.. |ci badge| image:: https://github.com/aio-libs/aiobotocore/actions/workflows/python-package.yml/badge.svg?branch=master
-    :target: https://github.com/aio-libs/aiobotocore/actions/workflows/python-package.yml
+.. |ci badge| image:: https://github.com/aio-libs/aiobotocore/actions/workflows/ci-cd.yml/badge.svg?branch=master
+    :target: https://github.com/aio-libs/aiobotocore/actions/workflows/ci-cd.yml
     :alt: CI status of master branch
 .. |coverage badge| image:: https://codecov.io/gh/aio-libs/aiobotocore/branch/master/graph/badge.svg
     :target: https://codecov.io/gh/aio-libs/aiobotocore

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,8 +5,8 @@
 
 aiobotocore's documentation!
 ============================
-.. image:: https://github.com/aio-libs/aiobotocore/actions/workflows/python-package.yml/badge.svg?branch=master
-    :target: https://github.com/aio-libs/aiobotocore/actions/workflows/python-package.yml
+.. image:: https://github.com/aio-libs/aiobotocore/actions/workflows/ci-cd.yml/badge.svg?branch=master
+    :target: https://github.com/aio-libs/aiobotocore/actions/workflows/ci-cd.yml
 .. image:: https://codecov.io/gh/aio-libs/aiobotocore/branch/master/graph/badge.svg
     :target: https://codecov.io/gh/aio-libs/aiobotocore
 .. image:: https://img.shields.io/pypi/v/aiobotocore.svg


### PR DESCRIPTION
### Description of Change
Partially adresses https://github.com/aio-libs/aiobotocore/pull/1154#issuecomment-2297940743 by renaming our CI GitHub workflow.

Since we do not use GitHub environments and trusted publisher expects `pypi`, this might still fail. @webknjaz: Is the environment really required or could you remove it, at least temporarily?

### Assumptions
None

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
