### PR TITLE
Bump `botocore` dependency specification

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 2.20.0 (2025-02-13)
 ^^^^^^^^^^^^^^^^^^^
 * patch `AwsChunkedWrapper.read`
-* relax botocore dependency specification
+* bump botocore dependency specification
 
 2.19.0 (2025-01-22)
 ^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 2.20.0 (2025-02-13)
 ^^^^^^^^^^^^^^^^^^^
 * patch `AwsChunkedWrapper.read`
+* relax botocore dependency specification
 
 2.19.0 (2025-01-22)
 ^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changes
 -------
 
-2.20.0 (2025-02-13)
+2.20.0 (2025-02-19)
 ^^^^^^^^^^^^^^^^^^^
 * patch `AwsChunkedWrapper.read`
 * bump botocore dependency specification

--- a/aiobotocore/httpchecksum.py
+++ b/aiobotocore/httpchecksum.py
@@ -213,6 +213,12 @@ def _apply_request_trailer_checksum(request):
         # services such as S3 may require the decoded content length
         headers["X-Amz-Decoded-Content-Length"] = str(content_length)
 
+        if "Content-Length" in headers:
+            del headers["Content-Length"]
+            logger.debug(
+                "Removing the Content-Length header since 'chunked' is specified for Transfer-Encoding."
+            )
+
     if isinstance(body, (bytes, bytearray)):
         body = io.BytesIO(body)
 

--- a/aiobotocore/httpchecksum.py
+++ b/aiobotocore/httpchecksum.py
@@ -6,6 +6,7 @@ from botocore.httpchecksum import (
     FlexibleChecksumError,
     _apply_request_header_checksum,
     base64,
+    conditionally_calculate_md5,
     determine_content_length,
     logger,
 )
@@ -169,7 +170,10 @@ def apply_request_checksum(request):
     if not algorithm:
         return
 
-    if algorithm["in"] == "header":
+    if algorithm == "conditional-md5":
+        # Special case to handle the http checksum required trait
+        conditionally_calculate_md5(request)
+    elif algorithm["in"] == "header":
         _apply_request_header_checksum(request)
     elif algorithm["in"] == "trailer":
         _apply_request_trailer_checksum(request)

