### PR TITLE
Add Python 3.14 to CI/CD test matrix

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -38,6 +38,7 @@ jobs:
         - 3.11
         - 3.12
         - 3.13
+        - 3.14
         os:
         - ubuntu-24.04
         - ubuntu-24.04-arm
@@ -46,21 +47,10 @@ jobs:
         experimental:
         - false
         include:
-        - python-version: 3.13  # add a no-httpx run
+        - python-version: 3.14  # add a no-httpx run
           os: ubuntu-24.04
           no-httpx: true
           experimental: false
-
-      # add experimental 3.14 runs. Move this to being a 3.14 python-version
-      # entry when stable.
-      # - python-version: 3.14
-      #   os: ubuntu-24.04
-      #   no-httpx: false
-      #   experimental: true
-      # - python-version: 3.14
-      #   os: ubuntu-24.04-arm
-      #   no-httpx: false
-      #   experimental: true
       fail-fast: false
     uses: ./.github/workflows/reusable-test.yml
     with:


### PR DESCRIPTION
### Description of Change
Add Python 3.14 to CI/CD test matrix

### Assumptions
The final release of Python 3.14 has been shipped.

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
* [ ] I have added URL to diff: https://github.com/boto/botocore/compare/[CURRENT_BOTO_VERSION_TAG]...[NEW_BOTO_VERSION_TAG]
