### PR TITLE
Use SPDX license identifier for project metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,10 @@
 Changes
 -------
 
-2.22.0 (2025-04-09)
+2.22.0 (2025-04-15)
 ^^^^^^^^^^^^^^^^^^^
 * patch `ResponseParser`
+* use SPDX license identifier for project metadata
 
 2.21.1 (2025-03-04)
 ^^^^^^^^^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.8"
 authors = [
     { name = "Nikolay Novik", email = "nickolainovik@gmail.com" },
 ]
-license = { text = "Apache License 2.0" }
+license = { text = "Apache-2.0" }
 classifiers = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',


### PR DESCRIPTION
### Description of Change
PEP 639 specified the use of SPDX license expressions for `license` metadata.
Setuptools `v77` added full support for it. However that version requires Python `>=3.9`.

Until `3.8` is dropped, I believe it makes sense to just use the SPDX identifier with the old `license.text` field.

https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files

### Checklist for All Submissions
* [x] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
* [ ] I have added URL to diff: https://github.com/boto/botocore/compare/[CURRENT_BOTO_VERSION_TAG]...[NEW_BOTO_VERSION_TAG]
