### PR TITLE
trim usage of the old Python 2 vs 3 helper

### DIFF
--- a/aiobotocore/credentials.py
+++ b/aiobotocore/credentials.py
@@ -7,7 +7,6 @@ import subprocess
 from copy import deepcopy
 from hashlib import sha1
 
-import botocore.compat
 from botocore import UNSIGNED
 from botocore.compat import compat_shell_split
 from botocore.config import Config
@@ -517,7 +516,7 @@ class AioProcessProvider(ProcessProvider):
             raise CredentialRetrievalError(
                 provider=self.METHOD, error_msg=stderr.decode('utf-8')
             )
-        parsed = botocore.compat.json.loads(stdout.decode('utf-8'))
+        parsed = json.loads(stdout.decode('utf-8'))
         version = parsed.get('Version', '<Version key not provided>')
         if version != 1:
             raise CredentialRetrievalError(

--- a/aiobotocore/tokens.py
+++ b/aiobotocore/tokens.py
@@ -3,7 +3,6 @@ import logging
 from datetime import timedelta
 
 import dateutil.parser
-from botocore.compat import total_seconds
 from botocore.exceptions import ClientError, TokenRetrievalError
 from botocore.tokens import (
     DeferredRefreshableToken,
@@ -118,7 +117,7 @@ class AioSSOTokenProvider(SSOTokenProvider):
             return None
 
         expiry = dateutil.parser.parse(token["registrationExpiresAt"])
-        if total_seconds(expiry - self._now()) <= 0:
+        if (expiry - self._now()).total_seconds() <= 0:
             logger.info(f"SSO token registration expired at {expiry}")
             return None
 
@@ -136,7 +135,7 @@ class AioSSOTokenProvider(SSOTokenProvider):
         expiration = dateutil.parser.parse(token_dict["expiresAt"])
         logger.debug(f"Cached SSO token expires at {expiration}")
 
-        remaining = total_seconds(expiration - self._now())
+        remaining = (expiration - self._now()).total_seconds()
         if remaining < self._REFRESH_WINDOW:
             new_token_dict = await self._refresh_access_token(token_dict)
             if new_token_dict is not None:

--- a/tests/boto_tests/__init__.py
+++ b/tests/boto_tests/__init__.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from botocore.compat import parse_qs, urlparse
+from urllib.parse import parse_qs, urlparse
 
 
 def _urlparse(url):


### PR DESCRIPTION
botocore only supports Python 3 anyway.

https://github.com/boto/botocore/blob/develop/botocore/compat.py

This showed up while doing an audit with 'Debian Code Search'

https://codesearch.debian.net/search?q=botocore.compat&literal=1&perpkg=1

https://wiki.debian.org/Python3-six-removal