### PR TITLE
Create common interface for aio response classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changes
 ^^^^^^^^^^^^^^^^^^^
 * patch `ResponseParser`
 * use SPDX license identifier for project metadata
-* refactor `AioResponseParser` to have a consistent async implementation of the `parse` method.
+* refactor ``AioResponseParser`` to have a consistent async implementation of the `parse` method.
+  sync `parse` methods are deprecated and will be removed in a future release.``
 
 2.21.1 (2025-03-04)
 ^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changes
 ^^^^^^^^^^^^^^^^^^^
 * patch `ResponseParser`
 * use SPDX license identifier for project metadata
+* refactor `AioResponseParser` to have a consistent async implementation of the `parse` method.
 
 2.21.1 (2025-03-04)
 ^^^^^^^^^^^^^^^^^^^

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -204,15 +204,9 @@ class AioEndpoint(Endpoint):
         )
         parser = self._response_parser_factory.create_parser(protocol)
 
-        if asyncio.iscoroutinefunction(parser.parse):
-            parsed_response = await parser.parse(
-                response_dict, operation_model.output_shape
-            )
-        else:
-            parsed_response = parser.parse(
-                response_dict, operation_model.output_shape
-            )
-
+        parsed_response = await parser.parse(
+            response_dict, operation_model.output_shape
+        )
         parsed_response.update(customized_response_dict)
 
         if http_response.status_code >= 300:
@@ -240,10 +234,7 @@ class AioEndpoint(Endpoint):
         if error_shape is None:
             return
 
-        if asyncio.iscoroutinefunction(parser.parse):
-            modeled_parse = await parser.parse(response_dict, error_shape)
-        else:
-            modeled_parse = parser.parse(response_dict, error_shape)
+        modeled_parse = await parser.parse(response_dict, error_shape)
         # TODO: avoid naming conflicts with ResponseMetadata and Error
         parsed_response.update(modeled_parse)
 

