### PR TITLE
Fixes context propagation, adds context tests

### DIFF
--- a/aiobotocore/context.py
+++ b/aiobotocore/context.py
@@ -1,7 +1,6 @@
 from contextlib import asynccontextmanager
 from copy import deepcopy
 from functools import wraps
-from inspect import iscoroutinefunction
 
 from botocore.context import (
     ClientContext,
@@ -9,6 +8,8 @@ from botocore.context import (
     reset_context,
     set_context,
 )
+
+from ._helpers import resolve_awaitable
 
 
 @asynccontextmanager
@@ -31,10 +32,7 @@ def with_current_context(hook=None):
         async def wrapper(*args, **kwargs):
             async with start_as_current_context():
                 if hook:
-                    if iscoroutinefunction(hook):
-                        await hook()
-                    else:
-                        hook()
+                    await resolve_awaitable(hook())
                 return await func(*args, **kwargs)
 
         return wrapper

--- a/aiobotocore/paginate.py
+++ b/aiobotocore/paginate.py
@@ -1,13 +1,22 @@
+from functools import partial
+
 import aioitertools
 import jmespath
 from botocore.exceptions import PaginationError
 from botocore.paginate import PageIterator, Paginator
+from botocore.useragent import register_feature_id
 from botocore.utils import merge_dicts, set_value_from_jmespath
+
+from .context import with_current_context
 
 
 class AioPageIterator(PageIterator):
     def __aiter__(self):
         return self.__anext__()
+
+    @with_current_context(partial(register_feature_id, 'PAGINATOR'))
+    async def _make_request(self, current_kwargs):
+        return await self._method(**current_kwargs)
 
     async def __anext__(self):
         current_kwargs = self._op_kwargs

--- a/aiobotocore/waiter.py
+++ b/aiobotocore/waiter.py
@@ -2,7 +2,6 @@ import asyncio
 from functools import partial
 
 # WaiterModel is required for client.py import
-from botocore.context import with_current_context
 from botocore.docs.docstring import WaiterDocstring
 from botocore.exceptions import ClientError
 from botocore.useragent import register_feature_id
@@ -18,6 +17,8 @@ from botocore.waiter import (
     logger,
     xform_name,
 )
+
+from .context import with_current_context
 
 
 def create_waiter_with_client(waiter_name, waiter_model, client):

--- a/tests/botocore_tests/functional/test_useragent.py
+++ b/tests/botocore_tests/functional/test_useragent.py
@@ -1,0 +1,123 @@
+import asyncio
+
+from aiobotocore.session import AioSession
+
+from ...mock_server import AIOServer
+from .. import ClientHTTPStubber
+
+
+def get_captured_ua_strings(stubber):
+    """Get captured request-level user agent strings from stubber.
+    :type stubber: tests.BaseHTTPStubber
+    """
+    return [req.headers['User-Agent'].decode() for req in stubber.requests]
+
+
+def parse_registered_feature_ids(ua_string):
+    """Parse registered feature ids in user agent string.
+    :type ua_string: str
+    :rtype: list[str]
+    """
+    ua_fields = ua_string.split(' ')
+    feature_field = [field for field in ua_fields if field.startswith('m/')][0]
+    return feature_field[2:].split(',')
+
+
+async def test_user_agent_has_registered_feature_id():
+    session = AioSession()
+
+    async with (
+        AIOServer() as server,
+        session.create_client(
+            's3',
+            endpoint_url=server.endpoint_url,
+            aws_secret_access_key='xxx',
+            aws_access_key_id='xxx',
+        ) as s3_client,
+    ):
+        with ClientHTTPStubber(s3_client) as stub_client:
+            stub_client.add_response()
+            paginator = s3_client.get_paginator('list_buckets')
+            # The `paginate()` method registers `'PAGINATOR': 'C'`
+            async for _ in paginator.paginate():
+                pass
+
+        ua_string = get_captured_ua_strings(stub_client)[0]
+        feature_list = parse_registered_feature_ids(ua_string)
+        assert 'C' in feature_list
+
+
+async def test_registered_feature_ids_dont_bleed_between_requests():
+    session = AioSession()
+
+    async with (
+        AIOServer() as server,
+        session.create_client(
+            's3',
+            endpoint_url=server.endpoint_url,
+            aws_secret_access_key='xxx',
+            aws_access_key_id='xxx',
+        ) as s3_client,
+    ):
+        with ClientHTTPStubber(s3_client) as stub_client:
+            stub_client.add_response()
+            waiter = s3_client.get_waiter('bucket_exists')
+            # The `wait()` method registers `'WAITER': 'B'`
+            await waiter.wait(Bucket='mybucket')
+
+            stub_client.add_response()
+            paginator = s3_client.get_paginator('list_buckets')
+            # The `paginate()` method registers `'PAGINATOR': 'C'`
+            async for _ in paginator.paginate():
+                pass
+
+        ua_strings = get_captured_ua_strings(stub_client)
+        waiter_feature_list = parse_registered_feature_ids(ua_strings[0])
+        assert 'B' in waiter_feature_list
+
+        paginator_feature_list = parse_registered_feature_ids(ua_strings[1])
+        assert 'C' in paginator_feature_list
+        assert 'B' not in paginator_feature_list
+
+
+# This tests context's bleeding across tasks instead
+async def test_registered_feature_ids_dont_bleed_across_threads():
+    session = AioSession()
+
+    async with (
+        AIOServer() as server,
+        session.create_client(
+            's3',
+            endpoint_url=server.endpoint_url,
+            aws_secret_access_key='xxx',
+            aws_access_key_id='xxx',
+        ) as s3_client,
+    ):
+
+        async def wait():
+            with ClientHTTPStubber(s3_client) as stub_client:
+                stub_client.add_response()
+                waiter = s3_client.get_waiter('bucket_exists')
+                # The `wait()` method registers `'WAITER': 'B'`
+                await waiter.wait(Bucket='mybucket')
+            ua_string = get_captured_ua_strings(stub_client)[0]
+            return parse_registered_feature_ids(ua_string)
+
+        async def paginate():
+            with ClientHTTPStubber(s3_client) as stub_client:
+                stub_client.add_response()
+                paginator = s3_client.get_paginator('list_buckets')
+                # The `paginate()` method registers `'PAGINATOR': 'C'`
+                async for _ in paginator.paginate():
+                    pass
+            ua_string = get_captured_ua_strings(stub_client)[0]
+            return parse_registered_feature_ids(ua_string)
+
+        waiter_features, paginator_features = await asyncio.gather(
+            wait(), paginate()
+        )
+
+        assert 'B' in waiter_features
+        assert 'C' not in waiter_features
+        assert 'C' in paginator_features
+        assert 'B' not in paginator_features

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -787,6 +787,12 @@ def test_protocol_parsers():
             },
         ),
         (
+            PageIterator._make_request,
+            {
+                'e926671018897ac5851a3add5d2bc15a2d6142df',
+            },
+        ),
+        (
             PageIterator.result_key_iters,
             {
                 'e8cd36fdc4960e08c9aa50196c4e5d1ee4e39756',


### PR DESCRIPTION
Part 2 of #1362, fixes some tests and context usage.

Fixes:
* Changes context hook evaluation to use `resolve_awaitable`
* Missing context propagation to paginators
* Importing wrong `with_current_context` for waiters

Adds:
* `botocore.tests.ClientHTTPStubber`, this is somewhat different to the "Stubber" functionality. Is ported in so that we can reuse some functional tests which inspect request headers.
* Adds _some_ botocore useragent functional tests, specifically the ones which test context usage and propagation