--- a/aiobotocore/httpchecksum.py
+++ b/aiobotocore/httpchecksum.py
@@ -129,7 +129,7 @@ async def handle_checksum_body(
         response["context"]["checksum"] = checksum_context
         return
 
-    logger.info(
+    logger.debug(
         f'Skipping checksum validation. Response did not contain one of the '
         f'following algorithms: {algorithms}.'
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dynamic = ["version", "readme"]
 dependencies = [
     "aiohttp >= 3.9.2, < 4.0.0",
     "aioitertools >= 0.5.1, < 1.0.0",
-    "botocore >= 1.36.0, < 1.36.11", # NOTE: When updating, always keep `project.optional-dependencies` aligned
+    "botocore >= 1.36.11, < 1.36.18", # NOTE: When updating, always keep `project.optional-dependencies` aligned
     "python-dateutil >= 2.1, < 3.0.0",
     "jmespath >= 0.7.1, < 2.0.0",
     "multidict >= 6.0.0, < 7.0.0",
@@ -43,10 +43,10 @@ dependencies = [
 
 [project.optional-dependencies]
 awscli = [
-    "awscli >= 1.37.0, < 1.37.11",
+    "awscli >= 1.37.11, < 1.37.18",
 ]
 boto3 = [
-    "boto3 >= 1.36.0, < 1.36.11",
+    "boto3 >= 1.36.11, < 1.36.18",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dynamic = ["version", "readme"]
 dependencies = [
     "aiohttp >= 3.9.2, < 4.0.0",
     "aioitertools >= 0.5.1, < 1.0.0",
-    "botocore >= 1.36.18, < 1.36.20", # NOTE: When updating, always keep `project.optional-dependencies` aligned
+    "botocore >= 1.36.20, < 1.36.24", # NOTE: When updating, always keep `project.optional-dependencies` aligned
     "python-dateutil >= 2.1, < 3.0.0",
     "jmespath >= 0.7.1, < 2.0.0",
     "multidict >= 6.0.0, < 7.0.0",
@@ -43,10 +43,10 @@ dependencies = [
 
 [project.optional-dependencies]
 awscli = [
-    "awscli >= 1.37.18, < 1.37.20",
+    "awscli >= 1.37.20, < 1.37.24",
 ]
 boto3 = [
-    "boto3 >= 1.36.18, < 1.36.20",
+    "boto3 >= 1.36.20, < 1.36.24",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dynamic = ["version", "readme"]
 dependencies = [
     "aiohttp >= 3.9.2, < 4.0.0",
     "aioitertools >= 0.5.1, < 1.0.0",
-    "botocore >= 1.36.0, < 1.36.4", # NOTE: When updating, always keep `project.optional-dependencies` aligned
+    "botocore >= 1.36.0, < 1.36.11", # NOTE: When updating, always keep `project.optional-dependencies` aligned
     "python-dateutil >= 2.1, < 3.0.0",
     "jmespath >= 0.7.1, < 2.0.0",
     "multidict >= 6.0.0, < 7.0.0",
@@ -43,10 +43,10 @@ dependencies = [
 
 [project.optional-dependencies]
 awscli = [
-    "awscli >= 1.37.0, < 1.37.4",
+    "awscli >= 1.37.0, < 1.37.11",
 ]
 boto3 = [
-    "boto3 >= 1.36.0, < 1.36.4",
+    "boto3 >= 1.36.0, < 1.36.11",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dynamic = ["version", "readme"]
 dependencies = [
     "aiohttp >= 3.9.2, < 4.0.0",
     "aioitertools >= 0.5.1, < 1.0.0",
-    "botocore >= 1.36.11, < 1.36.18", # NOTE: When updating, always keep `project.optional-dependencies` aligned
+    "botocore >= 1.36.18, < 1.36.20", # NOTE: When updating, always keep `project.optional-dependencies` aligned
     "python-dateutil >= 2.1, < 3.0.0",
     "jmespath >= 0.7.1, < 2.0.0",
     "multidict >= 6.0.0, < 7.0.0",
@@ -43,10 +43,10 @@ dependencies = [
 
 [project.optional-dependencies]
 awscli = [
-    "awscli >= 1.37.11, < 1.37.18",
+    "awscli >= 1.37.18, < 1.37.20",
 ]
 boto3 = [
-    "boto3 >= 1.36.11, < 1.36.18",
+    "boto3 >= 1.36.18, < 1.36.20",
 ]
 
 [project.urls]

--- a/tests/boto_tests/unit/test_eventstream.py
+++ b/tests/boto_tests/unit/test_eventstream.py
@@ -23,7 +23,6 @@ from botocore.eventstream import (
     EventStreamHeaderParser,
     EventStreamMessage,
     InvalidHeadersLength,
-    InvalidPayloadLength,
     MessagePrelude,
     NoInitialResponseError,
 )
@@ -262,17 +261,6 @@ INVALID_HEADERS_LENGTH = (
     InvalidHeadersLength,
 )
 
-# In contrast to the CORRUPTED_PAYLOAD case, this message is otherwise
-# well-formed - the checksums match.
-INVALID_PAYLOAD_LENGTH = (
-    b"\x01\x00\x00\x11"  # total length
-    + b"\x00\x00\x00\x00"  # headers length
-    + b"\xf4\x08\x61\xc5"  # prelude crc
-    + b"0" * (16 * 1024**2 + 1)  # payload
-    + b"\x2a\xb4\xc5\xa5",  # message crc
-    InvalidPayloadLength,
-)
-
 # Tuples of encoded messages and their expected exception
 NEGATIVE_CASES = [
     CORRUPTED_LENGTH,
@@ -281,7 +269,6 @@ NEGATIVE_CASES = [
     CORRUPTED_HEADER_LENGTH,
     DUPLICATE_HEADER,
     INVALID_HEADERS_LENGTH,
-    INVALID_PAYLOAD_LENGTH,
 ]
 
 
@@ -349,7 +336,6 @@ def test_all_positive_cases():
         "corrupted-headers-length",
         "duplicate-headers",
         "invalid-headers-length",
-        "invalid-payload-length",
     ],
 )
 def test_negative_cases(encoded, exception):

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -717,7 +717,7 @@ _API_DIGESTS = {
     },
     AwsChunkedWrapper.__iter__: {'261e26d1061655555fe3dcb2689d963e43f80fb0'},
     apply_request_checksum: {
-        '94f2d201a07a3831fd55d8ca2f2d75cdb06a9514',
+        '6d904d118cd9d768935e38a60a73a46c67a8d440',
     },
     _apply_request_trailer_checksum: {
         '45f483dd8520bf67616a063bdf6386865aad3591',

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -696,8 +696,7 @@ _API_DIGESTS = {
     AWSResponse.text: {'a724100ba9f6d51b333b8fe470fac46376d5044a'},
     # httpchecksum.py
     handle_checksum_body: {
-        '898cee7a7a5e5a02af7e0e65dcbb8122257b85df',
-        '6f15cc120818413e89aac088d130c729ba3d422c',
+        '040cb48d8ebfb5ca195d41deb55b38d1fcb489f8',
     },
     _handle_streaming_response: {
         '7ce971e012f9d4b04889f0af83f67281ed6a9e6e',

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -721,7 +721,7 @@ _API_DIGESTS = {
         '94f2d201a07a3831fd55d8ca2f2d75cdb06a9514',
     },
     _apply_request_trailer_checksum: {
-        '28cdf19282be7cd2c99a734831ec4f489648bcc7'
+        '45f483dd8520bf67616a063bdf6386865aad3591',
     },
     # retryhandler.py
     retryhandler.create_retry_handler: {

--- a/uv.lock
+++ b/uv.lock
@@ -58,9 +58,9 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.2,<4.0.0" },
     { name = "aioitertools", specifier = ">=0.5.1,<1.0.0" },
-    { name = "awscli", marker = "extra == 'awscli'", specifier = ">=1.37.18,<1.37.20" },
-    { name = "boto3", marker = "extra == 'boto3'", specifier = ">=1.36.18,<1.36.20" },
-    { name = "botocore", specifier = ">=1.36.18,<1.36.20" },
+    { name = "awscli", marker = "extra == 'awscli'", specifier = ">=1.37.20,<1.37.24" },
+    { name = "boto3", marker = "extra == 'boto3'", specifier = ">=1.36.20,<1.36.24" },
+    { name = "botocore", specifier = ">=1.36.20,<1.36.24" },
     { name = "jmespath", specifier = ">=0.7.1,<2.0.0" },
     { name = "multidict", specifier = ">=6.0.0,<7.0.0" },
     { name = "python-dateutil", specifier = ">=2.1,<3.0.0" },
@@ -440,7 +440,7 @@ wheels = [
 
 [[package]]
 name = "awscli"
-version = "1.37.19"
+version = "1.37.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
@@ -450,9 +450,9 @@ dependencies = [
     { name = "rsa" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/9f/9b0036fdb7eb26b9298e944853666844bd8c803c14f932c7dc8d36639976/awscli-1.37.19.tar.gz", hash = "sha256:77099f913ab79aef7f4cb031a1e58d26b28ee603410011bce2fa7e28e71fa97c", size = 1867277 }
+sdist = { url = "https://files.pythonhosted.org/packages/62/ed/2718031653856b0ccc2470d79cf52326586946b6cc5cffe970d196d80fd6/awscli-1.37.23.tar.gz", hash = "sha256:721c5e38f087a0366e56a5927c6382687f41e8118a18644b1346feab6125d859", size = 1867415 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/32/39812605dc0688dbf2df45f07c8b41ae7efb36a5694e309a00869dd06fe4/awscli-1.37.19-py3-none-any.whl", hash = "sha256:788ab479247ac436efe7831a1bee2c5324cd4ed22818753b9cb8436d20216776", size = 4625854 },
+    { url = "https://files.pythonhosted.org/packages/4a/b5/a15d45a6e2f53a237878e90b16af1a10a82db5fd3af633c426b134319219/awscli-1.37.23-py3-none-any.whl", hash = "sha256:f4d517b6f650aa0839fb23d01d5d7ccf849f092777def91bd70a987fe52682ec", size = 4625856 },
 ]
 
 [[package]]
@@ -482,21 +482,21 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.36.19"
+version = "1.36.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/2a/d0cd75ce8ab6cb475b2dd7b087e81ead98a42f4566f063a614960a339da3/boto3-1.36.19.tar.gz", hash = "sha256:8c2c2a4ccdfe35dd2611ee1b7473dd2383948415c777e42dc4e7f1ebe371fe8c", size = 111034 }
+sdist = { url = "https://files.pythonhosted.org/packages/05/54/a91d274f50bbe8fbd16ecea8bfd60249d0dc1ca50874e3a06119c6e5723a/boto3-1.36.23.tar.gz", hash = "sha256:006800604c34382873521b20890b758eea7109d699696ece932131259d0a4658", size = 111094 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/49/3224349561611ffa2e636e4fa07e87d90d1447c5c5517d1656f7a2a98a38/boto3-1.36.19-py3-none-any.whl", hash = "sha256:7784590369a9d545bb07b2de56b6ce4d5a5e232883a957f704c3f842caeba155", size = 139178 },
+    { url = "https://files.pythonhosted.org/packages/e8/b5/2217a8ebb59bbc5f28dc10d3184b1f7e238f1929d211e69298421f912411/boto3-1.36.23-py3-none-any.whl", hash = "sha256:d59642672b1f35f55f47b317693241ce53333816f47c9e72fcc8fd0e9adc6a87", size = 139179 },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.36.19"
+version = "1.36.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
@@ -504,9 +504,9 @@ dependencies = [
     { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "urllib3", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/75/6f/d708853ddb391a05b5288b107e9113fcfb7fdd23521b939470c4857b8177/botocore-1.36.19.tar.gz", hash = "sha256:cdf6729f601f82b1acdb9004b1f88b57cfb470f576394cdb3bbf5150f7fafb5b", size = 13519297 }
+sdist = { url = "https://files.pythonhosted.org/packages/25/d4/e93bcf4f825faa25c2ff27b653cd9e976226df527445f8c414198020c967/botocore-1.36.23.tar.gz", hash = "sha256:9feaa2d876f487e718a5fd80a35fa401042b518c0c75117d3e1ea39a567439e7", size = 13571101 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/42/ce1204fd8229ae5779fbfe53c787a6a72e23263250579017e280ce9d7aff/botocore-1.36.19-py3-none-any.whl", hash = "sha256:98882c106fec4c08678ea028199f7f5119550fab95d682b30846f7aae04b7bec", size = 13344643 },
+    { url = "https://files.pythonhosted.org/packages/7c/93/a566604998182dd354aa6bab3c5b0393077a2ce4b97e18713d94c362da06/botocore-1.36.23-py3-none-any.whl", hash = "sha256:886730e79495a2e153842725ebdf85185c8277cdf255b3b5879cd097ddc7fcc3", size = 13355279 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -58,9 +58,9 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.2,<4.0.0" },
     { name = "aioitertools", specifier = ">=0.5.1,<1.0.0" },
-    { name = "awscli", marker = "extra == 'awscli'", specifier = ">=1.37.0,<1.37.11" },
-    { name = "boto3", marker = "extra == 'boto3'", specifier = ">=1.36.0,<1.36.11" },
-    { name = "botocore", specifier = ">=1.36.0,<1.36.11" },
+    { name = "awscli", marker = "extra == 'awscli'", specifier = ">=1.37.11,<1.37.18" },
+    { name = "boto3", marker = "extra == 'boto3'", specifier = ">=1.36.11,<1.36.18" },
+    { name = "botocore", specifier = ">=1.36.11,<1.36.18" },
     { name = "jmespath", specifier = ">=0.7.1,<2.0.0" },
     { name = "multidict", specifier = ">=6.0.0,<7.0.0" },
     { name = "python-dateutil", specifier = ">=2.1,<3.0.0" },
@@ -440,7 +440,7 @@ wheels = [
 
 [[package]]
 name = "awscli"
-version = "1.37.10"
+version = "1.37.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
@@ -450,9 +450,9 @@ dependencies = [
     { name = "rsa" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/65/356179ff8b1770f9b0052436ac2390e07ae3f2fbd8a83d137c371dac9cbf/awscli-1.37.10.tar.gz", hash = "sha256:e5bbfbcbadc866a52e1e02b87b6148a5a98aa62a71cbf29aca6aec2abad9ef17", size = 1864554 }
+sdist = { url = "https://files.pythonhosted.org/packages/71/a7/c11fb1c83458b4a890b4d38e58ec39ba0a292705d9101df8010413625ef0/awscli-1.37.17.tar.gz", hash = "sha256:5def81fb4972af98623112e4fdcf15d7170523f4fc0f54d67737ef8a7298547c", size = 1867303 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/dc/0ed065c2c23cde4f94f12f50006dfdbe4e10f73f7ef1ddb32bfc079c3bb8/awscli-1.37.10-py3-none-any.whl", hash = "sha256:0cdb766c94e9dd44dd05fb4959cd5e94ff4db41885ae431494a3dac85efa3ee6", size = 4609860 },
+    { url = "https://files.pythonhosted.org/packages/14/80/c8ac48893441e7d37046d6129b1aef2ef16edd2ad4cb0b9e25900db55776/awscli-1.37.17-py3-none-any.whl", hash = "sha256:7c8b5ced9aa6810f74391b43a1076901c9780df68c97a34e11b2d593259f55d6", size = 4625850 },
 ]
 
 [[package]]
@@ -482,21 +482,21 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.36.10"
+version = "1.36.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/16/af/e41306c8fe705f19436b5339b23edcc6c4388b548c79fdd21cc120f61899/boto3-1.36.10.tar.gz", hash = "sha256:d2f1010db699326b26fbd465d91c4b49177c9d995d7e72c0f31335f139efa0d2", size = 111006 }
+sdist = { url = "https://files.pythonhosted.org/packages/10/21/906f0d797ab4678fadccf7d0dbc897fa3deca1c8e8e30f7932920345bf0a/boto3-1.36.17.tar.gz", hash = "sha256:5ecae20e780a3ce9afb3add532b61c466a8cb8960618e4fa565b3883064c1346", size = 110976 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/3b/7a169cf550531dd89aa702a38313185af30aef685f058cf6f56e840d2eb4/boto3-1.36.10-py3-none-any.whl", hash = "sha256:5f8d5c2024a2d1411d3d67abb7357ec7d4c6162e3f1c396dc9b79d042cfd0a80", size = 139177 },
+    { url = "https://files.pythonhosted.org/packages/f0/2d/b599c7cdeb774aa227ea602c7a3216127318add8f887b59352b899cc7576/boto3-1.36.17-py3-none-any.whl", hash = "sha256:59bcf0c4b04d9cc36f8b418ad17ab3c4a99a21a175d2fad7096aa21cbe84630b", size = 139178 },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.36.10"
+version = "1.36.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
@@ -504,9 +504,9 @@ dependencies = [
     { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "urllib3", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/da/8d21e15a1366a076c54529059c45c66943c217f1eadea5eb36791274d8d0/botocore-1.36.10.tar.gz", hash = "sha256:d27bb73f0ea81395527a6298ac0a7ea5b2958094169f7cf7d48e3f4e4bc21b65", size = 13495786 }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/42/76ed22d63f91eb8b7bf0a68f653b75a5a9909cac0616cd53797d6a8073be/botocore-1.36.17.tar.gz", hash = "sha256:cec13e0a7ce78e71aad0b397581b4e81824c7981ef4c261d2e296d200c399b09", size = 13514828 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/84/b038ec69154135a46267d96eb6ddbebe8e6775f18e1e827700b3e30f4170/botocore-1.36.10-py3-none-any.whl", hash = "sha256:45c8a6e01dc18d44a13ba688f1d60ad562db8154b08c46b412387ea040a741c2", size = 13325134 },
+    { url = "https://files.pythonhosted.org/packages/fa/f1/dac56ef12a14fac9dd16dc20d99644d84d03b886ade1d9d21fb6b0ad05e9/botocore-1.36.17-py3-none-any.whl", hash = "sha256:069858b2fd693548035d7fd53a774e37e4260fea64e0ac9b8a3aee904f9321df", size = 13341585 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -58,9 +58,9 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.2,<4.0.0" },
     { name = "aioitertools", specifier = ">=0.5.1,<1.0.0" },
-    { name = "awscli", marker = "extra == 'awscli'", specifier = ">=1.37.11,<1.37.18" },
-    { name = "boto3", marker = "extra == 'boto3'", specifier = ">=1.36.11,<1.36.18" },
-    { name = "botocore", specifier = ">=1.36.11,<1.36.18" },
+    { name = "awscli", marker = "extra == 'awscli'", specifier = ">=1.37.18,<1.37.20" },
+    { name = "boto3", marker = "extra == 'boto3'", specifier = ">=1.36.18,<1.36.20" },
+    { name = "botocore", specifier = ">=1.36.18,<1.36.20" },
     { name = "jmespath", specifier = ">=0.7.1,<2.0.0" },
     { name = "multidict", specifier = ">=6.0.0,<7.0.0" },
     { name = "python-dateutil", specifier = ">=2.1,<3.0.0" },
@@ -440,7 +440,7 @@ wheels = [
 
 [[package]]
 name = "awscli"
-version = "1.37.17"
+version = "1.37.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
@@ -450,9 +450,9 @@ dependencies = [
     { name = "rsa" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/a7/c11fb1c83458b4a890b4d38e58ec39ba0a292705d9101df8010413625ef0/awscli-1.37.17.tar.gz", hash = "sha256:5def81fb4972af98623112e4fdcf15d7170523f4fc0f54d67737ef8a7298547c", size = 1867303 }
+sdist = { url = "https://files.pythonhosted.org/packages/17/9f/9b0036fdb7eb26b9298e944853666844bd8c803c14f932c7dc8d36639976/awscli-1.37.19.tar.gz", hash = "sha256:77099f913ab79aef7f4cb031a1e58d26b28ee603410011bce2fa7e28e71fa97c", size = 1867277 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/80/c8ac48893441e7d37046d6129b1aef2ef16edd2ad4cb0b9e25900db55776/awscli-1.37.17-py3-none-any.whl", hash = "sha256:7c8b5ced9aa6810f74391b43a1076901c9780df68c97a34e11b2d593259f55d6", size = 4625850 },
+    { url = "https://files.pythonhosted.org/packages/62/32/39812605dc0688dbf2df45f07c8b41ae7efb36a5694e309a00869dd06fe4/awscli-1.37.19-py3-none-any.whl", hash = "sha256:788ab479247ac436efe7831a1bee2c5324cd4ed22818753b9cb8436d20216776", size = 4625854 },
 ]
 
 [[package]]
@@ -482,21 +482,21 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.36.17"
+version = "1.36.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/21/906f0d797ab4678fadccf7d0dbc897fa3deca1c8e8e30f7932920345bf0a/boto3-1.36.17.tar.gz", hash = "sha256:5ecae20e780a3ce9afb3add532b61c466a8cb8960618e4fa565b3883064c1346", size = 110976 }
+sdist = { url = "https://files.pythonhosted.org/packages/77/2a/d0cd75ce8ab6cb475b2dd7b087e81ead98a42f4566f063a614960a339da3/boto3-1.36.19.tar.gz", hash = "sha256:8c2c2a4ccdfe35dd2611ee1b7473dd2383948415c777e42dc4e7f1ebe371fe8c", size = 111034 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/2d/b599c7cdeb774aa227ea602c7a3216127318add8f887b59352b899cc7576/boto3-1.36.17-py3-none-any.whl", hash = "sha256:59bcf0c4b04d9cc36f8b418ad17ab3c4a99a21a175d2fad7096aa21cbe84630b", size = 139178 },
+    { url = "https://files.pythonhosted.org/packages/e6/49/3224349561611ffa2e636e4fa07e87d90d1447c5c5517d1656f7a2a98a38/boto3-1.36.19-py3-none-any.whl", hash = "sha256:7784590369a9d545bb07b2de56b6ce4d5a5e232883a957f704c3f842caeba155", size = 139178 },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.36.17"
+version = "1.36.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
@@ -504,9 +504,9 @@ dependencies = [
     { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "urllib3", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/42/76ed22d63f91eb8b7bf0a68f653b75a5a9909cac0616cd53797d6a8073be/botocore-1.36.17.tar.gz", hash = "sha256:cec13e0a7ce78e71aad0b397581b4e81824c7981ef4c261d2e296d200c399b09", size = 13514828 }
+sdist = { url = "https://files.pythonhosted.org/packages/75/6f/d708853ddb391a05b5288b107e9113fcfb7fdd23521b939470c4857b8177/botocore-1.36.19.tar.gz", hash = "sha256:cdf6729f601f82b1acdb9004b1f88b57cfb470f576394cdb3bbf5150f7fafb5b", size = 13519297 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/f1/dac56ef12a14fac9dd16dc20d99644d84d03b886ade1d9d21fb6b0ad05e9/botocore-1.36.17-py3-none-any.whl", hash = "sha256:069858b2fd693548035d7fd53a774e37e4260fea64e0ac9b8a3aee904f9321df", size = 13341585 },
+    { url = "https://files.pythonhosted.org/packages/fb/42/ce1204fd8229ae5779fbfe53c787a6a72e23263250579017e280ce9d7aff/botocore-1.36.19-py3-none-any.whl", hash = "sha256:98882c106fec4c08678ea028199f7f5119550fab95d682b30846f7aae04b7bec", size = 13344643 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -58,9 +58,9 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.2,<4.0.0" },
     { name = "aioitertools", specifier = ">=0.5.1,<1.0.0" },
-    { name = "awscli", marker = "extra == 'awscli'", specifier = ">=1.37.0,<1.37.4" },
-    { name = "boto3", marker = "extra == 'boto3'", specifier = ">=1.36.0,<1.36.4" },
-    { name = "botocore", specifier = ">=1.36.0,<1.36.4" },
+    { name = "awscli", marker = "extra == 'awscli'", specifier = ">=1.37.0,<1.37.11" },
+    { name = "boto3", marker = "extra == 'boto3'", specifier = ">=1.36.0,<1.36.11" },
+    { name = "botocore", specifier = ">=1.36.0,<1.36.11" },
     { name = "jmespath", specifier = ">=0.7.1,<2.0.0" },
     { name = "multidict", specifier = ">=6.0.0,<7.0.0" },
     { name = "python-dateutil", specifier = ">=2.1,<3.0.0" },
@@ -440,7 +440,7 @@ wheels = [
 
 [[package]]
 name = "awscli"
-version = "1.37.3"
+version = "1.37.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
@@ -450,9 +450,9 @@ dependencies = [
     { name = "rsa" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/13/6ae11e5e7edfe8383404af88f568e014d699763d64341c88c0d5e399bbe2/awscli-1.37.3.tar.gz", hash = "sha256:8f6c50a1c77a7de11d5985ef01afe6ce50fbeaad2faa0ff828b00be7f8a00119", size = 1851529 }
+sdist = { url = "https://files.pythonhosted.org/packages/db/65/356179ff8b1770f9b0052436ac2390e07ae3f2fbd8a83d137c371dac9cbf/awscli-1.37.10.tar.gz", hash = "sha256:e5bbfbcbadc866a52e1e02b87b6148a5a98aa62a71cbf29aca6aec2abad9ef17", size = 1864554 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/93/f9f212a34ab548c7de0d0b483712b289dfcede38f6358b338fb590135ef2/awscli-1.37.3-py3-none-any.whl", hash = "sha256:c8f1783e2e11cd68ed02f400b1bcdb46bdffb08ea13f5771fc29d453e3eb41be", size = 4566819 },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/0ed065c2c23cde4f94f12f50006dfdbe4e10f73f7ef1ddb32bfc079c3bb8/awscli-1.37.10-py3-none-any.whl", hash = "sha256:0cdb766c94e9dd44dd05fb4959cd5e94ff4db41885ae431494a3dac85efa3ee6", size = 4609860 },
 ]
 
 [[package]]
@@ -482,21 +482,21 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.36.3"
+version = "1.36.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/12/b9ad4c3dd6e6044243d08bae076795e41357651683f4fad99d5828c4291c/boto3-1.36.3.tar.gz", hash = "sha256:53a5307f6a3526ee2f8590e3c45efa504a3ea4532c1bfe4926c0c19bf188d141", size = 110987 }
+sdist = { url = "https://files.pythonhosted.org/packages/16/af/e41306c8fe705f19436b5339b23edcc6c4388b548c79fdd21cc120f61899/boto3-1.36.10.tar.gz", hash = "sha256:d2f1010db699326b26fbd465d91c4b49177c9d995d7e72c0f31335f139efa0d2", size = 111006 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/97/4697aa8050e306d6139815996adeb263ddc83024399a188e8b42587665db/boto3-1.36.3-py3-none-any.whl", hash = "sha256:f9843a5d06f501d66ada06f5a5417f671823af2cf319e36ceefa1bafaaaaa953", size = 139165 },
+    { url = "https://files.pythonhosted.org/packages/34/3b/7a169cf550531dd89aa702a38313185af30aef685f058cf6f56e840d2eb4/boto3-1.36.10-py3-none-any.whl", hash = "sha256:5f8d5c2024a2d1411d3d67abb7357ec7d4c6162e3f1c396dc9b79d042cfd0a80", size = 139177 },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.36.3"
+version = "1.36.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
@@ -504,9 +504,9 @@ dependencies = [
     { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "urllib3", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/61/69eb06a803c83e0da733b60b2bc65880c18ef2dee19ee10cf8732794a3c1/botocore-1.36.3.tar.gz", hash = "sha256:775b835e979da5c96548ed1a0b798101a145aec3cd46541d62e27dda5a94d7f8", size = 13507880 }
+sdist = { url = "https://files.pythonhosted.org/packages/05/da/8d21e15a1366a076c54529059c45c66943c217f1eadea5eb36791274d8d0/botocore-1.36.10.tar.gz", hash = "sha256:d27bb73f0ea81395527a6298ac0a7ea5b2958094169f7cf7d48e3f4e4bc21b65", size = 13495786 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/14/f952fed35b9c04aa66453b5fb5d1262a5a9f5dfdcb396d387c1ff0c6da41/botocore-1.36.3-py3-none-any.whl", hash = "sha256:536ab828e6f90dbb000e3702ac45fd76642113ae2db1b7b1373ad24104e89255", size = 13304681 },
+    { url = "https://files.pythonhosted.org/packages/f6/84/b038ec69154135a46267d96eb6ddbebe8e6775f18e1e827700b3e30f4170/botocore-1.36.10-py3-none-any.whl", hash = "sha256:45c8a6e01dc18d44a13ba688f1d60ad562db8154b08c46b412387ea040a741c2", size = 13325134 },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description of Change
This PR intends to improve general compatibility of `aiobotocore` within the Python ecosystem by bumping the dependency specification of `botocore`, as well as `boto3` and `awscli`.

### Assumptions
[Upstream diff](https://github.com/boto/botocore/compare/1.36.3..1.36.23) contains several changes that require minor adjustments to the aiobotocore codebase.

### Checklist for All Submissions
* [x] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [x] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [x] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [x] I have ensured that the awscli/boto3 versions match the updated botocore version