### PR TITLE
Patch `ResponseParser.parse()` and others to prepare for upstream bump

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 2.22.0 (2025-04-29)
 ^^^^^^^^^^^^^^^^^^^
 * fully patch ``ClientArgsCreator.get_client_args()``
+* patch ``AioEndpoint.__init__()``
 * patch `ResponseParser` and subclasses
 * use SPDX license identifier for project metadata
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,9 @@
 Changes
 -------
 
-2.22.0 (2025-04-21)
+2.22.0 (2025-04-29)
 ^^^^^^^^^^^^^^^^^^^
+* fully patch ``ClientArgsCreator.get_client_args()``
 * patch `ResponseParser` and subclasses
 * use SPDX license identifier for project metadata
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes
 ^^^^^^^^^^^^^^^^^^^
 * fully patch ``ClientArgsCreator.get_client_args()``
 * patch ``AioEndpoint.__init__()``
-* patch `ResponseParser` and subclasses
+* patch ``EventStream._parse_event()``, ``ResponseParser`` and subclasses
 * use SPDX license identifier for project metadata
 
 2.21.1 (2025-03-04)

--- a/aiobotocore/args.py
+++ b/aiobotocore/args.py
@@ -6,6 +6,7 @@ from botocore.args import ClientArgsCreator, EPRBuiltins
 
 from .config import AioConfig
 from .endpoint import DEFAULT_HTTP_SESSION_CLS, AioEndpointCreator
+from .parsers import create_parser
 from .regions import AioEndpointRulesetResolver
 from .signers import AioRequestSigner
 
@@ -94,7 +95,7 @@ class AioClientArgsCreator(ClientArgsCreator):
         serializer = botocore.serialize.create_serializer(
             protocol, parameter_validation
         )
-        response_parser = botocore.parsers.create_parser(protocol)
+        response_parser = create_parser(protocol)
 
         ruleset_resolver = self._build_endpoint_resolver(
             endpoints_ruleset_data,

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -226,16 +226,9 @@ class AioEndpoint(Endpoint):
             customized_response_dict=customized_response_dict,
         )
         parser = self._response_parser_factory.create_parser(protocol)
-
-        if asyncio.iscoroutinefunction(parser.parse):
-            parsed_response = await parser.parse(
-                response_dict, operation_model.output_shape
-            )
-        else:
-            parsed_response = parser.parse(
-                response_dict, operation_model.output_shape
-            )
-
+        parsed_response = await parser.parse(
+            response_dict, operation_model.output_shape
+        )
         parsed_response.update(customized_response_dict)
 
         if http_response.status_code >= 300:
@@ -262,11 +255,7 @@ class AioEndpoint(Endpoint):
         error_shape = service_model.shape_for_error_code(error_code)
         if error_shape is None:
             return
-
-        if asyncio.iscoroutinefunction(parser.parse):
-            modeled_parse = await parser.parse(response_dict, error_shape)
-        else:
-            modeled_parse = parser.parse(response_dict, error_shape)
+        modeled_parse = await parser.parse(response_dict, error_shape)
         # TODO: avoid naming conflicts with ResponseMetadata and Error
         parsed_response.update(modeled_parse)
 

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -16,6 +16,7 @@ from botocore.hooks import first_non_none_response
 
 from aiobotocore.httpchecksum import handle_checksum_body
 from aiobotocore.httpsession import AIOHTTPSession
+from aiobotocore.parsers import AioResponseParserFactory
 from aiobotocore.response import StreamingBody
 
 DEFAULT_HTTP_SESSION_CLS = AIOHTTPSession
@@ -57,6 +58,28 @@ async def convert_to_response_dict(http_response, operation_model):
 
 
 class AioEndpoint(Endpoint):
+    def __init__(
+        self,
+        host,
+        endpoint_prefix,
+        event_emitter,
+        response_parser_factory=None,
+        http_session=None,
+    ):
+        if response_parser_factory is None:
+            response_parser_factory = AioResponseParserFactory()
+
+        if http_session is None:
+            raise ValueError('http_session must be provided')
+
+        super().__init__(
+            host=host,
+            endpoint_prefix=endpoint_prefix,
+            event_emitter=event_emitter,
+            response_parser_factory=response_parser_factory,
+            http_session=http_session,
+        )
+
     async def close(self):
         await self.http_session.close()
 

