### PR TITLE
leverage pytest-asyncio test discovery mode auto

### DIFF
--- a/tests/boto_tests/test_credentials.py
+++ b/tests/boto_tests/test_credentials.py
@@ -128,7 +128,6 @@ def credential_provider():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_assumerolefetcher_no_cache():
     response = {
         'Credentials': {
@@ -151,7 +150,6 @@ async def test_assumerolefetcher_no_cache():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_assumerolefetcher_cache_key_with_role_session_name():
     response = {
         'Credentials': {
@@ -181,7 +179,6 @@ async def test_assumerolefetcher_cache_key_with_role_session_name():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_assumerolefetcher_cache_in_cache_but_expired():
     response = {
         'Credentials': {
@@ -216,7 +213,6 @@ async def test_assumerolefetcher_cache_in_cache_but_expired():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_assumerolefetcher_mfa():
     response = {
         'Credentials': {
@@ -249,7 +245,6 @@ async def test_assumerolefetcher_mfa():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_recursive_assume_role(assume_role_setup):
     self = assume_role_setup
 
@@ -307,7 +302,6 @@ def assume_role_web_identity_client_creator(with_response):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_webidentfetcher_no_cache():
     response = {
         'Credentials': {
@@ -330,7 +324,6 @@ async def test_webidentfetcher_no_cache():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_credresolver_load_credentials_single_provider(
     credential_provider,
 ):
@@ -348,7 +341,6 @@ async def test_credresolver_load_credentials_single_provider(
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_credresolver_no_providers(credential_provider):
     provider1 = credential_provider('provider1', 'CustomProvider1', None)
     resolver = credentials.AioCredentialResolver(providers=[provider1])
@@ -359,7 +351,6 @@ async def test_credresolver_no_providers(credential_provider):
 
 # From class TestCanonicalNameSourceProvider(BaseEnvVar):
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_canonicalsourceprovider_source_creds(credential_provider):
     creds = credentials.AioCredentials('a', 'b', 'c')
     provider1 = credential_provider('provider1', 'CustomProvider1', creds)
@@ -373,7 +364,6 @@ async def test_canonicalsourceprovider_source_creds(credential_provider):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_canonicalsourceprovider_source_creds_case_insensitive(
     credential_provider,
 ):
@@ -419,7 +409,6 @@ def assumerolecredprovider_config_loader():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_assumerolecredprovider_assume_role_no_cache(
     credential_provider, assumerolecredprovider_config_loader
 ):
@@ -462,7 +451,6 @@ async def test_assumerolecredprovider_assume_role_no_cache(
 
 # MFA
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_assumerolecredprovider_mfa(
     credential_provider, assumerolecredprovider_config_loader
 ):
@@ -521,7 +509,6 @@ async def test_assumerolecredprovider_mfa(
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_assumerolecredprovider_mfa_cannot_refresh_credentials(
     credential_provider, assumerolecredprovider_config_loader
 ):
@@ -578,7 +565,6 @@ async def test_assumerolecredprovider_mfa_cannot_refresh_credentials(
 
 # From class TestAssumeRoleWithWebIdentityCredentialProvider
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_assumerolewebidentprovider_no_cache():
     future = datetime.now(tzlocal()) + timedelta(hours=24)
 
@@ -631,7 +617,6 @@ def full_url(url):
 
 # From class TestEnvVar(BaseEnvVar):
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_envvarprovider_env_var_present():
     environ = {
         'AWS_ACCESS_KEY_ID': 'foo',
@@ -647,7 +632,6 @@ async def test_envvarprovider_env_var_present():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_envvarprovider_env_var_absent():
     environ = {}
     provider = credentials.AioEnvProvider(environ)
@@ -656,7 +640,6 @@ async def test_envvarprovider_env_var_absent():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_envvarprovider_env_var_expiry():
     expiry_time = datetime.now(tzlocal()) - timedelta(hours=1)
     environ = {
@@ -692,7 +675,6 @@ def profile_config():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_configprovider_file_exists(profile_config):
     provider = credentials.AioConfigProvider(
         'cli.cfg', 'default', profile_config
@@ -706,7 +688,6 @@ async def test_configprovider_file_exists(profile_config):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_configprovider_file_missing_profile(profile_config):
     provider = credentials.AioConfigProvider(
         'cli.cfg', 'NOT-default', profile_config
@@ -717,7 +698,6 @@ async def test_configprovider_file_missing_profile(profile_config):
 
 # From class TestSharedCredentialsProvider(BaseEnvVar):
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_sharedcredentials_file_exists():
     parser = mock.Mock()
     parser.return_value = {
@@ -741,7 +721,6 @@ async def test_sharedcredentials_file_exists():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_sharedcredentials_file_missing():
     parser = mock.Mock()
     parser.side_effect = botocore.exceptions.ConfigNotFound(path='foo')
@@ -755,7 +734,6 @@ async def test_sharedcredentials_file_missing():
 
 # From class TestBotoProvider(BaseEnvVar):
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_botoprovider_file_exists():
     parser = mock.Mock()
     parser.return_value = {
@@ -775,7 +753,6 @@ async def test_botoprovider_file_exists():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_botoprovider_file_missing():
     parser = mock.Mock()
     parser.side_effect = botocore.exceptions.ConfigNotFound(path='foo')
@@ -787,7 +764,6 @@ async def test_botoprovider_file_missing():
 
 # From class TestOriginalEC2Provider(BaseEnvVar):
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_originalec2provider_file_exists():
     envrion = {'AWS_CREDENTIAL_FILE': 'foo.cfg'}
     parser = mock.Mock()
@@ -808,7 +784,6 @@ async def test_originalec2provider_file_exists():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_originalec2provider_file_missing():
     provider = credentials.AioOriginalEC2Provider(environ={})
     creds = await provider.load()
@@ -855,7 +830,6 @@ def mock_session():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_createcredentialresolver(mock_session):
     session = mock_session()
 
@@ -864,7 +838,6 @@ async def test_createcredentialresolver(mock_session):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_get_credentials(mock_session):
     session = mock_session()
 
@@ -1099,7 +1072,6 @@ def assume_role_setup(base_assume_role_test_setup):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_sso_credential_fetcher_can_fetch_credentials(
     ssl_credential_fetcher_setup,
 ):
@@ -1142,7 +1114,6 @@ async def test_sso_credential_fetcher_can_fetch_credentials(
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_sso_cred_fetcher_raises_helpful_message_on_unauthorized_exception(
     ssl_credential_fetcher_setup,
 ):
@@ -1247,7 +1218,6 @@ def _add_get_role_credentials_response(self):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_load_sso_credentials_without_cache(sso_provider_setup):
     self = sso_provider_setup
     _add_get_role_credentials_response(self)
@@ -1260,7 +1230,6 @@ async def test_load_sso_credentials_without_cache(sso_provider_setup):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_load_sso_credentials_with_cache(sso_provider_setup):
     self = sso_provider_setup
 
@@ -1281,7 +1250,6 @@ async def test_load_sso_credentials_with_cache(sso_provider_setup):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_load_sso_credentials_with_cache_expired(sso_provider_setup):
     self = sso_provider_setup
     cached_creds = {
@@ -1305,7 +1273,6 @@ async def test_load_sso_credentials_with_cache_expired(sso_provider_setup):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_required_config_not_set(sso_provider_setup):
     self = sso_provider_setup
     del self.config['sso_start_url']

--- a/tests/boto_tests/test_signers.py
+++ b/tests/boto_tests/test_signers.py
@@ -10,7 +10,6 @@ import aiobotocore.signers
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_signers_generate_db_auth_token(rds_client):
     hostname = 'prod-instance.us-east-1.rds.amazonaws.com'
     port = 3306

--- a/tests/boto_tests/test_utils.py
+++ b/tests/boto_tests/test_utils.py
@@ -71,7 +71,6 @@ def fake_aiohttp_session(responses: list[Response] | Response):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_idmsfetcher_disabled():
     env = {'AWS_EC2_METADATA_DISABLED': 'true'}
     fetcher = utils.AioIMDSFetcher(env=env)
@@ -81,7 +80,6 @@ async def test_idmsfetcher_disabled():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_idmsfetcher_get_token_success():
     session = fake_aiohttp_session(
         ('blah', 200),
@@ -95,7 +93,6 @@ async def test_idmsfetcher_get_token_success():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_idmsfetcher_get_token_not_found():
     session = fake_aiohttp_session(
         ('blah', 404),
@@ -109,7 +106,6 @@ async def test_idmsfetcher_get_token_not_found():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_idmsfetcher_get_token_bad_request():
     session = fake_aiohttp_session(
         ('blah', 400),
@@ -123,7 +119,6 @@ async def test_idmsfetcher_get_token_bad_request():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_idmsfetcher_get_token_timeout():
     session = fake_aiohttp_session(
         [
@@ -138,7 +133,6 @@ async def test_idmsfetcher_get_token_timeout():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_idmsfetcher_get_token_retry():
     session = fake_aiohttp_session(
         [
@@ -155,7 +149,6 @@ async def test_idmsfetcher_get_token_retry():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_idmsfetcher_retry():
     session = fake_aiohttp_session(
         [
@@ -184,7 +177,6 @@ async def test_idmsfetcher_retry():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_idmsfetcher_timeout():
     session = fake_aiohttp_session(
         [

--- a/tests/python3.8/boto_tests/test_credentials.py
+++ b/tests/python3.8/boto_tests/test_credentials.py
@@ -79,7 +79,6 @@ def deferrable_creds():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_refreshablecredentials_get_credentials_set(refreshable_creds):
     creds = refreshable_creds(
         mock_time_return_value=(
@@ -97,7 +96,6 @@ async def test_refreshablecredentials_get_credentials_set(refreshable_creds):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_refreshablecredentials_refresh_returns_empty_dict(
     refreshable_creds,
 ):
@@ -113,7 +111,6 @@ async def test_refreshablecredentials_refresh_returns_empty_dict(
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_refreshablecredentials_refresh_returns_none(refreshable_creds):
     creds = refreshable_creds(
         mock_time_return_value=datetime.now(tzlocal()),
@@ -127,7 +124,6 @@ async def test_refreshablecredentials_refresh_returns_none(refreshable_creds):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_refreshablecredentials_refresh_returns_partial(
     refreshable_creds,
 ):
@@ -143,7 +139,6 @@ async def test_refreshablecredentials_refresh_returns_partial(
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_deferrablecredentials_get_credentials_set(deferrable_creds):
     creds = deferrable_creds()
 
@@ -154,7 +149,6 @@ async def test_deferrablecredentials_get_credentials_set(deferrable_creds):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_deferrablecredentials_refresh_only_called_once(
     deferrable_creds,
 ):
@@ -170,7 +164,6 @@ async def test_deferrablecredentials_refresh_only_called_once(
 
 # From class TestInstanceMetadataProvider(BaseEnvVar):
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_instancemetadata_load():
     timeobj = datetime.now(tzlocal())
     timestamp = (timeobj + timedelta(hours=24)).isoformat()
@@ -200,7 +193,6 @@ async def test_instancemetadata_load():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_containerprovider_assume_role_no_cache():
     environ = {
         'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI': '/latest/credentials?id=foo'
@@ -248,7 +240,6 @@ def process_provider():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_processprovider_retrieve_refereshable_creds(process_provider):
     config = {
         'profiles': {'default': {'credential_process': 'my-process /somefile'}}
@@ -287,7 +278,6 @@ async def test_processprovider_retrieve_refereshable_creds(process_provider):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_processprovider_retrieve_creds(process_provider):
     config = {'profiles': {'default': {'credential_process': 'my-process'}}}
     invoked_process = mock.AsyncMock()
@@ -315,7 +305,6 @@ async def test_processprovider_retrieve_creds(process_provider):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_processprovider_bad_version(process_provider):
     config = {'profiles': {'default': {'credential_process': 'my-process'}}}
     invoked_process = mock.AsyncMock()
@@ -339,7 +328,6 @@ async def test_processprovider_bad_version(process_provider):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_processprovider_missing_field(process_provider):
     config = {'profiles': {'default': {'credential_process': 'my-process'}}}
     invoked_process = mock.AsyncMock()
@@ -362,7 +350,6 @@ async def test_processprovider_missing_field(process_provider):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_processprovider_bad_exitcode(process_provider):
     config = {'profiles': {'default': {'credential_process': 'my-process'}}}
     invoked_process = mock.AsyncMock()
@@ -378,7 +365,6 @@ async def test_processprovider_bad_exitcode(process_provider):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_processprovider_bad_config(process_provider):
     config = {'profiles': {'default': {'credential_process': None}}}
     invoked_process = mock.AsyncMock()
@@ -402,7 +388,6 @@ async def test_processprovider_bad_config(process_provider):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_session_credentials():
     with mock.patch(
         'aiobotocore.credentials.AioCredential' 'Resolver.load_credentials'

--- a/tests/python3.8/boto_tests/test_signers.py
+++ b/tests/python3.8/boto_tests/test_signers.py
@@ -65,7 +65,6 @@ async def base_signer_setup_s3v4() -> dict:
 
 # From class TestGenerateUrl
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_signers_generate_presigned_urls():
     with mock.patch(
         'aiobotocore.signers.AioRequestSigner.generate_presigned_url'
@@ -109,7 +108,6 @@ async def test_signers_generate_presigned_urls():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_signers_generate_presigned_post():
     with mock.patch(
         'aiobotocore.signers.AioS3PostPresigner.generate_presigned_post'
@@ -146,7 +144,6 @@ async def test_signers_generate_presigned_post():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_testsigner_get_auth(base_signer_setup: dict):
     auth_cls = mock.Mock()
     with mock.patch.dict(botocore.auth.AUTH_TYPE_MAPS, {'v4': auth_cls}):
@@ -162,7 +159,6 @@ async def test_testsigner_get_auth(base_signer_setup: dict):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_testsigner_region_required_for_sig4(base_signer_setup: dict):
     signer = aiobotocore.signers.AioRequestSigner(
         ServiceId('service_name'),
@@ -178,7 +174,6 @@ async def test_testsigner_region_required_for_sig4(base_signer_setup: dict):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_testsigner_custom_sign_version(base_signer_setup: dict):
     signer = base_signer_setup['signer']
     with pytest.raises(UnknownSignatureVersionError):
@@ -188,7 +183,6 @@ async def test_testsigner_custom_sign_version(base_signer_setup: dict):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_testsigner_choose_signer_override(base_signer_setup: dict):
     auth_cls = mock.Mock()
     auth_cls.REQUIRES_REGION = False
@@ -208,7 +202,6 @@ async def test_testsigner_choose_signer_override(base_signer_setup: dict):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_testsigner_generate_presigned_url(base_signer_setup: dict):
     auth_cls = mock.Mock()
     auth_cls.REQUIRES_REGION = True
@@ -239,7 +232,6 @@ async def test_testsigner_generate_presigned_url(base_signer_setup: dict):
 
 # From class TestGeneratePresignedPost
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_testsigner_generate_presigned_post(
     base_signer_setup_s3v4: dict,
 ):

--- a/tests/python3.8/boto_tests/test_tokens.py
+++ b/tests/python3.8/boto_tests/test_tokens.py
@@ -275,7 +275,6 @@ sso_provider_refresh_cases = [
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 @parametrize(sso_provider_refresh_cases)
 async def test_sso_token_provider_refresh(test_case):
     config = {

--- a/tests/python3.8/boto_tests/test_utils.py
+++ b/tests/python3.8/boto_tests/test_utils.py
@@ -80,7 +80,6 @@ class TestInstanceMetadataFetcher(unittest.IsolatedAsyncioTestCase):
         return response
 
     @pytest.mark.moto
-    @pytest.mark.asyncio
     async def test_disabled_by_environment(self):
         env = {'AWS_EC2_METADATA_DISABLED': 'true'}
         fetcher = AioInstanceMetadataFetcher(env=env)
@@ -89,7 +88,6 @@ class TestInstanceMetadataFetcher(unittest.IsolatedAsyncioTestCase):
         self._send.assert_not_called()
 
     @pytest.mark.moto
-    @pytest.mark.asyncio
     async def test_disabled_by_environment_mixed_case(self):
         env = {'AWS_EC2_METADATA_DISABLED': 'tRuE'}
         fetcher = AioInstanceMetadataFetcher(env=env)
@@ -98,7 +96,6 @@ class TestInstanceMetadataFetcher(unittest.IsolatedAsyncioTestCase):
         self._send.assert_not_called()
 
     @pytest.mark.moto
-    @pytest.mark.asyncio
     async def test_disabling_env_var_not_true(self):
         url = 'https://example.com/'
         env = {'AWS_EC2_METADATA_DISABLED': 'false'}
@@ -113,7 +110,6 @@ class TestInstanceMetadataFetcher(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, self._expected_creds)
 
     @pytest.mark.moto
-    @pytest.mark.asyncio
     async def test_includes_user_agent_header(self):
         user_agent = 'my-user-agent'
         self.add_get_token_imds_response(token='token')
@@ -129,7 +125,6 @@ class TestInstanceMetadataFetcher(unittest.IsolatedAsyncioTestCase):
             self.assertTrue(call[0][0].headers['User-Agent'], user_agent)
 
     @pytest.mark.moto
-    @pytest.mark.asyncio
     async def test_non_200_response_for_role_name_is_retried(self):
         # Response for role name that have a non 200 status code should
         # be retried.
@@ -145,7 +140,6 @@ class TestInstanceMetadataFetcher(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, self._expected_creds)
 
     @pytest.mark.moto
-    @pytest.mark.asyncio
     async def test_http_connection_error_for_role_name_is_retried(self):
         # Connection related errors should be retried
         self.add_get_token_imds_response(token='token')
@@ -158,7 +152,6 @@ class TestInstanceMetadataFetcher(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, self._expected_creds)
 
     @pytest.mark.moto
-    @pytest.mark.asyncio
     async def test_empty_response_for_role_name_is_retried(self):
         # Response for role name that have a non 200 status code should
         # be retried.
@@ -172,7 +165,6 @@ class TestInstanceMetadataFetcher(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, self._expected_creds)
 
     @pytest.mark.moto
-    @pytest.mark.asyncio
     async def test_non_200_response_is_retried(self):
         self.add_get_token_imds_response(token='token')
         self.add_get_role_name_imds_response()
@@ -188,7 +180,6 @@ class TestInstanceMetadataFetcher(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, self._expected_creds)
 
     @pytest.mark.moto
-    @pytest.mark.asyncio
     async def test_http_connection_errors_is_retried(self):
         self.add_get_token_imds_response(token='token')
         self.add_get_role_name_imds_response()
@@ -201,7 +192,6 @@ class TestInstanceMetadataFetcher(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, self._expected_creds)
 
     @pytest.mark.moto
-    @pytest.mark.asyncio
     async def test_empty_response_is_retried(self):
         self.add_get_token_imds_response(token='token')
         self.add_get_role_name_imds_response()
@@ -215,7 +205,6 @@ class TestInstanceMetadataFetcher(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, self._expected_creds)
 
     @pytest.mark.moto
-    @pytest.mark.asyncio
     async def test_invalid_json_is_retried(self):
         self.add_get_token_imds_response(token='token')
         self.add_get_role_name_imds_response()
@@ -229,7 +218,6 @@ class TestInstanceMetadataFetcher(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, self._expected_creds)
 
     @pytest.mark.moto
-    @pytest.mark.asyncio
     async def test_exhaust_retries_on_role_name_request(self):
         self.add_get_token_imds_response(token='token')
         self.add_imds_response(status_code=400, body=b'')
@@ -239,7 +227,6 @@ class TestInstanceMetadataFetcher(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, {})
 
     @pytest.mark.moto
-    @pytest.mark.asyncio
     async def test_exhaust_retries_on_credentials_request(self):
         self.add_get_token_imds_response(token='token')
         self.add_get_role_name_imds_response()
@@ -250,7 +237,6 @@ class TestInstanceMetadataFetcher(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, {})
 
     @pytest.mark.moto
-    @pytest.mark.asyncio
     async def test_missing_fields_in_credentials_response(self):
         self.add_get_token_imds_response(token='token')
         self.add_get_role_name_imds_response()
@@ -265,7 +251,6 @@ class TestInstanceMetadataFetcher(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, {})
 
     @pytest.mark.moto
-    @pytest.mark.asyncio
     async def test_token_is_included(self):
         user_agent = 'my-user-agent'
         self.add_get_token_imds_response(token='token')
@@ -285,7 +270,6 @@ class TestInstanceMetadataFetcher(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, self._expected_creds)
 
     @pytest.mark.moto
-    @pytest.mark.asyncio
     async def test_metadata_token_not_supported_404(self):
         user_agent = 'my-user-agent'
         self.add_imds_response(b'', status_code=404)
@@ -301,7 +285,6 @@ class TestInstanceMetadataFetcher(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, self._expected_creds)
 
     @pytest.mark.moto
-    @pytest.mark.asyncio
     async def test_metadata_token_not_supported_403(self):
         user_agent = 'my-user-agent'
         self.add_imds_response(b'', status_code=403)
@@ -317,7 +300,6 @@ class TestInstanceMetadataFetcher(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, self._expected_creds)
 
     @pytest.mark.moto
-    @pytest.mark.asyncio
     async def test_metadata_token_not_supported_405(self):
         user_agent = 'my-user-agent'
         self.add_imds_response(b'', status_code=405)
@@ -333,7 +315,6 @@ class TestInstanceMetadataFetcher(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, self._expected_creds)
 
     @pytest.mark.moto
-    @pytest.mark.asyncio
     async def test_metadata_token_not_supported_timeout(self):
         user_agent = 'my-user-agent'
         self.add_imds_connection_error(ReadTimeoutError(endpoint_url='url'))
@@ -349,7 +330,6 @@ class TestInstanceMetadataFetcher(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, self._expected_creds)
 
     @pytest.mark.moto
-    @pytest.mark.asyncio
     async def test_token_not_supported_exhaust_retries(self):
         user_agent = 'my-user-agent'
         self.add_imds_connection_error(ConnectTimeoutError(endpoint_url='url'))
@@ -365,7 +345,6 @@ class TestInstanceMetadataFetcher(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, self._expected_creds)
 
     @pytest.mark.moto
-    @pytest.mark.asyncio
     async def test_metadata_token_bad_request_yields_no_credentials(self):
         user_agent = 'my-user-agent'
         self.add_imds_response(b'', status_code=400)
@@ -376,7 +355,6 @@ class TestInstanceMetadataFetcher(unittest.IsolatedAsyncioTestCase):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_containermetadatafetcher_retrieve_url():
     json_body = json.dumps(
         {
@@ -407,7 +385,6 @@ async def test_containermetadatafetcher_retrieve_url():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_containermetadatafetcher_retrieve_url_bad_status():
     json_body = "not json"
 
@@ -420,7 +397,6 @@ async def test_containermetadatafetcher_retrieve_url_bad_status():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_containermetadatafetcher_retrieve_url_not_json():
     json_body = "not json"
 

--- a/tests/python3.8/test_eventstreams.py
+++ b/tests/python3.8/test_eventstreams.py
@@ -1,12 +1,9 @@
 import asyncio
 from contextlib import AsyncExitStack
 
-import pytest
-
 import aiobotocore.session
 
 
-@pytest.mark.asyncio
 async def test_kinesis_stream_json_parser(exit_stack: AsyncExitStack):
     # unfortunately moto doesn't support kinesis register_stream_consumer +
     # subscribe_to_shard yet

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -54,13 +54,11 @@ class TestAsyncClientRateLimiter:
         )
         return rate_limiter
 
-    @pytest.mark.asyncio
     async def test_bucket_bucket_acquisition_only_if_enabled(self):
         rate_limiter = self.create_client_limiter()
         await rate_limiter.on_sending_request(request=mock.sentinel.request)
         assert not self.token_bucket.acquire.called
 
-    @pytest.mark.asyncio
     async def test_token_bucket_enabled_on_throttling_error(self):
         rate_limiter = self.create_client_limiter()
         self.throttling_detector.is_throttling_error.return_value = True
@@ -73,7 +71,6 @@ class TestAsyncClientRateLimiter:
         await rate_limiter.on_sending_request(request=mock.sentinel.request)
         assert self.token_bucket.acquire.called
 
-    @pytest.mark.asyncio
     async def test_max_rate_updated_on_success_response(self):
         rate_limiter = self.create_client_limiter()
         self.throttling_detector.is_throttling_error.return_value = False
@@ -82,7 +79,6 @@ class TestAsyncClientRateLimiter:
         await rate_limiter.on_receiving_response()
         assert await self.token_bucket.set_max_rate.called_with(20)
 
-    @pytest.mark.asyncio
     async def test_max_rate_cant_exceed_20_percent_max(self):
         rate_limiter = self.create_client_limiter()
         self.throttling_detector.is_throttling_error.return_value = False
@@ -107,7 +103,6 @@ class TestAsyncTokenBucket:
             max_rate=max_rate, clock=self.clock, min_rate=min_rate
         )
 
-    @pytest.mark.asyncio
     async def test_can_acquire_amount(self):
         self.timestamp_sequences.extend(
             [
@@ -124,7 +119,6 @@ class TestAsyncTokenBucket:
         for _ in range(5):
             assert await token_bucket.acquire(1, block=False)
 
-    @pytest.mark.asyncio
     async def test_can_change_max_capacity_lower(self):
         # Requests at 1 TPS.
         self.timestamp_sequences.extend([1, 2, 3, 4, 5])
@@ -140,7 +134,6 @@ class TestAsyncTokenBucket:
         for _ in range(5):
             assert await token_bucket.acquire(1, block=False)
 
-    @pytest.mark.asyncio
     async def test_max_capacity_is_at_least_one(self):
         token_bucket = self.create_token_bucket()
         self.timestamp_sequences.append(1)
@@ -148,7 +141,6 @@ class TestAsyncTokenBucket:
         assert token_bucket._fill_rate == 0.5
         assert token_bucket._max_capacity == 1
 
-    @pytest.mark.asyncio
     async def test_acquire_fails_on_non_block_mode_returns_false(self):
         self.timestamp_sequences.extend(
             [
@@ -162,7 +154,6 @@ class TestAsyncTokenBucket:
         with pytest.raises(CapacityNotAvailableError):
             await token_bucket.acquire(100, block=False)
 
-    @pytest.mark.asyncio
     async def test_can_retrieve_at_max_send_rate(self):
         self.timestamp_sequences.extend(
             [
@@ -175,7 +166,6 @@ class TestAsyncTokenBucket:
         for _ in range(20):
             assert await token_bucket.acquire(1, block=False)
 
-    @pytest.mark.asyncio
     async def test_acquiring_blocks_when_capacity_reached(self):
         # This is 1 token every 0.1 seconds.
         token_bucket = self.create_token_bucket(max_rate=10)
@@ -201,7 +191,6 @@ class TestAsyncTokenBucket:
         assert token_bucket._current_capacity == 0
         assert await token_bucket.acquire(1, block=False)
 
-    @pytest.mark.asyncio
     async def test_rate_cant_go_below_min(self):
         token_bucket = self.create_token_bucket(max_rate=1, min_rate=0.2)
         self.timestamp_sequences.append(1)

--- a/tests/test_basic_s3.py
+++ b/tests/test_basic_s3.py
@@ -19,7 +19,6 @@ async def fetch_all(pages):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_can_make_request(s3_client):
     # Basic smoke test to ensure we can talk to s3.
     result = await s3_client.list_buckets()
@@ -31,7 +30,6 @@ async def test_can_make_request(s3_client):
 
 @pytest.mark.moto
 @pytest.mark.parametrize('s3_verify', [False])
-@pytest.mark.asyncio
 async def test_can_make_request_no_verify(s3_client):
     # Basic smoke test to ensure we can talk to s3.
     result = await s3_client.list_buckets()
@@ -42,7 +40,6 @@ async def test_can_make_request_no_verify(s3_client):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_fail_proxy_request(
     aa_fail_proxy_config, s3_client, monkeypatch
 ):
@@ -51,7 +48,6 @@ async def test_fail_proxy_request(
         await s3_client.list_buckets()
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize('mocking_test', [False])
 async def test_succeed_proxy_request(aa_succeed_proxy_config, s3_client):
     result = await s3_client.list_buckets()
@@ -59,7 +55,6 @@ async def test_succeed_proxy_request(aa_succeed_proxy_config, s3_client):
     assert actual_keys == ['Buckets', 'Owner', 'ResponseMetadata']
 
 
-@pytest.mark.asyncio
 @pytest.mark.moto
 async def test_can_get_bucket_location(s3_client, bucket_name):
     result = await s3_client.get_bucket_location(Bucket=bucket_name)
@@ -70,7 +65,6 @@ async def test_can_get_bucket_location(s3_client, bucket_name):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_can_delete_urlencoded_object(
     s3_client, bucket_name, create_object
 ):
@@ -91,7 +85,6 @@ async def test_can_delete_urlencoded_object(
     pytest.aio.assert_status_code(response, 204)
 
 
-@pytest.mark.asyncio
 @pytest.mark.moto
 async def test_can_paginate(s3_client, bucket_name, create_object):
     for i in range(5):
@@ -107,7 +100,6 @@ async def test_can_paginate(s3_client, bucket_name, create_object):
     assert key_names == ['key0', 'key1', 'key2', 'key3', 'key4']
 
 
-@pytest.mark.asyncio
 @pytest.mark.moto
 async def test_can_paginate_with_page_size(
     s3_client, bucket_name, create_object
@@ -128,7 +120,6 @@ async def test_can_paginate_with_page_size(
     assert key_names == ['key0', 'key1', 'key2', 'key3', 'key4']
 
 
-@pytest.mark.asyncio
 @pytest.mark.moto
 async def test_can_search_paginate(s3_client, bucket_name, create_object):
     keys = []
@@ -143,7 +134,6 @@ async def test_can_search_paginate(s3_client, bucket_name, create_object):
         assert key_name in keys
 
 
-@pytest.mark.asyncio
 @pytest.mark.moto
 async def test_can_paginate_iterator(s3_client, bucket_name, create_object):
     for i in range(5):
@@ -163,7 +153,6 @@ async def test_can_paginate_iterator(s3_client, bucket_name, create_object):
     assert key_names == ['key0', 'key1', 'key2', 'key3', 'key4']
 
 
-@pytest.mark.asyncio
 @pytest.mark.moto
 async def test_result_key_iters(s3_client, bucket_name, create_object):
     for i in range(5):
@@ -195,7 +184,6 @@ async def test_result_key_iters(s3_client, bucket_name, create_object):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_can_get_and_put_object(s3_client, create_object, bucket_name):
     await create_object('foobarbaz', body='body contents')
     resp = await s3_client.get_object(Bucket=bucket_name, Key='foobarbaz')
@@ -206,7 +194,6 @@ async def test_can_get_and_put_object(s3_client, create_object, bucket_name):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 @pytest.mark.patch_attributes(
     [
         dict(
@@ -260,7 +247,6 @@ async def test_adaptive_retry(
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_get_object_stream_wrapper(
     s3_client, create_object, bucket_name
 ):
@@ -275,7 +261,6 @@ async def test_get_object_stream_wrapper(
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_get_object_stream_context(
     s3_client, create_object, bucket_name
 ):
@@ -285,7 +270,6 @@ async def test_get_object_stream_context(
         await stream.read()
 
 
-@pytest.mark.asyncio
 @pytest.mark.moto
 async def test_paginate_max_items(
     s3_client, create_multipart_upload, bucket_name
@@ -327,7 +311,6 @@ async def test_paginate_max_items(
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_paginate_within_page_boundaries(
     s3_client, create_object, bucket_name
 ):
@@ -370,7 +353,6 @@ async def test_paginate_within_page_boundaries(
     assert fourth['Contents'][-1]['Key'] == 'd'
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize('mocking_test', [False])
 async def test_unicode_key_put_list(s3_client, bucket_name, create_object):
     # Verify we can upload a key with a unicode char and list it as well.
@@ -385,7 +367,6 @@ async def test_unicode_key_put_list(s3_client, bucket_name, create_object):
     assert data == b'foo'
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize('mocking_test', [False])
 async def test_unicode_system_character(s3_client, bucket_name, create_object):
     # Verify we can use a unicode system character which would normally
@@ -404,7 +385,6 @@ async def test_unicode_system_character(s3_client, bucket_name, create_object):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_non_normalized_key_paths(s3_client, bucket_name, create_object):
     # The create_object method has assertEqual checks for 200 status.
     await create_object('key./././name')
@@ -415,7 +395,6 @@ async def test_non_normalized_key_paths(s3_client, bucket_name, create_object):
 
 
 @pytest.mark.skipif(True, reason='Not supported')
-@pytest.mark.asyncio
 async def test_reset_stream_on_redirects(region, create_bucket):
     # Create a bucket in a non classic region.
     bucket_name = await create_bucket(region)
@@ -424,7 +403,6 @@ async def test_reset_stream_on_redirects(region, create_bucket):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_copy_with_quoted_char(s3_client, create_object, bucket_name):
     key_name = 'a+b/foo'
     await create_object(key_name=key_name)
@@ -443,7 +421,6 @@ async def test_copy_with_quoted_char(s3_client, create_object, bucket_name):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_copy_with_query_string(s3_client, create_object, bucket_name):
     key_name = 'a+b/foo?notVersionid=bar'
     await create_object(key_name=key_name)
@@ -463,7 +440,6 @@ async def test_copy_with_query_string(s3_client, create_object, bucket_name):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_can_copy_with_dict_form(s3_client, create_object, bucket_name):
     key_name = 'a+b/foo?versionId=abcd'
     await create_object(key_name=key_name)
@@ -483,7 +459,6 @@ async def test_can_copy_with_dict_form(s3_client, create_object, bucket_name):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_can_copy_with_dict_form_with_version(
     s3_client, create_object, bucket_name
 ):
@@ -508,7 +483,6 @@ async def test_can_copy_with_dict_form_with_version(
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_copy_with_s3_metadata(s3_client, create_object, bucket_name):
     key_name = 'foo.txt'
     await create_object(key_name=key_name)
@@ -527,7 +501,6 @@ async def test_copy_with_s3_metadata(s3_client, create_object, bucket_name):
 @pytest.mark.parametrize('signature_version', ['s3'])
 # 'Content-Disposition' not supported by moto yet
 @pytest.mark.parametrize('mocking_test', [False])
-@pytest.mark.asyncio
 async def test_presign_with_existing_query_string_values(
     s3_client, bucket_name, aio_session, create_object
 ):
@@ -554,7 +527,6 @@ async def test_presign_with_existing_query_string_values(
 @pytest.mark.parametrize('signature_version', ['s3v4'])
 # moto host will be localhost
 @pytest.mark.parametrize('mocking_test', [False])
-@pytest.mark.asyncio
 async def test_presign_sigv4(
     s3_client, bucket_name, aio_session, create_object
 ):
@@ -579,7 +551,6 @@ async def test_presign_sigv4(
 
 @pytest.mark.parametrize('signature_version', ['s3v4'])
 @pytest.mark.parametrize('mocking_test', [False])
-@pytest.mark.asyncio
 async def test_can_follow_signed_url_redirect(
     alternative_s3_client, create_object, bucket_name
 ):
@@ -597,7 +568,6 @@ async def test_can_follow_signed_url_redirect(
 @pytest.mark.parametrize('region', ['eu-west-1'])
 @pytest.mark.parametrize('alternative_region', ['us-west-2'])
 @pytest.mark.parametrize('mocking_test', [False])
-@pytest.mark.asyncio
 async def test_bucket_redirect(
     s3_client, alternative_s3_client, region, create_bucket
 ):
@@ -617,7 +587,6 @@ async def test_bucket_redirect(
 
 
 @pytest.mark.parametrize('signature_version', ['s3v4'])
-@pytest.mark.asyncio
 @pytest.mark.moto
 async def test_head_object_keys(s3_client, create_object, bucket_name):
     await create_object('foobarbaz')
@@ -644,7 +613,6 @@ async def test_head_object_keys(s3_client, create_object, bucket_name):
 @pytest.mark.parametrize('server_scheme', ['https'])
 @pytest.mark.parametrize('s3_verify', [False])
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_put_object_sha256(s3_client, bucket_name):
     data = b'test1234'
     digest = hashlib.sha256(data).digest().hex()

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -2,7 +2,6 @@ import pytest
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_batch(batch_client):
     job_queues = await batch_client.describe_job_queues()
     assert job_queues['jobQueues'] == []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,7 +13,6 @@ from tests.mock_server import AIOServer
 
 # NOTE: this doesn't require moto but needs to be marked to run with coverage
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_connector_args():
     with pytest.raises(ParamValidationError):
         # wrong type
@@ -64,7 +63,6 @@ async def test_connector_args():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_connector_timeout():
     session = AioSession()
     config = AioConfig(
@@ -97,7 +95,6 @@ async def test_connector_timeout():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_connector_timeout2():
     session = AioSession()
     config = AioConfig(
@@ -119,7 +116,6 @@ async def test_connector_timeout2():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_get_session():
     session = get_session()
     assert isinstance(session, AioSession)
@@ -137,7 +133,6 @@ def test_merge():
 
 # Check that it's possible to specify custom http_session_cls
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_config_http_session_cls():
     class SuccessExc(Exception): ...
 

--- a/tests/test_configprovider.py
+++ b/tests/test_configprovider.py
@@ -8,7 +8,6 @@ from aiobotocore.session import AioSession
     [('legacy', 'legacy'), ('standard', 'standard'), ('auto', 'standard')],
 )
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_defaults_mode(monkeypatch, defaults_mode, retry_mode):
     monkeypatch.setenv('AWS_DEFAULTS_MODE', defaults_mode)
 

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -26,7 +26,6 @@ def dynamodb_table_def():
 
 @pytest.mark.moto
 @pytest.mark.parametrize('signature_version', ['v4'])
-@pytest.mark.asyncio
 async def test_get_item(dynamodb_client, table_name, dynamodb_put_item):
     test_value = 'testValue'
     await dynamodb_put_item(test_value)
@@ -39,7 +38,6 @@ async def test_get_item(dynamodb_client, table_name, dynamodb_put_item):
 
 @pytest.mark.moto
 @pytest.mark.parametrize('signature_version', ['v4'])
-@pytest.mark.asyncio
 async def test_create_waiter(dynamodb_client, dynamodb_table_def):
     table_name = dynamodb_table_def['TableName']
 
@@ -56,7 +54,6 @@ async def test_create_waiter(dynamodb_client, dynamodb_table_def):
 
 @pytest.mark.moto
 @pytest.mark.parametrize('signature_version', ['v4'])
-@pytest.mark.asyncio
 async def test_batch_write_scan(dynamodb_client, table_name):
     response = await dynamodb_client.batch_write_item(
         RequestItems={
@@ -91,7 +88,6 @@ async def test_batch_write_scan(dynamodb_client, table_name):
 
 @pytest.mark.moto
 @pytest.mark.parametrize('signature_version', ['v4'])
-@pytest.mark.asyncio
 async def test_delete_table(dynamodb_client, dynamodb_table_def):
     table_name = dynamodb_table_def['TableName']
 
@@ -109,7 +105,6 @@ async def test_delete_table(dynamodb_client, dynamodb_table_def):
 
 @pytest.mark.moto
 @pytest.mark.parametrize('signature_version', ['v4'])
-@pytest.mark.asyncio
 async def test_waiter_table_exists_failure(dynamodb_client):
     waiter = dynamodb_client.get_waiter('table_exists')
     with pytest.raises(
@@ -122,7 +117,6 @@ async def test_waiter_table_exists_failure(dynamodb_client):
 
 @pytest.mark.moto
 @pytest.mark.parametrize('signature_version', ['v4'])
-@pytest.mark.asyncio
 async def test_waiter_table_exists(
     event_loop, dynamodb_client, dynamodb_table_def
 ):

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -2,7 +2,6 @@ import pytest
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_ec2_snapshot(ec2_client):
     # TODO: this needs to somehow validate the presigned url sent because moto is not
     volume_response = await ec2_client.create_volume(

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -2,7 +2,6 @@ import pytest
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_invalid_endpoint_url(session, region):
     endpoint_url = 'invalid_url'
     with pytest.raises(ValueError, match=f'Invalid endpoint: {endpoint_url}'):

--- a/tests/test_eventstreams.py
+++ b/tests/test_eventstreams.py
@@ -44,7 +44,6 @@ class FakeStreamReader:
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_eventstream_chunking(s3_client):
     # These are the options passed to the EventStream class
     # during a normal run with botocore.
@@ -75,7 +74,6 @@ async def test_eventstream_chunking(s3_client):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_eventstream_no_iter(s3_client):
     # These are the options passed to the EventStream class
     # during a normal run with botocore.

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -42,7 +42,6 @@ def lambda_handler(event, context):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_run_lambda(iam_client, lambda_client, aws_lambda_zip):
     role_arn = await _get_role_arn(iam_client, 'test-iam-role')
     lambda_response = await lambda_client.create_function(

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -4,7 +4,6 @@ from aiobotocore.session import AioSession
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_monitor_response_received(session: AioSession, s3_client):
     # Basic smoke test to ensure we can talk to s3.
     handler_kwargs = {}

--- a/tests/test_mturk.py
+++ b/tests/test_mturk.py
@@ -1,4 +1,3 @@
-import pytest
 from botocore.stub import ANY, Stubber
 
 _mturk_list_hits_response = {
@@ -21,7 +20,6 @@ _mturk_list_hits_response = {
 # Unfortunately moto does not support mturk yet
 # Also looks like we won't be able to support this (see notes from 1.0.6 release)
 # @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_mturk_stubber(session):
     async with session.create_client(
         'mturk', region_name='us-east-1'

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -36,7 +36,6 @@ async def _tolist(aiter):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_streaming_wrapper_validates_content_length():
     body = AsyncBytesIO(b'1234567890')
     stream = response.StreamingBody(body, content_length=10)
@@ -44,7 +43,6 @@ async def test_streaming_wrapper_validates_content_length():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_streaming_body_with_invalid_length():
     body = AsyncBytesIO(b'123456789')
     stream = response.StreamingBody(body, content_length=10)
@@ -56,7 +54,6 @@ async def test_streaming_body_with_invalid_length():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_streaming_body_with_zero_read():
     body = AsyncBytesIO(b'1234567890')
     stream = response.StreamingBody(body, content_length=10)
@@ -66,7 +63,6 @@ async def test_streaming_body_with_zero_read():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_streaming_body_with_single_read():
     body = AsyncBytesIO(b'123456789')
     stream = response.StreamingBody(body, content_length=10)
@@ -75,7 +71,6 @@ async def test_streaming_body_with_single_read():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_streaming_body_closes():
     body = AsyncBytesIO(b'1234567890')
     stream = response.StreamingBody(body, content_length=10)
@@ -85,7 +80,6 @@ async def test_streaming_body_closes():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_default_iter_behavior():
     body = AsyncBytesIO(b'a' * 2048)
     stream = response.StreamingBody(body, content_length=2048)
@@ -95,7 +89,6 @@ async def test_default_iter_behavior():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_iter_chunks_single_byte():
     body = AsyncBytesIO(b'abcde')
     stream = response.StreamingBody(body, content_length=5)
@@ -104,7 +97,6 @@ async def test_iter_chunks_single_byte():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_iter_chunks_with_leftover():
     body = AsyncBytesIO(b'abcde')
     stream = response.StreamingBody(body, content_length=5)
@@ -113,7 +105,6 @@ async def test_iter_chunks_with_leftover():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_iter_chunks_single_chunk():
     body = AsyncBytesIO(b'abcde')
     stream = response.StreamingBody(body, content_length=5)
@@ -122,7 +113,6 @@ async def test_iter_chunks_single_chunk():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_streaming_line_iterator():
     body = AsyncBytesIO(b'1234567890\n1234567890\n12345')
     stream = response.StreamingBody(body, content_length=27)
@@ -133,7 +123,6 @@ async def test_streaming_line_iterator():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_streaming_line_iterator_ends_newline():
     body = AsyncBytesIO(b'1234567890\n1234567890\n12345\n')
     stream = response.StreamingBody(body, content_length=28)
@@ -144,7 +133,6 @@ async def test_streaming_line_iterator_ends_newline():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_streaming_line_iter_chunk_sizes():
     for chunk_size in range(1, 30):
         body = AsyncBytesIO(b'1234567890\n1234567890\n12345')
@@ -156,7 +144,6 @@ async def test_streaming_line_iter_chunk_sizes():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_streaming_body_is_an_iterator():
     body = AsyncBytesIO(b'a' * 1024 + b'b' * 1024 + b'c' * 2)
     stream = response.StreamingBody(body, content_length=2050)
@@ -168,7 +155,6 @@ async def test_streaming_body_is_an_iterator():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_streaming_line_abstruse_newline_standard():
     for chunk_size in range(1, 30):
         body = AsyncBytesIO(b'1234567890\r\n1234567890\r\n12345\r\n')
@@ -180,7 +166,6 @@ async def test_streaming_line_abstruse_newline_standard():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_streaming_line_empty_body():
     stream = response.StreamingBody(
         AsyncBytesIO(b''),

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -9,7 +9,6 @@ from aiobotocore.session import AioSession
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_get_service_data(session):
     handler_called = False
 
@@ -24,7 +23,6 @@ async def test_get_service_data(session):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_retry(
     session: AioSession, caplog: LogCaptureFixture, monkeypatch
 ):

--- a/tests/test_sns.py
+++ b/tests/test_sns.py
@@ -34,7 +34,6 @@ def _get_topic_policy(topic_arn: str):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_topic_attributes(sns_client, topic_arn):
     response = await sns_client.list_topics()
     pytest.aio.assert_status_code(response, 200)
@@ -57,7 +56,6 @@ async def test_topic_attributes(sns_client, topic_arn):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_creating_subscription(sns_client, topic_arn):
     response = await sns_client.subscribe(
         TopicArn=topic_arn, Protocol="http", Endpoint="http://httpbin.org/"
@@ -72,7 +70,6 @@ async def test_creating_subscription(sns_client, topic_arn):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_publish_to_http(sns_client, topic_arn):
     response = await sns_client.subscribe(
         TopicArn=topic_arn,
@@ -91,14 +88,12 @@ async def test_publish_to_http(sns_client, topic_arn):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_get_missing_endpoint_attributes(sns_client):
     with pytest.raises(botocore.exceptions.ClientError):
         await sns_client.get_endpoint_attributes(EndpointArn="arn1")
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_platform_applications(sns_client):
     await sns_client.create_platform_application(
         Name="app1",

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -4,7 +4,6 @@ import pytest
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_list_queues(sqs_client, sqs_queue_url):
     response = await sqs_client.list_queues()
     pytest.aio.assert_status_code(response, 200)
@@ -13,7 +12,6 @@ async def test_list_queues(sqs_client, sqs_queue_url):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_get_queue_name(sqs_client, sqs_queue_url):
     queue_name = sqs_queue_url.rsplit('/', 1)[-1]
 
@@ -24,7 +22,6 @@ async def test_get_queue_name(sqs_client, sqs_queue_url):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_put_pull_delete_test(sqs_client, sqs_queue_url):
     response = await sqs_client.send_message(
         QueueUrl=sqs_queue_url,
@@ -59,7 +56,6 @@ async def test_put_pull_delete_test(sqs_client, sqs_queue_url):
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_put_pull_wait(sqs_client, sqs_queue_url):
     start = time.perf_counter()
     response = await sqs_client.receive_message(

--- a/tests/test_stubber.py
+++ b/tests/test_stubber.py
@@ -8,7 +8,6 @@ from .mock_server import AIOServer
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_add_response():
     session = AioSession()
 
@@ -37,7 +36,6 @@ async def test_add_response():
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_add_client_error():
     session = AioSession()
 

--- a/tests/test_waiter.py
+++ b/tests/test_waiter.py
@@ -29,7 +29,6 @@ def test_create_waiter_with_client(
 
 
 @pytest.mark.moto
-@pytest.mark.asyncio
 async def test_sqs(cloudformation_client):
     cloudformation_template = """{
       "AWSTemplateFormatVersion": "2010-09-09",


### PR DESCRIPTION
### Description of Change
Removes `@pytest.mark.asyncio`decorators from test functions, in line with [pytest-asyncio recommendation](https://pytest-asyncio.readthedocs.io/en/latest/concepts.html#auto-mode).

Cherry picked from @thehesiod: https://github.com/aio-libs/aiobotocore/pull/1232/commits/f7a2f752d62f694d7984ea3235ac1f73801dbf85

### Assumptions
*Replace this text with any assumptions made (if any)*

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
