### PR TITLE
Remove `boto3` packaging extra

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,5 +20,4 @@
 
 * [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
 * [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
-* [ ] I have ensured that the boto3 version matches the updated botocore version
 * [ ] I have added URL to diff: https://github.com/boto/botocore/compare/[CURRENT_BOTO_VERSION_TAG]...[NEW_BOTO_VERSION_TAG]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changes
 ^^^^^^^^^^^^^^^^^^^
 * BREAKING: forbid creating loose ``ClientSession`` when ``AioBaseClient`` exits context
 * BREAKING: remove `awscli` packaging extra. Instead of ``pip install aiobotocore[awscli]``, use ``pip install aiobotocore awscli`` or similar to install compatible versions of `aiobotocore`, `botocore` and `awscli`.
+* BREAKING: remove `boto3` packaging extra. Instead of ``pip install aiobotocore[boto3]``, use ``pip install aiobotocore boto3`` or similar to install compatible versions of `aiobotocore`, `botocore` and `boto3`.
 * relax botocore dependency specification
 
 2.26.0 (2025-11-27)

--- a/README.rst
+++ b/README.rst
@@ -216,13 +216,3 @@ Requirements
 .. _Pylance: https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance
 .. _pyright: https://github.com/microsoft/pyright
 .. _mypy: http://mypy-lang.org/
-
-boto3
---------------
-
-boto3 depends on a single version, or a narrow range of versions, of botocore.
-However, aiobotocore only supports a specific range of botocore versions. To ensure you
-install the latest version of boto3 that your specific combination of
-aiobotocore and botocore can support use::
-
-    pip install -U 'aiobotocore[boto3]'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -77,16 +77,6 @@ Basic Example
     loop = asyncio.get_event_loop()
     loop.run_until_complete(go())
 
-
-boto3
-------
-
-boto3 depends on a single version of botocore, however aiobotocore only supports a
-specific range of botocore versions. To ensure you install the latest version of
-boto3 that your specific combination of aiobotocore and botocore can support use::
-
-    pip install -U aiobotocore[boto3]
-
 Contents
 --------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-boto3 = [
-    "boto3 >= 1.41.0, < 1.42.2",
-]
 httpx = [
     "httpx >= 0.25.1, < 0.29"
 ]
@@ -77,7 +74,6 @@ dev = [
     "pip >= 24.3.1, < 26", # Used in test_version.py
     "pre-commit >= 3.5.0, < 5",
     "pytest-rerunfailures >= 16.0.1, < 17", # Used in test_lambda.py
-    "requests >= 2.32.3, < 3", # Used in test_version.py
     "time-machine >= 2.15.0, < 4", # Used in test_signers.py
     "tomli; python_version<'3.11'", # Used in test_version.py
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -21,9 +21,6 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-boto3 = [
-    { name = "boto3" },
-]
 httpx = [
     { name = "httpx" },
 ]
@@ -50,7 +47,6 @@ dev = [
     { name = "pre-commit", version = "4.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-rerunfailures", version = "16.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest-rerunfailures", version = "16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "requests" },
     { name = "time-machine", version = "2.19.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "time-machine", version = "3.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -60,7 +56,6 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.2,<4.0.0" },
     { name = "aioitertools", specifier = ">=0.5.1,<1.0.0" },
-    { name = "boto3", marker = "extra == 'boto3'", specifier = ">=1.41.0,<1.42.2" },
     { name = "botocore", specifier = ">=1.41.0,<1.42.2" },
     { name = "httpx", marker = "extra == 'httpx'", specifier = ">=0.25.1,<0.29" },
     { name = "jmespath", specifier = ">=0.7.1,<2.0.0" },
@@ -68,7 +63,7 @@ requires-dist = [
     { name = "python-dateutil", specifier = ">=2.1,<3.0.0" },
     { name = "wrapt", specifier = ">=1.10.10,<3.0.0" },
 ]
-provides-extras = ["boto3", "httpx"]
+provides-extras = ["httpx"]
 
 [package.metadata.requires-dev]
 awscrt = [{ name = "botocore", extras = ["crt"] }]
@@ -88,7 +83,6 @@ dev = [
     { name = "pip", specifier = ">=24.3.1,<26" },
     { name = "pre-commit", specifier = ">=3.5.0,<5" },
     { name = "pytest-rerunfailures", specifier = ">=16.0.1,<17" },
-    { name = "requests", specifier = ">=2.32.3,<3" },
     { name = "time-machine", specifier = ">=2.15.0,<4" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]


### PR DESCRIPTION
### Description of Change
Remove `boto3` packaging extra

### Assumptions
The discussion around #1424 has not yielded substantial concerns with regards to removing the boto3 packaging extra. This PR makes the proposed change concrete and may act as another opportunity for critical discussion or feedback.

### Checklist for All Submissions
* [x] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [x] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details): closes #1252, closes #1424
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have ensured that the boto3 version matches the updated botocore version
* [ ] I have added URL to diff: https://github.com/boto/botocore/compare/[CURRENT_BOTO_VERSION_TAG]...[NEW_BOTO_VERSION_TAG]
