### PR TITLE
Relax `botocore` dependency specification

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changes
 -------
 
-2.14.0 (2024-08-23)
+2.14.0 (2024-08-28)
 ^^^^^^^^^^^^^^^^^^^
 * bump botocore dependency specification
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 dynamic = ["version", "readme"]
 
 dependencies = [
-    "botocore >=1.35.0, <1.35.5", # NOTE: When updating, always keep `project.optional-dependencies` aligned
+    "botocore >=1.35.0, <1.35.8", # NOTE: When updating, always keep `project.optional-dependencies` aligned
     "aiohttp >=3.9.2, <4.0.0",
     "wrapt >=1.10.10, <2.0.0",
     "aioitertools >=0.5.1, <1.0.0",
@@ -37,10 +37,10 @@ dependencies = [
 
 [project.optional-dependencies]
 awscli = [
-    "awscli >=1.34.0, <1.34.5",
+    "awscli >=1.34.0, <1.34.8",
 ]
 boto3 = [
-    "boto3 >=1.35.0, <1.35.5",
+    "boto3 >=1.35.0, <1.35.8",
 ]
 
 [project.urls]


### PR DESCRIPTION
### Description of Change
This PR intends to improve general compatibility of `aiobotocore` within the Python ecosystem by relaxing the dependency specification of `botocore`, as well as `boto3` and `awscli`.

### Assumptions
[Upstream diff](https://github.com/boto/botocore/compare/1.35.4..1.35.7) contains no changes that require any adjustments to the aiobotocore codebase.

### Checklist for All Submissions
* [x] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [x] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details): closes #1191
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [x] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [x] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [x] I have ensured that the awscli/boto3 versions match the updated botocore version
