### PR TITLE
Patch `ResponseParser` and remaining subclasses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,9 @@
 Changes
 -------
 
-2.22.0 (2025-04-15)
+2.22.0 (2025-04-21)
 ^^^^^^^^^^^^^^^^^^^
-* patch `ResponseParser`
+* patch `ResponseParser` and subclasses
 * use SPDX license identifier for project metadata
 
 2.21.1 (2025-03-04)

--- a/aiobotocore/parsers.py
+++ b/aiobotocore/parsers.py
@@ -1,6 +1,12 @@
 from botocore.parsers import (
     LOG,
+    BaseEventStreamParser,
+    BaseJSONParser,
+    BaseRestParser,
+    BaseXMLResponseParser,
     EC2QueryParser,
+    EventStreamJSONParser,
+    EventStreamXMLParser,
     JSONParser,
     NoInitialResponseError,
     QueryParser,
@@ -32,15 +38,41 @@ class AioResponseParser(ResponseParser):
         return AioEventStream(response['body'], shape, parser, name)
 
 
-class AioQueryParser(QueryParser, AioResponseParser):
+class AioBaseXMLResponseParser(BaseXMLResponseParser, AioResponseParser):
     pass
 
 
-class AioEC2QueryParser(EC2QueryParser, AioResponseParser):
+class AioQueryParser(QueryParser, AioBaseXMLResponseParser):
     pass
 
 
-class AioJSONParser(JSONParser, AioResponseParser):
+class AioEC2QueryParser(EC2QueryParser, AioQueryParser):
+    pass
+
+
+class AioBaseJSONParser(BaseJSONParser, AioResponseParser):
+    pass
+
+
+class AioBaseEventStreamParser(BaseEventStreamParser, AioResponseParser):
+    pass
+
+
+class AioEventStreamJSONParser(
+    EventStreamJSONParser, AioBaseEventStreamParser, AioBaseJSONParser
+):
+    pass
+
+
+class AioEventStreamXMLParser(
+    EventStreamXMLParser, AioBaseEventStreamParser, AioBaseXMLResponseParser
+):
+    pass
+
+
+class AioJSONParser(JSONParser, AioBaseJSONParser):
+    EVENT_STREAM_PARSER_CLS = AioEventStreamJSONParser
+
     async def _do_parse(self, response, shape):
         parsed = {}
         if shape is not None:
@@ -102,12 +134,18 @@ class AioJSONParser(JSONParser, AioResponseParser):
         return parsed
 
 
-class AioRestJSONParser(RestJSONParser, AioResponseParser):
+class AioBaseRestParser(BaseRestParser, AioResponseParser):
     pass
 
 
-class AioRestXMLParser(RestXMLParser, AioResponseParser):
-    pass
+class AioRestJSONParser(RestJSONParser, AioBaseRestParser, AioBaseJSONParser):
+    EVENT_STREAM_PARSER_CLS = AioEventStreamJSONParser
+
+
+class AioRestXMLParser(
+    RestXMLParser, AioBaseRestParser, AioBaseXMLResponseParser
+):
+    EVENT_STREAM_PARSER_CLS = AioEventStreamXMLParser
 
 
 PROTOCOL_PARSERS = {


### PR DESCRIPTION
### Description of Change
Follow on of #1312 to patch full parsers class hierarchy as prerequisite for #1328.

### Assumptions
None

### Checklist for All Submissions
* [x] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
* [ ] I have added URL to diff: https://github.com/boto/botocore/compare/[CURRENT_BOTO_VERSION_TAG]...[NEW_BOTO_VERSION_TAG]
