### PR TITLE
Remove `awscli` packaging extra

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,5 +20,5 @@
 
 * [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
 * [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
-* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
+* [ ] I have ensured that the boto3 version matches the updated botocore version
 * [ ] I have added URL to diff: https://github.com/boto/botocore/compare/[CURRENT_BOTO_VERSION_TAG]...[NEW_BOTO_VERSION_TAG]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,10 @@
 Changes
 -------
 
-3.0.0 (2025-11-30)
+3.0.0 (2025-11-28)
 ^^^^^^^^^^^^^^^^^^^
 * BREAKING: forbid creating loose ``ClientSession`` when ``AioBaseClient`` exits context
+* BREAKING: remove `awscli` packaging extra. Instead of ``pip install aiobotocore[awscli]``, use ``pip install aiobotocore awscli`` or similar to install compatible versions of `aiobotocore`, `botocore` and `awscli`.
 
 2.26.0 (2025-11-27)
 ^^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -217,15 +217,12 @@ Requirements
 .. _pyright: https://github.com/microsoft/pyright
 .. _mypy: http://mypy-lang.org/
 
-awscli & boto3
+boto3
 --------------
 
-awscli and boto3 depend on a single version, or a narrow range of versions, of botocore.
+boto3 depends on a single version, or a narrow range of versions, of botocore.
 However, aiobotocore only supports a specific range of botocore versions. To ensure you
-install the latest version of awscli and boto3 that your specific combination or
+install the latest version of boto3 that your specific combination of
 aiobotocore and botocore can support use::
 
-    pip install -U 'aiobotocore[awscli,boto3]'
-
-If you only need awscli and not boto3 (or vice versa) you can just install one extra or
-the other.
+    pip install -U 'aiobotocore[boto3]'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -78,14 +78,14 @@ Basic Example
     loop.run_until_complete(go())
 
 
-awscli
+boto3
 ------
 
-awscli depends on a single version of botocore, however aiobotocore only supports a
+boto3 depends on a single version of botocore, however aiobotocore only supports a
 specific range of botocore versions. To ensure you install the latest version of
-awscli that your specific combination or aiobotocore and botocore can support use::
+boto3 that your specific combination of aiobotocore and botocore can support use::
 
-    pip install -U aiobotocore[awscli]
+    pip install -U aiobotocore[boto3]
 
 Contents
 --------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-awscli = [
-    "awscli >= 1.43.0, < 1.43.6",
-]
 boto3 = [
     "boto3 >= 1.41.0, < 1.41.6",
 ]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -100,7 +100,7 @@ def _get_boto_module_versions(
             assert False, f'Unsupported ver: {ver}'
 
         module = ver.req.name
-        if module not in {'botocore', 'awscli', 'boto3'}:
+        if module not in {'botocore', 'boto3'}:
             continue
 
         # NOTE: don't support complex versioning yet as requirements are unknown
@@ -186,18 +186,6 @@ def test_release_versions():
             _get_requirements_from_pyproject_toml(content),
             False,
         )
-
-    # get awscli reqs
-    awscli_resp = requests.get(
-        f"https://raw.githubusercontent.com/aws/aws-cli/"
-        f"{aioboto_reqs['awscli'].least_version}/setup.py"
-    )
-    awscli_reqs = _get_boto_module_versions(
-        _get_requirements_from_setup_py(awscli_resp.text)
-    )
-    assert awscli_reqs['botocore'].specifier_set.contains(
-        aioboto_reqs['botocore'].least_version
-    )
 
     # get boto3 reqs
     boto3_resp = requests.get(

--- a/uv.lock
+++ b/uv.lock
@@ -21,9 +21,6 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-awscli = [
-    { name = "awscli" },
-]
 boto3 = [
     { name = "boto3" },
 ]
@@ -61,7 +58,6 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.2,<4.0.0" },
     { name = "aioitertools", specifier = ">=0.5.1,<1.0.0" },
-    { name = "awscli", marker = "extra == 'awscli'", specifier = ">=1.43.0,<1.43.6" },
     { name = "boto3", marker = "extra == 'boto3'", specifier = ">=1.41.0,<1.41.6" },
     { name = "botocore", specifier = ">=1.41.0,<1.41.6" },
     { name = "httpx", marker = "extra == 'httpx'", specifier = ">=0.25.1,<0.29" },
@@ -70,7 +66,7 @@ requires-dist = [
     { name = "python-dateutil", specifier = ">=2.1,<3.0.0" },
     { name = "wrapt", specifier = ">=1.10.10,<2.0.0" },
 ]
-provides-extras = ["awscli", "boto3", "httpx"]
+provides-extras = ["boto3", "httpx"]
 
 [package.metadata.requires-dev]
 awscrt = [{ name = "botocore", extras = ["crt"] }]
@@ -343,23 +339,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e0/6c/8e7fb2a45f20afc5c19d52807b560793fb48b0feca1de7de116b62a7893e/aws_xray_sdk-2.14.0.tar.gz", hash = "sha256:aab843c331af9ab9ba5cefb3a303832a19db186140894a523edafc024cc0493c", size = 93976, upload-time = "2024-06-04T22:11:38.124Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/69/b417833a8926fa5491e5346d7c233bf7d8a9b12ba1f4ef41ccea2494000c/aws_xray_sdk-2.14.0-py2.py3-none-any.whl", hash = "sha256:cfbe6feea3d26613a2a869d14c9246a844285c97087ad8f296f901633554ad94", size = 101922, upload-time = "2024-06-04T22:12:25.729Z" },
-]
-
-[[package]]
-name = "awscli"
-version = "1.43.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "botocore" },
-    { name = "colorama" },
-    { name = "docutils" },
-    { name = "pyyaml" },
-    { name = "rsa" },
-    { name = "s3transfer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/15/f0b0b62dbf139b1906f99439cd292ebe8df397a3e4e35ede61cb06e1abed/awscli-1.43.5.tar.gz", hash = "sha256:4ff153bf2f9097eeb794d4150522df204ea982b6da08eb82f7fd09c138ac46cf", size = 1878320, upload-time = "2025-11-26T20:27:43.631Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/a1/1e7e0f29b7d3d327b5ebcf967f2efe697cb635f7514828c9f6dc794ed14b/awscli-1.43.5-py3-none-any.whl", hash = "sha256:8707de8e4c4e42a0fded867c1369027a5e6149c128815d487aedab34de71152c", size = 4631862, upload-time = "2025-11-26T20:27:41.651Z" },
 ]
 
 [[package]]
@@ -1913,15 +1892,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyasn1"
-version = "0.6.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322, upload-time = "2024-09-10T22:41:42.55Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135, upload-time = "2024-09-11T16:00:36.122Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "2.23"
 source = { registry = "https://pypi.org/simple" }
@@ -2602,18 +2572,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/40/7f/8b7b136069ef7ac3960eda25d832639bdb163018a34c960ed042dd1707c8/rpds_py-0.27.1-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:7e32721e5d4922deaaf963469d795d5bde6093207c52fec719bd22e5d1bedbc4", size = 590384, upload-time = "2025-08-27T12:16:31.005Z" },
     { url = "https://files.pythonhosted.org/packages/d8/06/c316d3f6ff03f43ccb0eba7de61376f8ec4ea850067dddfafe98274ae13c/rpds_py-0.27.1-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:2c426b99a068601b5f4623573df7a7c3d72e87533a2dd2253353a03e7502566c", size = 555959, upload-time = "2025-08-27T12:16:32.73Z" },
     { url = "https://files.pythonhosted.org/packages/60/94/384cf54c430b9dac742bbd2ec26c23feb78ded0d43d6d78563a281aec017/rpds_py-0.27.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:4fc9b7fe29478824361ead6e14e4f5aed570d477e06088826537e202d25fe859", size = 228784, upload-time = "2025-08-27T12:16:34.428Z" },
-]
-
-[[package]]
-name = "rsa"
-version = "4.7.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/db/b5/475c45a58650b0580421746504b680cd2db4e81bc941e94ca53785250269/rsa-4.7.2.tar.gz", hash = "sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9", size = 39711, upload-time = "2021-02-24T10:55:05.846Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/93/0c0f002031f18b53af7a6166103c02b9c0667be528944137cc954ec921b3/rsa-4.7.2-py3-none-any.whl", hash = "sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2", size = 34505, upload-time = "2021-02-24T10:55:03.55Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description of Change
Remove the `awscli` packaging extra.

### Assumptions
The discussion around #1424 has not yielded substantial concerns with regards to removing the `awscli` packaging extra. This PR makes the proposed change concrete and may act as another opportunity for critical discussion or feedback.

### Checklist for All Submissions
* [x] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [x] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details): partially addresses #1424
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the awscli/boto3 versions match the updated botocore version
* [ ] I have added URL to diff: https://github.com/boto/botocore/compare/[CURRENT_BOTO_VERSION_TAG]...[NEW_BOTO_VERSION_TAG]
