### PR TITLE
Reduce noisiness of `pre-commit.ci` autoupdates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,7 @@
 ---
+ci:
+  autoupdate_schedule: quarterly
+
 repos:
 - repo: 'https://github.com/pre-commit/pre-commit-hooks'
   rev: v4.5.0


### PR DESCRIPTION
### Description of Change
This PR sets the [pre-commit.ci autoupdate schedule setting](https://pre-commit.ci/#configuration-autoupdate_schedule) to the maximum value 'quarterly'. The goal is to limit the amount of noisy PRs, such as #1222.

### Assumptions
By default, pre-commit.ci performs weekly autoupdate runs that create PRs. Our pre-commit configuration is partially derived from upstream and needs to remain in sync. As a result, these PRs are routinely closed. It is currently impossible to deactivate pre-commit.ci autoupdate, but the schedule setting recently became configurable.

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
