### PR TITLE
Remove setuptools dev dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # ?= conditional assign, so users can pass options on the CLI instead of manually editing this file
 FLAGS?=
 
-pre-commit: checkrst
+pre-commit:
 	pre-commit run --all
 
 test: pre-commit
@@ -11,9 +11,6 @@ test: pre-commit
 
 vtest:
 	python -Wd -X tracemalloc=5 -X faulthandler -m pytest -s -vv $(FLAGS) ./tests/
-
-checkrst:
-	python setup.py check -rms
 
 cov cover coverage: pre-commit
 	python -Wd -m pytest -s -vv --cov-report term --cov-report html --cov aiobotocore ./tests

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -7,7 +7,6 @@ pytest==8.1.1
 pytest-cov==5.0.0
 pytest-asyncio~=0.23.8
 pytest-xdist==3.5.0
-setuptools==67.8.0;python_version>="3.12"
 
 # this is needed for test_patches
 dill~=0.3.3

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -15,9 +15,6 @@ dill~=0.3.3
 # this is needed for test_version
 tomli; python_version < "3.11"
 
-# this is needed when running setup.py check -rms
-Pygments
-
 aiohttp${AIOHTTP_VERSION}
 
 -e .[awscli,boto3]

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
### Description of Change
Remove all remaining occurrences of `setuptools` / `setup.py` in the 'development space'.

### Assumptions
* `twine check --strict` in CI is adequate replacement for `setup.py check`
* `setuptools` is still used as build backend, as specified in `pyproject.toml`

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
