### PR TITLE
Disallow creating new sessions if client exits context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,9 @@
 Changes
 -------
+2.24.2 (XXXX-XX-XX)
+^^^^^^^^^^^^^^^^^^^
+* forbid creating loose ``ClientSession`` when ``AioBaseClient`` exits context
+
 2.24.1 (2025-08-15)
 ^^^^^^^^^^^^^^^^^^^
 * fix endpoint circular import error

--- a/aiobotocore/httpsession.py
+++ b/aiobotocore/httpsession.py
@@ -3,6 +3,7 @@ import contextlib
 import io
 import os
 import socket
+from threading import Lock
 from typing import Optional
 
 import aiohttp  # lgtm [py/import-and-import-from]
@@ -43,6 +44,8 @@ import aiobotocore.awsrequest
 
 from ._constants import DEFAULT_KEEPALIVE_TIMEOUT
 from ._endpoint_helpers import _IOBaseWrapper, _text
+
+_session_lock = Lock()
 
 
 class AIOHTTPSession:
@@ -99,13 +102,29 @@ class AIOHTTPSession:
         # request so don't need proxy manager
 
     async def __aenter__(self):
-        assert not self._sessions
+        with _session_lock:
+            self._aexited = False
 
+        assert not self._sessions
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         self._sessions.clear()
         await self._exit_stack.aclose()
+
+        with _session_lock:
+            self._aexited = True
+
+    @property
+    def _can_create_session(self) -> bool:
+        """Check if a new client session can be created.
+
+        This is true for two cases:
+        - We are inside the context manager of the class.
+        - We have never attempted to enter the context manager.
+        """
+        with _session_lock:
+            return not getattr(self, '_aexited', False)
 
     def _get_ssl_context(self):
         return create_urllib3_context()
@@ -173,6 +192,11 @@ class AIOHTTPSession:
 
     async def _get_session(self, proxy_url):
         if not (session := self._sessions.get(proxy_url)):
+            if not self._can_create_session:
+                raise RuntimeError(
+                    f'Cannot create a new {aiohttp.ClientSession.__name__} '
+                    'when context manager was exited.'
+                )
             connector = self._create_connector(proxy_url)
             self._sessions[proxy_url] = (
                 session

--- a/tests/botocore_tests/unit/test_session.py
+++ b/tests/botocore_tests/unit/test_session.py
@@ -152,6 +152,21 @@ class TestCreateClient(BaseSessionTest):
         async with sts_client_context as sts_client:
             assert isinstance(sts_client, client.AioBaseClient)
 
+    async def test_cannot_create_client_sessions_outside_context(
+        self, session
+    ):
+        s3_client_context = session.create_client('s3', 'us-west-2')
+
+        async with s3_client_context as s3_client:
+            pass
+
+        with pytest.raises(
+            botocore.exceptions.HTTPClientError,
+            match='Cannot create a new ClientSession when context manager was'
+            ' exited',
+        ):
+            await s3_client.list_buckets()
+
     async def test_credential_provider_not_called_when_creds_provided(
         self, session
     ):


### PR DESCRIPTION
### Description of Change

Once an `AioBaseClient` is used as a context manager and exits, forbid any following attempt to create a new session. 

If `AioBaseClient` is never used as a context manager, this restriction does not apply.

### Assumptions

### Checklist for All Submissions
* [x] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [x] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details): https://github.com/aio-libs/aiobotocore/discussions/1398
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

(**_not applicable_**)

* [x] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
* [ ] I have added URL to diff: https://github.com/boto/botocore/compare/[CURRENT_BOTO_VERSION_TAG]...[NEW_BOTO_VERSION_TAG]
