### PR TITLE
Graduate `ubuntu-24.04-arm` runners, except for Python 3.8

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -57,8 +57,9 @@ jobs:
         - ubuntu-24.04-arm
         include:
         - experimental: false
-        - experimental: true
-          os: ubuntu-24.04-arm  # deal with flaky runners
+        - experimental: true  # no reliable moto release available
+          python-version: 3.8
+          os: ubuntu-24.04-arm
         - upload-coverage: false
         - upload-coverage: true
           python-version: 3.11


### PR DESCRIPTION
### Description of Change
Graduate `ubuntu-24.04-arm` runners, except for Python 3.8

### Assumptions
Support for Python 3.8 will be dropped rather sooner than later 

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
