### PR TITLE
Avoid pulling outdated container images in `mototest` make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,6 @@ cov cover coverage: pre-commit
 	@echo "open file://`pwd`/htmlcov/index.html"
 
 mototest:
-	docker pull alpine
-	docker pull lambci/lambda:python3.8
 	python -Wd -X tracemalloc=5 -X faulthandler -m pytest -vv -m "not localonly" -n auto --cov-report term --cov-report html --cov-report xml --cov=aiobotocore --cov=tests --log-cli-level=DEBUG $(FLAGS) aiobotocore tests
 	@echo "open file://`pwd`/htmlcov/index.html"
 


### PR DESCRIPTION
### Description of Change
Avoid pulling outdated container images in `mototest` make target

### Assumptions
We aim to use default images "for recent versions" as [documented by moto](https://docs.getmoto.org/en/latest/docs/services/lambda.html).

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [x] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details): closes #1267
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