--- a/aiobotocore/eventstream.py
+++ b/aiobotocore/eventstream.py
@@ -3,6 +3,7 @@ from botocore.eventstream import (
     EventStreamBuffer,
     NoInitialResponseError,
 )
+from botocore.exceptions import EventStreamError
 
 
 class AioEventStream(EventStream):
@@ -14,7 +15,7 @@ class AioEventStream(EventStream):
 
     async def __anext__(self):
         async for event in self._event_generator:
-            parsed_event = self._parse_event(event)
+            parsed_event = await self._parse_event(event)
             if parsed_event:
                 yield parsed_event
 
@@ -24,6 +25,16 @@ class AioEventStream(EventStream):
             event_stream_buffer.add_data(chunk)
             for event in event_stream_buffer:
                 yield event  # unfortunately no yield from async func support
+
+    async def _parse_event(self, event):
+        response_dict = event.to_response_dict()
+        parsed_response = await self._parser.parse(
+            response_dict, self._output_shape
+        )
+        if response_dict['status_code'] == 200:
+            return parsed_response
+        else:
+            raise EventStreamError(parsed_response, self._operation_name)
 
     async def get_initial_response(self):
         try:

--- a/aiobotocore/response.py
+++ b/aiobotocore/response.py
@@ -150,10 +150,5 @@ async def get_response(operation_model, http_response):
         response_dict['body'] = await http_response.content
 
     parser = parsers.create_parser(protocol)
-    if asyncio.iscoroutinefunction(parser.parse):
-        parsed = await parser.parse(
-            response_dict, operation_model.output_shape
-        )
-    else:
-        parsed = parser.parse(response_dict, operation_model.output_shape)
+    parsed = await parser.parse(response_dict, operation_model.output_shape)
     return http_response, parsed

--- a/tests/botocore_tests/unit/test_eventstream.py
+++ b/tests/botocore_tests/unit/test_eventstream.py
@@ -27,9 +27,9 @@ from botocore.eventstream import (
     NoInitialResponseError,
 )
 from botocore.exceptions import EventStreamError
-from botocore.parsers import EventStreamXMLParser
 
 from aiobotocore.eventstream import AioEventStream
+from aiobotocore.parsers import AioEventStreamXMLParser
 
 EMPTY_MESSAGE = (
     b'\x00\x00\x00\x10\x00\x00\x00\x00\x05\xc2H\xeb}\x98\xc8\xff',
@@ -494,7 +494,7 @@ async def test_event_stream_wrapper_iteration():
         b"\x00\x00\x00+\x00\x00\x00\x0e4\x8b\xec{\x08event-id\x04\x00",
         b"\x00\xa0\x0c{'foo':'bar'}\xd3\x89\x02\x85",
     )
-    parser = mock.Mock(spec=EventStreamXMLParser)
+    parser = mock.Mock(spec=AioEventStreamXMLParser)
     output_shape = mock.Mock()
     event_stream = AioEventStream(raw_stream, output_shape, parser, '')
     events = [e async for e in event_stream]
@@ -510,7 +510,7 @@ async def test_event_stream_wrapper_iteration():
 
 async def test_eventstream_wrapper_iteration_error():
     raw_stream = create_mock_raw_stream(ERROR_EVENT_MESSAGE[0])
-    parser = mock.Mock(spec=EventStreamXMLParser)
+    parser = mock.Mock(spec=AioEventStreamXMLParser)
     parser.parse.return_value = {}
     output_shape = mock.Mock()
     event_stream = AioEventStream(raw_stream, output_shape, parser, '')
@@ -532,7 +532,7 @@ async def test_event_stream_initial_response():
         b'\x05event\x0b:event-type\x07\x00\x10initial-response\r:content-type',
         b'\x07\x00\ttext/json{"InitialResponse": "sometext"}\xf6\x98$\x83',
     )
-    parser = mock.Mock(spec=EventStreamXMLParser)
+    parser = mock.Mock(spec=AioEventStreamXMLParser)
     output_shape = mock.Mock()
     event_stream = AioEventStream(raw_stream, output_shape, parser, '')
     event = await event_stream.get_initial_response()
@@ -551,7 +551,7 @@ async def test_event_stream_initial_response_wrong_type():
         b"\x00\x00\x00+\x00\x00\x00\x0e4\x8b\xec{\x08event-id\x04\x00",
         b"\x00\xa0\x0c{'foo':'bar'}\xd3\x89\x02\x85",
     )
