### PR TITLE
Clean up `localonly` tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,4 +176,5 @@ docstring-code-line-length = "dynamic"
 [tool.coverage.report]
 exclude_also = [
     "if TYPE_CHECKING",
+    "@pytest.mark.localonly",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -212,10 +212,9 @@ def aws_auth():
 
 
 @pytest.fixture
-def mocking_test():
+def mocking_test(request) -> bool:
     # change this flag for test with real aws
-    # TODO: this should be merged with pytest.mark.moto
-    return True
+    return request.node.get_closest_marker("localonly") is None
 
 
 @pytest.fixture

--- a/tests/test_basic_s3.py
+++ b/tests/test_basic_s3.py
@@ -559,10 +559,9 @@ async def test_presign_with_existing_query_string_values(
 
 @pytest.mark.parametrize('region', ['us-east-1'])
 @pytest.mark.parametrize('signature_version', ['s3v4'])
-# moto host will be localhost
 @pytest.mark.localonly
 async def test_presign_sigv4(
-    s3_client, bucket_name, aio_session, create_object
+    moto_server, s3_client, bucket_name, aio_session, create_object
 ):
     key = 'myobject'
     await create_object(key_name=key)
@@ -570,12 +569,10 @@ async def test_presign_sigv4(
         'get_object', Params={'Bucket': bucket_name, 'Key': key}
     )
     msg = (
-        "Host was suppose to be the us-east-1 endpoint, "
+        "Host was supposed to be the local moto server, "
         f"instead got: {presigned_url}"
     )
-    assert presigned_url.startswith(
-        f'https://{bucket_name}.s3.amazonaws.com/{key}'
-    ), msg
+    assert presigned_url.startswith(f'{moto_server}/{bucket_name}/{key}'), msg
 
     # Try to retrieve the object using the presigned url.
     if httpx and isinstance(aio_session, httpx.AsyncClient):

--- a/tests/test_basic_s3.py
+++ b/tests/test_basic_s3.py
@@ -52,7 +52,6 @@ async def test_fail_proxy_request(
         await s3_client.list_buckets()
 
 
-@pytest.mark.parametrize('mocking_test', [False])
 @pytest.mark.localonly
 async def test_succeed_proxy_request(aa_succeed_proxy_config, s3_client):
     result = await s3_client.list_buckets()
@@ -375,7 +374,6 @@ async def test_paginate_within_page_boundaries(
     assert fourth['Contents'][-1]['Key'] == 'd'
 
 
-@pytest.mark.parametrize('mocking_test', [False])
 @pytest.mark.localonly
 async def test_unicode_key_put_list(s3_client, bucket_name, create_object):
     # Verify we can upload a key with a unicode char and list it as well.
@@ -390,7 +388,6 @@ async def test_unicode_key_put_list(s3_client, bucket_name, create_object):
     assert data == b'foo'
 
 
-@pytest.mark.parametrize('mocking_test', [False])
 @pytest.mark.localonly
 async def test_unicode_system_character(s3_client, bucket_name, create_object):
     # Verify we can use a unicode system character which would normally
@@ -531,7 +528,6 @@ async def test_copy_with_s3_metadata(s3_client, create_object, bucket_name):
 @pytest.mark.parametrize('region', ['us-east-1'])
 @pytest.mark.parametrize('signature_version', ['s3'])
 # 'Content-Disposition' not supported by moto yet
-@pytest.mark.parametrize('mocking_test', [False])
 @pytest.mark.localonly
 async def test_presign_with_existing_query_string_values(
     s3_client, bucket_name, aio_session, create_object
@@ -564,7 +560,6 @@ async def test_presign_with_existing_query_string_values(
 @pytest.mark.parametrize('region', ['us-east-1'])
 @pytest.mark.parametrize('signature_version', ['s3v4'])
 # moto host will be localhost
-@pytest.mark.parametrize('mocking_test', [False])
 @pytest.mark.localonly
 async def test_presign_sigv4(
     s3_client, bucket_name, aio_session, create_object
@@ -593,7 +588,6 @@ async def test_presign_sigv4(
 
 
 @pytest.mark.parametrize('signature_version', ['s3v4'])
-@pytest.mark.parametrize('mocking_test', [False])
 @pytest.mark.localonly
 async def test_can_follow_signed_url_redirect(
     alternative_s3_client, create_object, bucket_name
@@ -614,7 +608,6 @@ async def test_can_follow_signed_url_redirect(
 
 @pytest.mark.parametrize('region', ['eu-west-1'])
 @pytest.mark.parametrize('alternative_region', ['us-west-2'])
-@pytest.mark.parametrize('mocking_test', [False])
 @pytest.mark.localonly
 async def test_bucket_redirect(
     s3_client, alternative_s3_client, region, create_bucket

--- a/tests/test_basic_s3.py
+++ b/tests/test_basic_s3.py
@@ -374,7 +374,6 @@ async def test_paginate_within_page_boundaries(
     assert fourth['Contents'][-1]['Key'] == 'd'
 
 
-@pytest.mark.localonly
 async def test_unicode_key_put_list(s3_client, bucket_name, create_object):
     # Verify we can upload a key with a unicode char and list it as well.
     key_name = '\u2713'
@@ -415,7 +414,6 @@ async def test_non_normalized_key_paths(s3_client, bucket_name, create_object):
 
 
 @pytest.mark.skipif(True, reason='Not supported')
-@pytest.mark.localonly
 async def test_reset_stream_on_redirects(region, create_bucket):
     # Create a bucket in a non classic region.
     bucket_name = await create_bucket(region)
@@ -559,7 +557,6 @@ async def test_presign_with_existing_query_string_values(
 
 @pytest.mark.parametrize('region', ['us-east-1'])
 @pytest.mark.parametrize('signature_version', ['s3v4'])
-@pytest.mark.localonly
 async def test_presign_sigv4(
     moto_server, s3_client, bucket_name, aio_session, create_object
 ):
@@ -585,7 +582,6 @@ async def test_presign_sigv4(
 
 
 @pytest.mark.parametrize('signature_version', ['s3v4'])
-@pytest.mark.localonly
 async def test_can_follow_signed_url_redirect(
     alternative_s3_client, create_object, bucket_name
 ):
@@ -605,7 +601,6 @@ async def test_can_follow_signed_url_redirect(
 
 @pytest.mark.parametrize('region', ['eu-west-1'])
 @pytest.mark.parametrize('alternative_region', ['us-west-2'])
-@pytest.mark.localonly
 async def test_bucket_redirect(
     s3_client, alternative_s3_client, region, create_bucket
 ):

--- a/tests/test_basic_s3.py
+++ b/tests/test_basic_s3.py
@@ -383,8 +383,8 @@ async def test_unicode_key_put_list(s3_client, bucket_name, create_object):
     assert len(parsed['Contents']) == 1
     assert parsed['Contents'][0]['Key'] == key_name
     parsed = await s3_client.get_object(Bucket=bucket_name, Key=key_name)
-    data = await parsed['Body'].read()
-    await parsed['Body'].aclose()
+    async with parsed['Body'] as stream:
+        data = await stream.read()
     assert data == b'foo'
 
 


### PR DESCRIPTION
### Description of Change
* Base `mocking_test` pytest fixture onto `localonly` marker
* Fix broken `localonly` tests
* Remove unnecessary `localonly` markers
* Exclude remaining unit tests marked `localonly` from coverage

### Assumptions
This PR prepares the project for eventual implementation of #1490.

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/main/CHANGES.rst)
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/main/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have added URL to diff: https://github.com/boto/botocore/compare/[CURRENT_BOTO_VERSION_TAG]...[NEW_BOTO_VERSION_TAG]
