### PR TITLE
Bump `botocore` dependency specification

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,11 @@
 Changes
 -------
 
-2.21.0 (2025-02-27)
+2.21.0 (2025-02-28)
 ^^^^^^^^^^^^^^^^^^^
 * make `AioDeferredRefreshableCredentials` subclass of `DeferredRefreshableCredentials`
 * make `AioSSOCredentialFetcher` subclass of `SSOCredentialFetcher`
-* relax botocore dependency specification
+* bump botocore dependency specification
 
 2.20.1.dev0 (2025-02-24)
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changes
 ^^^^^^^^^^^^^^^^^^^
 * make `AioDeferredRefreshableCredentials` subclass of `DeferredRefreshableCredentials`
 * make `AioSSOCredentialFetcher` subclass of `SSOCredentialFetcher`
+* relax botocore dependency specification
 
 2.20.1.dev0 (2025-02-24)
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/aiobotocore/args.py
+++ b/aiobotocore/args.py
@@ -49,6 +49,7 @@ class AioClientArgsCreator(ClientArgsCreator):
         configured_endpoint_url = final_args['configured_endpoint_url']
         signing_region = endpoint_config['signing_region']
         endpoint_region_name = endpoint_config['region_name']
+        account_id_endpoint_mode = config_kwargs['account_id_endpoint_mode']
 
         event_emitter = copy.copy(self._event_emitter)
         signer = AioRequestSigner(
@@ -107,6 +108,8 @@ class AioClientArgsCreator(ClientArgsCreator):
             is_secure,
             endpoint_bridge,
             event_emitter,
+            credentials,
+            account_id_endpoint_mode,
         )
 
         # Copy the session's user agent factory and adds client configuration.
@@ -144,6 +147,8 @@ class AioClientArgsCreator(ClientArgsCreator):
         is_secure,
         endpoint_bridge,
         event_emitter,
+        credentials,
+        account_id_endpoint_mode,
     ):
         if endpoints_ruleset_data is None:
             return None
@@ -168,6 +173,8 @@ class AioClientArgsCreator(ClientArgsCreator):
             endpoint_bridge=endpoint_bridge,
             client_endpoint_url=endpoint_url,
             legacy_endpoint_url=endpoint.host,
