### PR TITLE
Remove Codecov token from CI jobs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -88,7 +88,6 @@ jobs:
       with:
         fail_ci_if_error: true
         run_command: send-notifications
-        token: ${{ secrets.CODECOV_TOKEN }}  # not required for public repos
 
   zizmor:
     name: 🌈 zizmor

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -78,7 +78,6 @@ jobs:
       # yamllint disable-line rule:line-length
       uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de  # v5.5.2
       with:
-        token: ${{ secrets.codecov-token }}  # not required for public repos
         files: ./coverage.xml
         # yamllint disable-line rule:line-length
         flags: unittests,os-${{ inputs.os }},python-${{ inputs.python-version }}${{ inputs.with-awscrt && ',with-awscrt' || '' }}${{ inputs.no-httpx && ',no-httpx' || '' }}  # optional


### PR DESCRIPTION
### Description of Change
Remove Codecov token from CI jobs to address zizmor security scanning alerts.

### Assumptions
* Codecov token is not needed for public repositories (as demonstrated by successful checks below).
* Upon merging, the Codecov token still needs to be deleted from repository config to complete the change.

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst)
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/master/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have added URL to diff: https://github.com/boto/botocore/compare/[CURRENT_BOTO_VERSION_TAG]...[NEW_BOTO_VERSION_TAG]
