### PR TITLE
Fix compatibility with botocore v1.40.19+

### DIFF
--- a/aiobotocore/signers.py
+++ b/aiobotocore/signers.py
@@ -158,10 +158,6 @@ class AioRequestSigner(RequestSigner):
             return auth
 
         credentials = request_credentials or self._credentials
-        if credentials and (
-            cred_method := getattr(credentials, 'method', None)
-        ):
-            self.check_and_register_feature_id(cred_method)
         if getattr(cls, "REQUIRES_IDENTITY_CACHE", None) is True:
             cache = kwargs["identity_cache"]
             key = kwargs["cache_key"]


### PR DESCRIPTION
The botocore method `RequestSigner.check_and_register_feature_id()` was removed in https://github.com/boto/botocore/pull/3547.

From what I can tell, calling it should no longer be necessary during signing since credentials are registered on retrieval.