### PR TITLE
Pin non-trusted actions to a hash in CI/CD GitHub workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -33,7 +33,8 @@ jobs:
       with:
         persist-credentials: false
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      # yamllint disable-line rule:line-length
+      uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04  # v6.0.0
       with:
         # prevent cache poisoning
         enable-cache: ${{ github.ref_type == 'tag' && 'false' || 'auto' }}
@@ -85,7 +86,8 @@ jobs:
         persist-credentials: false
         submodules: true
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      # yamllint disable-line rule:line-length
+      uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04  # v6.0.0
       with:
         python-version: ${{ matrix.python-version }}
         # prevent cache poisoning
@@ -100,7 +102,8 @@ jobs:
         uv run make mototest
     - name: Upload coverage to Codecov
       if: ${{ matrix.upload-coverage }}
-      uses: codecov/codecov-action@v5.4.2
+      # yamllint disable-line rule:line-length
+      uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d  # v5.4.2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}  # not required for public repos
         files: ./coverage.xml
@@ -119,7 +122,8 @@ jobs:
 
     steps:
     - name: Decide whether the needed jobs succeeded or failed
-      uses: re-actors/alls-green@release/v1
+      # yamllint disable-line rule:line-length
+      uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
       with:
         jobs: ${{ toJSON(needs) }}
 
@@ -150,4 +154,5 @@ jobs:
       env:
         REF_NAME: ${{ github.ref_name }}
     - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      # yamllint disable-line rule:line-length
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4


### PR DESCRIPTION
### Description of Change
Pin non-trusted actions to a hash in CI/CD GitHub workflow
* https://woodruffw.github.io/zizmor/audits/#unpinned-uses

### Assumptions
None

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [x] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details): closes #1340 
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
* [ ] I have added URL to diff: https://github.com/boto/botocore/compare/[CURRENT_BOTO_VERSION_TAG]...[NEW_BOTO_VERSION_TAG]
