### PR TITLE
Relax `botocore` dependency specification

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes
 
 2.17.0 (2025-01-06)
 ^^^^^^^^^^^^^^^^^^^
+* relax botocore dependency specification
 * add missing dependencies `python-dateutil`, `jmespath`, `multidict`, and `urllib3`
 
 2.16.1 (2024-12-26)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dynamic = ["version", "readme"]
 dependencies = [
     "aiohttp >= 3.9.2, < 4.0.0",
     "aioitertools >= 0.5.1, < 1.0.0",
-    "botocore >= 1.35.74, < 1.35.89", # NOTE: When updating, always keep `project.optional-dependencies` aligned
+    "botocore >= 1.35.74, < 1.35.94", # NOTE: When updating, always keep `project.optional-dependencies` aligned
     "python-dateutil >= 2.1, < 3.0.0",
     "jmespath >= 0.7.1, < 2.0.0",
     "multidict >= 6.0.0, < 7.0.0",
@@ -43,10 +43,10 @@ dependencies = [
 
 [project.optional-dependencies]
 awscli = [
-    "awscli >= 1.36.15, < 1.36.30",
+    "awscli >= 1.36.15, < 1.36.35",
 ]
 boto3 = [
-    "boto3 >= 1.35.74, < 1.35.89",
+    "boto3 >= 1.35.74, < 1.35.94",
 ]
 
 [project.urls]


### PR DESCRIPTION
### Description of Change
This PR intends to improve general compatibility of `aiobotocore` within the Python ecosystem by relaxing the dependency specification of `botocore`, as well as `boto3` and `awscli`.

### Assumptions
[Upstream diff](https://github.com/boto/botocore/compare/1.35.88..1.35.93) contains no changes that require adjustments to the aiobotocore codebase.

### Checklist for All Submissions
* [x] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [x] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [x] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [x] I have ensured that the awscli/boto3 versions match the updated botocore version
