### PR TITLE
Set `timeout-minutes` property for all GitHub Actions workflow jobs and check via pre-commit hook

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -21,6 +21,7 @@ jobs:
   build:
     name: Build distribution 📦
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
     - uses: actions/checkout@v4
@@ -58,7 +59,7 @@ jobs:
         - aiohttp-version: <4.0.0
           python-version: 3.11
       fail-fast: false
-    timeout-minutes: 15
+    timeout-minutes: 5
 
     steps:
     - name: Checkout
@@ -111,6 +112,7 @@ jobs:
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
+    timeout-minutes: 5
 
     steps:
     - name: Download distribution 📦

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   pre-commit:
     runs-on: ubuntu-20.04
+    timeout-minutes: 5
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+    timeout-minutes: 5
 
     steps:
     - uses: actions/stale@v9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,12 @@ repos:
   - id: check-dependabot
   - id: check-github-workflows
   - id: check-readthedocs
+  - id: check-jsonschema
+    alias: check-github-workflows-require-timeout
+    name: Check GitHub Actions workflow jobs set timeout-minutes
+    args:
+    - --builtin-schema
+    - github-workflows-require-timeout
+    files: ^\.github/workflows/[^/]+$
+    types:
+    - yaml


### PR DESCRIPTION
### Description of Change
Closes #1183

### Assumptions
5 minutes is ample time for all current jobs.

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
