### PR TITLE
run tests on `ubuntu-24.04` and `ubuntu-24.04-arm` CI runners

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -41,6 +41,7 @@ jobs:
   test:
     name: Test Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         python-version:
@@ -54,6 +55,10 @@ jobs:
         os:
         - ubuntu-24.04
         - ubuntu-24.04-arm
+        include:
+        - experimental: false
+        - experimental: true
+          os: ubuntu-24.04-arm  # deal with flaky runners
       fail-fast: false
     env:
       UV_FROZEN: 1

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -59,6 +59,10 @@ jobs:
         - experimental: false
         - experimental: true
           os: ubuntu-24.04-arm  # deal with flaky runners
+        - upload-coverage: false
+        - upload-coverage: true
+          python-version: 3.11
+          os: ubuntu-24.04
       fail-fast: false
     env:
       UV_FROZEN: 1
@@ -82,7 +86,7 @@ jobs:
       run: |
         uv run make mototest
     - name: Upload coverage to Codecov
-      if: matrix.python-version == '3.11' && matrix.os == 'ubuntu-24.04'
+      if: ${{ matrix.upload-coverage }}
       uses: codecov/codecov-action@v5.3.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}  # not required for public repos

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -39,8 +39,8 @@ jobs:
         path: dist/
 
   test:
-    name: Test Python ${{ matrix.python-version }}
-    runs-on: ubuntu-24.04
+    name: Test Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version:
@@ -51,6 +51,9 @@ jobs:
         - 3.11
         - 3.12
         - 3.13
+        os:
+        - ubuntu-24.04
+        - ubuntu-24.04-arm
       fail-fast: false
     env:
       UV_FROZEN: 1
@@ -74,7 +77,7 @@ jobs:
       run: |
         uv run make mototest
     - name: Upload coverage to Codecov
-      if: matrix.python-version == '3.11'
+      if: matrix.python-version == '3.11' && matrix.os == 'ubuntu-24.04'
       uses: codecov/codecov-action@v5.3.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}  # not required for public repos


### PR DESCRIPTION
### Description of Change
* Run tests on `ubuntu-24.04` and `ubuntu-24.04-arm` CI runners
* Leverage matrix job definition to trigger upload of coverage results to codecov

### Assumptions
CI on arm64 runners is currently flaky and is considered experimental. Such transient failures are not expected to affect the status of the CI run.

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [x] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details): closes #1264 
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
