### PR TITLE
Use `list_objects_v2` in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ Basic Example
                 assert await stream.read() == data
 
             # list s3 objects using paginator
-            paginator = client.get_paginator('list_objects')
+            paginator = client.get_paginator('list_objects_v2')
             async for result in paginator.paginate(Bucket=bucket, Prefix=folder):
                 for c in result.get('Contents', []):
                     print(c)


### PR DESCRIPTION
### Description of Change

- Updates README documentation to use `list_objects_v2` instead of `list_objects` since that is what the AWS documentation recommends (and `list_objects_v2` supports automatic pagination with the `client.get_paginator` function used in the sample). Should I add a comment or anything in the readme?
- `list_objects` [documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html) recommends to use `list_objects_v2` [documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html)


### Assumptions

- none

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
  - Do you want me to add something to the change list for a documentation change?
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [x] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [x] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [x] I have ensured that the awscli/boto3 versions match the updated botocore version