-    parser = mock.Mock(spec=EventStreamXMLParser)
+    parser = mock.Mock(spec=AioEventStreamXMLParser)
     output_shape = mock.Mock()
     event_stream = AioEventStream(raw_stream, output_shape, parser, '')
     with pytest.raises(NoInitialResponseError):
@@ -560,7 +560,7 @@ async def test_event_stream_initial_response_wrong_type():
 
 async def test_event_stream_initial_response_no_event():
     raw_stream = create_mock_raw_stream(b'')
-    parser = mock.Mock(spec=EventStreamXMLParser)
+    parser = mock.Mock(spec=AioEventStreamXMLParser)
     output_shape = mock.Mock()
     event_stream = AioEventStream(raw_stream, output_shape, parser, '')
     with pytest.raises(NoInitialResponseError):

--- a/tests/test_eventstreams.py
+++ b/tests/test_eventstreams.py
@@ -1,7 +1,7 @@
-import botocore.parsers
 import pytest
 
 from aiobotocore.eventstream import AioEventStream
+from aiobotocore.parsers import AioEventStreamXMLParser
 
 # TODO once Moto supports either S3 Select or Kinesis SubscribeToShard then
 # this can be tested against a real AWS API
@@ -50,7 +50,7 @@ async def test_eventstream_chunking(s3_client):
     outputshape = s3_client._service_model.operation_model(
         operation_name
     ).output_shape.members['Payload']
-    parser = botocore.parsers.EventStreamXMLParser()
+    parser = AioEventStreamXMLParser()
     sr = FakeStreamReader(TEST_STREAM_DATA)
 
     event_stream = AioEventStream(sr, outputshape, parser, operation_name)
@@ -79,7 +79,7 @@ async def test_eventstream_no_iter(s3_client):
     outputshape = s3_client._service_model.operation_model(
         operation_name
     ).output_shape.members['Payload']
-    parser = botocore.parsers.EventStreamXMLParser()
+    parser = AioEventStreamXMLParser()
     sr = FakeStreamReader(TEST_STREAM_DATA)
 
     event_stream = AioEventStream(sr, outputshape, parser, operation_name)

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -653,6 +653,12 @@ def test_protocol_parsers():
             },
         ),
         (
+            Endpoint.__init__,
+            {
+                '4bafe9733a02817950f5096612410ec4ebc40f55',
+            },
+        ),
+        (
             Endpoint.create_request,
             {
                 '37d0fbd02f91aef6c0499a2d0a725bf067c3ce8b',

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -723,6 +723,12 @@ def test_protocol_parsers():
             },
         ),
         (
+            EventStream._parse_event,
+            {
+                'c5b4e65fe718653a6f4cee4e8647f286f10fae05',
+            },
+        ),
+        (
             EventStream.get_initial_response,
             {
                 'aed648305970c90bb5d1e31f6fe5ff12cf6a2a06',
@@ -786,6 +792,12 @@ def test_protocol_parsers():
             },
         ),
         (
+            ResponseParser.parse,
+            {
+                'c2153eac3789855f4fc6a816a1f30a6afe0cf969',
+            },
+        ),
+        (
             ResponseParser._create_event_stream,
             {
                 '0564ba55383a71cc1ba3e5be7110549d7e9992f5',
@@ -825,13 +837,6 @@ def test_protocol_parsers():
             JSONParser._handle_event_stream,
             {
                 '3cf7bb1ecff0d72bafd7e7fd6625595b4060abd6',
-            },
-        ),
-        # NOTE, if this hits we need to change our ResponseParser impl in JSONParser
-        (
-            JSONParser.parse,
-            {
-                'c2153eac3789855f4fc6a816a1f30a6afe0cf969',
             },
         ),
         (


### PR DESCRIPTION
### Description of Change
Patch `ResponseParser.parse()` as well as `ClientArgsCreator.get_client_args()`, `Endpoint.__init__()`, and `EventStream._parse_event()`  in preparation for #1323.

Based on #1328 by @stj 

### Assumptions
* Thanks to #1329, we may be sure that all parsers have been patched. 
* `parsers.AioResponseParser` and many of its subclasses have not yet been released to PyPI. It is therefore considered safe to patch `.parse()` and remove checks in calling codepaths.

### Checklist for All Submissions
* [x] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst): implied in first item for pending release 2.22.0
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
* [ ] I have added URL to diff: https://github.com/boto/botocore/compare/[CURRENT_BOTO_VERSION_TAG]...[NEW_BOTO_VERSION_TAG]