--- a/aiobotocore/parsers.py
+++ b/aiobotocore/parsers.py
@@ -1,3 +1,5 @@
+import inspect
+
 from botocore.parsers import (
     LOG,
     EC2QueryParser,
@@ -30,6 +32,43 @@ class AioResponseParser(ResponseParser):
         parser = self._event_stream_parser
         name = response['context'].get('operation_name')
         return AioEventStream(response['body'], shape, parser, name)
+
+    # Only JSONParser needs this to be async. Override it here at the base
+    # class so the interface is consistent on all aio response classes.
+    async def parse(self, response, shape):
+        LOG.debug('Response headers: %s', response['headers'])
+        LOG.debug('Response body:\n%s', response['body'])
+        if response['status_code'] >= 301:
+            if self._is_generic_error_response(response):
+                parsed = self._do_generic_error_parse(response)
+            elif self._is_modeled_error_shape(shape):
+                parsed = self._do_modeled_error_parse(response, shape)
+                # We don't want to decorate the modeled fields with metadata
+                return parsed
+            else:
+                parsed = self._do_error_parse(response, shape)
+        else:
+            parsed = self._do_parse(response, shape)
+            if inspect.iscoroutine(parsed):
+                parsed = await parsed
+
+        # We don't want to decorate event stream responses with metadata
+        if shape and shape.serialization.get('eventstream'):
+            return parsed
+
+        # Add ResponseMetadata if it doesn't exist and inject the HTTP
+        # status code and headers from the response.
+        if isinstance(parsed, dict):
+            response_metadata = parsed.get('ResponseMetadata', {})
+            response_metadata['HTTPStatusCode'] = response['status_code']
+            # Ensure that the http header keys are all lower cased. Older
+            # versions of urllib3 (< 1.11) would unintentionally do this for us
+            # (see urllib3#633). We need to do this conversion manually now.
+            headers = response['headers']
+            response_metadata['HTTPHeaders'] = lowercase_dict(headers)
+            parsed['ResponseMetadata'] = response_metadata
+            self._add_checksum_response_metadata(response, response_metadata)
+        return parsed
 
 
 class AioQueryParser(QueryParser, AioResponseParser):
@@ -64,41 +103,6 @@ class AioJSONParser(JSONParser, AioResponseParser):
             raise ResponseParserError(error_msg)
         parsed = self._handle_json_body(event.payload, shape)
         parsed[event_name] = event_stream
-        return parsed
-
-    # this is actually from ResponseParser however for now JSONParser is the
-    # only class that needs this async
-    async def parse(self, response, shape):
-        LOG.debug('Response headers: %s', response['headers'])
-        LOG.debug('Response body:\n%s', response['body'])
-        if response['status_code'] >= 301:
-            if self._is_generic_error_response(response):
-                parsed = self._do_generic_error_parse(response)
-            elif self._is_modeled_error_shape(shape):
-                parsed = self._do_modeled_error_parse(response, shape)
-                # We don't want to decorate the modeled fields with metadata
-                return parsed
-            else:
-                parsed = self._do_error_parse(response, shape)
-        else:
-            parsed = await self._do_parse(response, shape)
-
-        # We don't want to decorate event stream responses with metadata
-        if shape and shape.serialization.get('eventstream'):
-            return parsed
-
-        # Add ResponseMetadata if it doesn't exist and inject the HTTP
-        # status code and headers from the response.
-        if isinstance(parsed, dict):
-            response_metadata = parsed.get('ResponseMetadata', {})
-            response_metadata['HTTPStatusCode'] = response['status_code']
-            # Ensure that the http header keys are all lower cased. Older
-            # versions of urllib3 (< 1.11) would unintentionally do this for us
-            # (see urllib3#633). We need to do this conversion manually now.
-            headers = response['headers']
-            response_metadata['HTTPHeaders'] = lowercase_dict(headers)
-            parsed['ResponseMetadata'] = response_metadata
-            self._add_checksum_response_metadata(response, response_metadata)
         return parsed
 
 

--- a/aiobotocore/response.py
+++ b/aiobotocore/response.py
@@ -150,10 +150,5 @@ async def get_response(operation_model, http_response):
         response_dict['body'] = await http_response.content
 
     parser = parsers.create_parser(protocol)
-    if asyncio.iscoroutinefunction(parser.parse):
-        parsed = await parser.parse(
-            response_dict, operation_model.output_shape
-        )
-    else:
-        parsed = parser.parse(response_dict, operation_model.output_shape)
+    parsed = await parser.parse(response_dict, operation_model.output_shape)
     return http_response, parsed

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -428,6 +428,7 @@ _API_DIGESTS = {
     ResponseParser._create_event_stream: {
         '0564ba55383a71cc1ba3e5be7110549d7e9992f5',
     },
+    ResponseParser.parse: {'c2153eac3789855f4fc6a816a1f30a6afe0cf969'},
     RestXMLParser._create_event_stream: {
         '0564ba55383a71cc1ba3e5be7110549d7e9992f5'
     },
@@ -444,8 +445,6 @@ _API_DIGESTS = {
     JSONParser._handle_event_stream: {
         '3cf7bb1ecff0d72bafd7e7fd6625595b4060abd6'
     },
-    # NOTE: if this hits we need to change our ResponseParser impl in JSONParser
-    JSONParser.parse: {'c2153eac3789855f4fc6a816a1f30a6afe0cf969'},
     RestJSONParser._create_event_stream: {
         '0564ba55383a71cc1ba3e5be7110549d7e9992f5'
     },


### PR DESCRIPTION
Having the `parse` method async on all parsers means the need for checking that `parse` is a coroutine is not needed anymore. The check for coroutine or not moved into the parser where a private method can be async or sync. This cleans up the public interface of the aio response classes.

### Description of Change

Change is extracted out of pull #1323 after a review comment ask for it.

### Assumptions
*Replace this text with any assumptions made (if any)*

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
* [ ] I have added URL to diff: https://github.com/boto/botocore/compare/[CURRENT_BOTO_VERSION_TAG]...[NEW_BOTO_VERSION_TAG]
