### PR TITLE
Remove legacy Google Groups mailing list from `README.rst`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -231,12 +231,6 @@ For `types-aiobotocore-lite` package use explicit type annotations:
 Full documentation for `types-aiobotocore` can be found here: https://youtype.github.io/types_aiobotocore_docs/
 
 
-Mailing List
-------------
-
-https://groups.google.com/forum/#!forum/aio-libs
-
-
 Requirements
 ------------
 * Python_ 3.8+


### PR DESCRIPTION
### Description of Change
Remove legacy Google Groups mailing list from `README.rst`

### Assumptions
Stakeholders know about and will use established channels, i.e. GitHub issues and discussions.

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