+            credentials=credentials,
+            account_id_endpoint_mode=account_id_endpoint_mode,
         )
         # Client context params for s3 conflict with the available settings
         # in the `s3` parameter on the `Config` object. If the same parameter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dynamic = ["version", "readme"]
 dependencies = [
     "aiohttp >= 3.9.2, < 4.0.0",
     "aioitertools >= 0.5.1, < 1.0.0",
-    "botocore >= 1.36.20, < 1.36.24", # NOTE: When updating, always keep `project.optional-dependencies` aligned
+    "botocore >= 1.36.20, < 1.36.27", # NOTE: When updating, always keep `project.optional-dependencies` aligned
     "python-dateutil >= 2.1, < 3.0.0",
     "jmespath >= 0.7.1, < 2.0.0",
     "multidict >= 6.0.0, < 7.0.0",
@@ -41,10 +41,10 @@ dependencies = [
 
 [project.optional-dependencies]
 awscli = [
-    "awscli >= 1.37.20, < 1.37.24",
+    "awscli >= 1.37.20, < 1.37.27",
 ]
 boto3 = [
-    "boto3 >= 1.36.20, < 1.36.24",
+    "boto3 >= 1.36.20, < 1.36.27",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dynamic = ["version", "readme"]
 dependencies = [
     "aiohttp >= 3.9.2, < 4.0.0",
     "aioitertools >= 0.5.1, < 1.0.0",
-    "botocore >= 1.36.20, < 1.36.27", # NOTE: When updating, always keep `project.optional-dependencies` aligned
+    "botocore >= 1.37.0, < 1.37.2", # NOTE: When updating, always keep `project.optional-dependencies` aligned
     "python-dateutil >= 2.1, < 3.0.0",
     "jmespath >= 0.7.1, < 2.0.0",
     "multidict >= 6.0.0, < 7.0.0",
@@ -41,10 +41,10 @@ dependencies = [
 
 [project.optional-dependencies]
 awscli = [
-    "awscli >= 1.37.20, < 1.37.27",
+    "awscli >= 1.38.0, < 1.38.2",
 ]
 boto3 = [
-    "boto3 >= 1.36.20, < 1.36.27",
+    "boto3 >= 1.37.0, < 1.37.2",
 ]
 
 [project.urls]

--- a/tests/boto_tests/__init__.py
+++ b/tests/boto_tests/__init__.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+import binascii
 import contextlib
 import os
 import random
@@ -25,6 +26,15 @@ from botocore.compat import parse_qs, urlparse
 import aiobotocore.session
 
 _LOADER = botocore.loaders.Loader()
+
+
+def random_chars(num_chars):
+    """Returns random hex characters.
+
+    Useful for creating resources with random names.
+
+    """
+    return binascii.hexlify(os.urandom(int(num_chars / 2))).decode('ascii')
 
 
 def create_session(**kwargs):

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -142,10 +142,10 @@ from dill.source import getsource
 _API_DIGESTS = {
     # args.py
     ClientArgsCreator.get_client_args: {
-        '2dc13a6f32c470bc415a2cfc1f82cf569b1a5196'
+        'd651b5c3d81738b7f2072b984eef8b5d4cfacd22',
     },
     ClientArgsCreator._build_endpoint_resolver: {
-        '0f80192233321ae4a55d95b68f5b8a68f3ad18e6',
+        '354033a66f90fc1d939a3309ae7d595d480020a6',
     },
     # client.py
     ClientCreator.create_client: {
@@ -205,15 +205,15 @@ _API_DIGESTS = {
     # config.py
     Config.merge: {'c3dd8c3ffe0da86953ceba4a35267dfb79c6a2c8'},
     Config: {
-        'b74583575a542516edeeeec2e5d30ee61ce449b0',
+        'c7cf339ac7fb2d5fca9f133beb84d750bd4c9e30',
     },
     # credentials.py
     create_mfa_serial_refresher: {'9b5e98782fcacdcea5899a6d0d29d1b9de348bb0'},
     Credentials.get_frozen_credentials: {
-        'eb247f2884aee311bdabba3435e749c3b8589100'
+        '87ced1e435eda7738852e0569ddbff3b7a8e977f',
     },
     RefreshableCredentials.__init__: {
-        '25ee814f47e5ce617f57e893ae158e5fd6d358ea',
+        '88ab16aa041eb1cad8d666834613cbe5f0cf7514',
     },
     # We've overridden some properties
     RefreshableCredentials.__dict__['access_key'].fset: {
@@ -234,20 +234,26 @@ _API_DIGESTS = {
     RefreshableCredentials.__dict__['token'].fget: {
         '005c1b44b616f37739ce9276352e4e83644d8220'
     },
+    RefreshableCredentials.__dict__['account_id'].fset: {
+        '0d67de1c18dc80429b8537fe94a842175636f850',
+    },
+    RefreshableCredentials.__dict__['account_id'].fget: {
+        'd40a5f4571df3a239500a615ca0cc3fe77ac70ab',
+    },
     RefreshableCredentials._refresh: {
         'd5731d01db2812d498df19b4bd5d7c17519241fe'
     },
     RefreshableCredentials._protected_refresh: {
-        '9f8fdb76f41c3b1c64fd4d03d0701504626939e5'
+        '8b2d523a605a4f4728ad99861c14143838e56176',
     },
     RefreshableCredentials.get_frozen_credentials: {
         'f661c84a8b759786e011f0b1e8a468a0c6294e36'
     },
     DeferredRefreshableCredentials.__init__: {
-        'd18601140386cfaa6718d0e0d38a0816cd151d35',
+        'dd5ccda2b047854ae5e88907b654b57d35fe0dfd',
     },
     SSOCredentialFetcher._get_credentials: {
-        '8b330f4b299aece9232577f066060e28d369f3e9',
+        '13ac3b73e0745dfeaa934a8873179ca6c22a164f',
     },
     SSOProvider.load: {'67aba81dd1def437f2035f5e20b0720b328d970a'},
     CachedCredentialFetcher._get_credentials: {
@@ -257,10 +263,10 @@ _API_DIGESTS = {
         '0dd2986a4cbb38764ec747075306a33117e86c3d'
     },
     CachedCredentialFetcher._get_cached_credentials: {
-        'a9f8c348d226e62122972da9ccc025365b6803d6'
+        'f578b2527712d501c021f8236bd20e68e99201f5',
     },
     AssumeRoleCredentialFetcher._get_credentials: {
-        '5c575634bc0a713c10e5668f28fbfa8779d5a1da'
+        '51e265bebde5b193d79a680706f2c7efc7b56622',
     },
     AssumeRoleCredentialFetcher._create_client: {
         '27c76f07bd43e665899ca8d21b6ba2038b276fbb'
@@ -270,20 +276,22 @@ _API_DIGESTS = {
         'ab270375dfe425c5e21276590dea690fdbfe40a5'
     },
     AssumeRoleWithWebIdentityCredentialFetcher._get_credentials: {
-        '02eba9d4e846474910cb076710070348e395a819'
+        '23a7efbaf2022dcf713399649936cd9c2116f6c5',
     },
     AssumeRoleWithWebIdentityCredentialFetcher._assume_role_kwargs: {
         '8fb4fefe8664b7d82a67e0fd6d6812c1c8d92285'
     },
     # Ensure that the load method doesn't do anything we should asyncify
-    EnvProvider.load: {'39871a6ec3b3f5d51bc967122793e86b7ca6ed3c'},
+    EnvProvider.load: {
+        '9c6bb8f48ea4cb3dfbe7df925a269a077205d62b',
+    },
     ContainerProvider.__init__: {'ea6aafb2e12730066af930fb5a27f7659c1736a1'},
     ContainerProvider.load: {'57c35569050b45c1e9e33fcdb3b49da9e342fdcf'},
     ContainerProvider._retrieve_or_fail: {
-        'c99153a4c68927810a3edde09ee98c5ba33d3697'
+        '057ebdc912f15ec4903ab2e157f339d2ae740615',
     },
     ContainerProvider._create_fetcher: {
-        'a921ee40b9b4779f238adcf369a3757b19857fc7'
+        'f61e3e60fda55de7dbcf4a66865981f7cb0804b8',
     },
     InstanceMetadataProvider.load: {
         '15becfc0373ccfbc1bb200bd6a34731e61561d06'
@@ -303,14 +311,18 @@ _API_DIGESTS = {
     ProfileProviderBuilder._create_sso_provider: {
         'e463160179add7a1a513e46ee848447a216504aa'
     },
-    ConfigProvider.load: {'d0714da9f1f54cebc555df82f181c4913ce97258'},
+    ConfigProvider.load: {
+        'dab41451970911f4b578015a3083ff550c6b7beb',
+    },
     SharedCredentialProvider.load: {
-        '8a17d992e2a90ebc0e07ba5a5dfef2b725367496'
+        '833ec38b8361165e1bb285740e99c7ff7af161a5',
     },
     ProcessProvider.__init__: {'2e870ec0c6b0bc8483fa9b1159ef68bbd7a12c56'},
-    ProcessProvider.load: {'6866e1d3abbde7a14e83aea28cc49377faaca84b'},
+    ProcessProvider.load: {
+        '6691e82aeeccc4e07c30ee484ee31ebba5b6e2fb',
+    },
     ProcessProvider._retrieve_credentials_using: {
-        'c12acda42ddc5dfd73946adce8c155295f8c6b88'
+        'd8755c0bb80c4c9852c89276db6ec418f988f6f0',
     },
     CredentialResolver.load_credentials: {
         'ef31ba8817f84c1f61f36259da1cc6e597b8625a'
@@ -329,7 +341,7 @@ _API_DIGESTS = {
         '105c0c011e23d76a3b8bd3d9b91b6d945c8307a1'
     },
     AssumeRoleProvider._resolve_credentials_from_profile: {
-        'a87ece979f8c94c1afd5801156e2b39f0d6d45ab'
+        '3e4e6371dabe4deb3445495aeb702eed8a3fba63',
     },
     AssumeRoleProvider._resolve_static_credentials_from_profile: {
         'a470795f6ba451cf99ce7456fef24777f8087654'
@@ -454,7 +466,9 @@ _API_DIGESTS = {
     Session._register_response_parser_factory: {
         'bb8f7f3cc4d9ff9551f0875604747c4bb5030ff6'
     },
-    Session.create_client: {'a821ae3870f33b65b1ea7cd347ca0497ed306ccd'},
+    Session.create_client: {
+        '256ae18c8b119c66bfaf24ff224db8a8d2ad9661',
+    },
     Session._create_token_resolver: {
         '142df7a219db0dd9c96fd81dc9e84a764a2fe5fb'
     },
@@ -462,7 +476,7 @@ _API_DIGESTS = {
         '87e98d201c72d06f7fbdb4ebee2dce1c09de0fb2'
     },
     Session.set_credentials: {
-        '63a10f97f417d3df8aae8a5444db4c8a6ebe06ad',
+        '923e96e9386054d65b38a3871574dd32c0f5015f',
     },
     Session.get_credentials: {'718da08b630569e631f93aedd65f1d9215bfc30b'},
     get_session: {'c47d588f5da9b8bde81ccc26eaef3aee19ddd901'},

--- a/uv.lock
+++ b/uv.lock
@@ -57,9 +57,9 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.2,<4.0.0" },
     { name = "aioitertools", specifier = ">=0.5.1,<1.0.0" },
-    { name = "awscli", marker = "extra == 'awscli'", specifier = ">=1.37.20,<1.37.24" },
-    { name = "boto3", marker = "extra == 'boto3'", specifier = ">=1.36.20,<1.36.24" },
-    { name = "botocore", specifier = ">=1.36.20,<1.36.24" },
+    { name = "awscli", marker = "extra == 'awscli'", specifier = ">=1.37.20,<1.37.27" },
+    { name = "boto3", marker = "extra == 'boto3'", specifier = ">=1.36.20,<1.36.27" },
+    { name = "botocore", specifier = ">=1.36.20,<1.36.27" },
     { name = "jmespath", specifier = ">=0.7.1,<2.0.0" },
     { name = "multidict", specifier = ">=6.0.0,<7.0.0" },
     { name = "python-dateutil", specifier = ">=2.1,<3.0.0" },
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "awscli"
-version = "1.37.23"
+version = "1.37.26"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
@@ -447,9 +447,9 @@ dependencies = [
     { name = "rsa" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/ed/2718031653856b0ccc2470d79cf52326586946b6cc5cffe970d196d80fd6/awscli-1.37.23.tar.gz", hash = "sha256:721c5e38f087a0366e56a5927c6382687f41e8118a18644b1346feab6125d859", size = 1867415 }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/f0/8fe9562e76038316dc934fd4902abf2a8f4b996a3566919d42646231678b/awscli-1.37.26.tar.gz", hash = "sha256:7741c33478948c69dc9c1632178eb9fcfe2d5ea07904dd5c78c93177292537bd", size = 1867333 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/b5/a15d45a6e2f53a237878e90b16af1a10a82db5fd3af633c426b134319219/awscli-1.37.23-py3-none-any.whl", hash = "sha256:f4d517b6f650aa0839fb23d01d5d7ccf849f092777def91bd70a987fe52682ec", size = 4625856 },
+    { url = "https://files.pythonhosted.org/packages/74/13/53c242b4a3160260b002cf306806e6198a8a3c36c3fae118a2837da57adf/awscli-1.37.26-py3-none-any.whl", hash = "sha256:e987c718fdad5cb44816262db773b874b898eedce9bb1dfc6e37190cbc7691c1", size = 4625857 },
 ]
 
 [[package]]
@@ -479,21 +479,21 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.36.23"
+version = "1.36.26"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/54/a91d274f50bbe8fbd16ecea8bfd60249d0dc1ca50874e3a06119c6e5723a/boto3-1.36.23.tar.gz", hash = "sha256:006800604c34382873521b20890b758eea7109d699696ece932131259d0a4658", size = 111094 }
+sdist = { url = "https://files.pythonhosted.org/packages/79/af/2082fde2cbd81f8b60fd46e3ac07a0f841abfdb9818b818d560e42b5c444/boto3-1.36.26.tar.gz", hash = "sha256:523b69457eee55ac15aa707c0e768b2a45ca1521f95b2442931090633ec72458", size = 111027 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/b5/2217a8ebb59bbc5f28dc10d3184b1f7e238f1929d211e69298421f912411/boto3-1.36.23-py3-none-any.whl", hash = "sha256:d59642672b1f35f55f47b317693241ce53333816f47c9e72fcc8fd0e9adc6a87", size = 139179 },
+    { url = "https://files.pythonhosted.org/packages/b1/a7/9081049e432f5130c6bd4d86f4db7a7729f812ebceda59baff69a06b19a5/boto3-1.36.26-py3-none-any.whl", hash = "sha256:f67d014a7c5a3cd540606d64d7cb9eec3600cf42acab1ac0518df9751ae115e2", size = 139178 },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.36.23"
+version = "1.36.26"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
@@ -501,9 +501,9 @@ dependencies = [
     { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "urllib3", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/d4/e93bcf4f825faa25c2ff27b653cd9e976226df527445f8c414198020c967/botocore-1.36.23.tar.gz", hash = "sha256:9feaa2d876f487e718a5fd80a35fa401042b518c0c75117d3e1ea39a567439e7", size = 13571101 }
+sdist = { url = "https://files.pythonhosted.org/packages/69/db/caa8778cf98ecbe0ad0efd7fbf673e2d036373386582e15dffff80bf16e1/botocore-1.36.26.tar.gz", hash = "sha256:4a63bcef7ecf6146fd3a61dc4f9b33b7473b49bdaf1770e9aaca6eee0c9eab62", size = 13574958 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/93/a566604998182dd354aa6bab3c5b0393077a2ce4b97e18713d94c362da06/botocore-1.36.23-py3-none-any.whl", hash = "sha256:886730e79495a2e153842725ebdf85185c8277cdf255b3b5879cd097ddc7fcc3", size = 13355279 },
+    { url = "https://files.pythonhosted.org/packages/dd/0c/a3eeca35b22ac8f441d412881582a5f3b8665de0269baf9fdeb8e86d7f1c/botocore-1.36.26-py3-none-any.whl", hash = "sha256:4e3f19913887a58502e71ef8d696fe7eaa54de7813ff73390cd5883f837dfa6e", size = 13360675 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -57,9 +57,9 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.2,<4.0.0" },
     { name = "aioitertools", specifier = ">=0.5.1,<1.0.0" },
-    { name = "awscli", marker = "extra == 'awscli'", specifier = ">=1.37.20,<1.37.27" },
-    { name = "boto3", marker = "extra == 'boto3'", specifier = ">=1.36.20,<1.36.27" },
-    { name = "botocore", specifier = ">=1.36.20,<1.36.27" },
+    { name = "awscli", marker = "extra == 'awscli'", specifier = ">=1.38.0,<1.38.2" },
+    { name = "boto3", marker = "extra == 'boto3'", specifier = ">=1.37.0,<1.37.2" },
+    { name = "botocore", specifier = ">=1.37.0,<1.37.2" },
     { name = "jmespath", specifier = ">=0.7.1,<2.0.0" },
     { name = "multidict", specifier = ">=6.0.0,<7.0.0" },
     { name = "python-dateutil", specifier = ">=2.1,<3.0.0" },
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "awscli"
-version = "1.37.26"
+version = "1.38.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
@@ -447,9 +447,9 @@ dependencies = [
     { name = "rsa" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/f0/8fe9562e76038316dc934fd4902abf2a8f4b996a3566919d42646231678b/awscli-1.37.26.tar.gz", hash = "sha256:7741c33478948c69dc9c1632178eb9fcfe2d5ea07904dd5c78c93177292537bd", size = 1867333 }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/80/51b46b22d212c039aade21c5344c30dc6bd3618b91c8e0be1c65555f4b10/awscli-1.38.1.tar.gz", hash = "sha256:93822b3c62254a9e4752f398829a68eddef2db1cac228a6097574468ac2ac01e", size = 1867374 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/13/53c242b4a3160260b002cf306806e6198a8a3c36c3fae118a2837da57adf/awscli-1.37.26-py3-none-any.whl", hash = "sha256:e987c718fdad5cb44816262db773b874b898eedce9bb1dfc6e37190cbc7691c1", size = 4625857 },
+    { url = "https://files.pythonhosted.org/packages/fc/35/4197be2fd3c5e6ba7ae2d49d0fb4ade84c94f622a0e550a71d44b71fbbf6/awscli-1.38.1-py3-none-any.whl", hash = "sha256:bd58ef26007f334bfd0206c6373d018553f850545c54fa81ba94aae8e8b615f7", size = 4625833 },
 ]
 
 [[package]]
@@ -479,21 +479,21 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.36.26"
+version = "1.37.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/af/2082fde2cbd81f8b60fd46e3ac07a0f841abfdb9818b818d560e42b5c444/boto3-1.36.26.tar.gz", hash = "sha256:523b69457eee55ac15aa707c0e768b2a45ca1521f95b2442931090633ec72458", size = 111027 }
+sdist = { url = "https://files.pythonhosted.org/packages/21/8c/c2af03daafaacea1db1823d23073facffa75818b61d376c3be77dd297ae8/boto3-1.37.1.tar.gz", hash = "sha256:96d18f7feb0c1fcb95f8837b74b6c8880e1b4e35ce5f8a8f8cb243a090c278ed", size = 111175 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/a7/9081049e432f5130c6bd4d86f4db7a7729f812ebceda59baff69a06b19a5/boto3-1.36.26-py3-none-any.whl", hash = "sha256:f67d014a7c5a3cd540606d64d7cb9eec3600cf42acab1ac0518df9751ae115e2", size = 139178 },
+    { url = "https://files.pythonhosted.org/packages/63/ec/e722c53c9dc41e8df094587c32e19409bace8b43b5eb31fe3536ca57a38b/boto3-1.37.1-py3-none-any.whl", hash = "sha256:4320441f904435a1b85e6ecb81793192e522c737cc9ed6566014e29f0a11cb22", size = 139338 },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.36.26"
+version = "1.37.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
@@ -501,9 +501,9 @@ dependencies = [
     { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "urllib3", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/db/caa8778cf98ecbe0ad0efd7fbf673e2d036373386582e15dffff80bf16e1/botocore-1.36.26.tar.gz", hash = "sha256:4a63bcef7ecf6146fd3a61dc4f9b33b7473b49bdaf1770e9aaca6eee0c9eab62", size = 13574958 }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/01/3083bff25fd91193162298920cb093b9095609408416526d52b2826965b7/botocore-1.37.1.tar.gz", hash = "sha256:b194db8fb2a0ffba53568c364ae26166e7eec0445496b2ac86a6e142f3dd982f", size = 13578835 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/0c/a3eeca35b22ac8f441d412881582a5f3b8665de0269baf9fdeb8e86d7f1c/botocore-1.36.26-py3-none-any.whl", hash = "sha256:4e3f19913887a58502e71ef8d696fe7eaa54de7813ff73390cd5883f837dfa6e", size = 13360675 },
+    { url = "https://files.pythonhosted.org/packages/3d/20/352b2bf99f93ba18986615841786cbd0d38f7856bd49d4e154a540f04afe/botocore-1.37.1-py3-none-any.whl", hash = "sha256:c1db1bfc5d8c6b3b6d1ca6794f605294b4264e82a7e727b88e0fef9c2b9fbb9c", size = 13359164 },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description of Change
This PR intends to improve general compatibility of `aiobotocore` within the Python ecosystem by bumping the dependency specification of `botocore`, as well as `boto3` and `awscli`.

### Assumptions
[Upstream diff](https://github.com/boto/botocore/compare/1.36.23..1.37.1) contains several changes that require adjustments to the aiobotocore codebase.

### Checklist for All Submissions
* [x] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [x] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details): closes #1306 
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [x] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [x] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [x] I have ensured that the awscli/boto3 versions match the updated botocore version