### PR TITLE
Migrate to modern docutils interface

### DIFF
--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -33,13 +33,20 @@ _rst_ver_date_str_re = re.compile(
 )
 
 
-# from: https://stackoverflow.com/a/48719723/1241593
+# from: https://stackoverflow.com/a/75996218
 def _parse_rst(text: str) -> docutils.nodes.document:
     parser = docutils.parsers.rst.Parser()
-    components = (docutils.parsers.rst.Parser,)
-    settings = docutils.frontend.OptionParser(
-        components=components
-    ).get_default_values()
+    if hasattr(docutils.frontend, 'get_default_settings'):
+        # Docutils >= 0.18
+        settings = docutils.frontend.get_default_settings(
+            docutils.parsers.rst.Parser
+        )
+    else:
+        # Docutils < 0.18
+        components = (docutils.parsers.rst.Parser,)
+        settings = docutils.frontend.OptionParser(
+            components=components
+        ).get_default_values()
     document = docutils.utils.new_document('<rst-doc>', settings=settings)
     parser.parse(text, document)
     return document


### PR DESCRIPTION
### Description of Change
`OptionParser` is deprecated in Docutils 0.18 and is expected to be removed in Docutils 0.22. The replacement, `get_default_settings`, was introduced in Docutils 0.18. This leads to the following warnings in the [CI logs](https://github.com/aio-libs/aiobotocore/actions/runs/15561595711/job/43815039801#step:5:4235):
```python
 /home/runner/work/aiobotocore/aiobotocore/tests/test_version.py:40: DeprecationWarning: The frontend.OptionParser class will be replaced by a subclass of argparse.ArgumentParser in Docutils 0.21 or later.
    settings = docutils.frontend.OptionParser(
```
This small PR updates `_parse_rst` method of `tests/test_version.py` to avoid the deprecated `docutils.frontend.OptionParser` by using `get_default_settings` when available. 

Please note that the aiobotocore project specifies `docutils >= 0.16, < 0.22` in the project setup, so this change maintains compatibility with all supported versions and future-proofs the code for upcoming releases. See [SO thread](https://stackoverflow.com/a/75996218) for my information.

### Assumptions

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [x] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
* [ ] I have added URL to diff: https://github.com/boto/botocore/compare/[CURRENT_BOTO_VERSION_TAG]...[NEW_BOTO_VERSION_TAG]
