### PR TITLE
consolidate documentation on running tests

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -31,7 +31,25 @@ Install pre-commit hooks::
 
     $ pre-commit install
 
-Congratulations, you are ready to run the test suite::
+Congratulations, you are ready to run the test suite.
+
+There are two set of tests, those that can be mocked through `moto <https://github.com/getmoto/moto>`_ running in docker, and those that require running against a personal amazon key. The CI only runs the moto tests.
+
+To run the moto tests::
+
+    $ make mototest
+
+To run the non-moto tests, make sure you have your amazon key and secret accessible via environment variables::
+
+    $ export AWS_ACCESS_KEY_ID=xxx
+    $ export AWS_SECRET_ACCESS_KEY=xxx
+    $ export AWS_DEFAULT_REGION=xxx # e.g. us-west-2
+
+Execute full tests suite::
+
+    $ make test
+
+Execute full tests suite with coverage::
 
     $ make cov
 

--- a/README.rst
+++ b/README.rst
@@ -163,39 +163,6 @@ stick ``await`` in front of methods to make them async, e.g. ``await client.list
 
 If a service is not listed here and you could do with some tests or examples feel free to raise an issue.
 
-Run Tests
----------
-
-There are two set of tests, those that can be mocked through `moto <https://github.com/getmoto/moto>`_ running in docker, and those that require running against a personal amazon key. The CI only runs the moto tests.
-
-To run the moto tests:
-
-::
-
-    $ make mototest
-
-To run the non-moto tests:
-
-Make sure you have development requirements installed and your amazon key and
-secret accessible via environment variables:
-
-::
-
-    $ pip install pip-tools
-    $ pip-compile --all-extras pyproject.toml
-    $ pip-sync
-    $ pip install -e ".[awscli,boto3]"
-    $ export AWS_ACCESS_KEY_ID=xxx
-    $ export AWS_SECRET_ACCESS_KEY=xxx
-    $ export AWS_DEFAULT_REGION=xxx # e.g. us-west-2
-
-Execute tests suite:
-
-::
-
-    $ make test
-
-
 
 Enable type checking and code completion
 ----------------------------------------


### PR DESCRIPTION
### Description of Change
Consolidate documentation on running tests.

### Assumptions
Documentation on running tests should be moved from README.rst (and PyPI page) to CONTRIBUTING.rst.

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [x] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details): closes #1247
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
