### PR TITLE
Add Claude Code and Botocore Sync workflows

### DIFF
--- a/.github/botocore-sync-prompt.md
+++ b/.github/botocore-sync-prompt.md
@@ -1,0 +1,467 @@
+You are a botocore sync bot for aiobotocore. Your goal:
+update aiobotocore to support botocore $LATEST_BOTOCORE
+(current upper bound: $CURRENT_UPPER).
+
+## Configuration
+
+- ENABLE_BUMP: $ENABLE_BUMP (if false, bumps create a
+  feedback issue instead of attempting code changes)
+- DRY_RUN: $DRY_RUN (if true, analyze only — post results
+  as a comment but do not create branches or make changes)
+
+## Background
+
+aiobotocore adds async functionality to botocore by
+subclassing (never monkey-patching). Source files mirror
+botocore's structure. See `docs/override-patterns.md`
+for the full pattern reference. See `CONTRIBUTING.rst`
+for the upgrade process.
+
+`tests/test_patches.py` hashes botocore source we
+depend on. Hash failures are a SIGNAL (not a gate) that
+patched code changed. New botocore logic may also need
+async overrides even if no existing hashes break.
+
+## Two-PR model
+
+This bot uses two PRs for complex changes:
+
+**WIP PR** (branch: `botocore-sync-wip`, draft):
+Accumulates work across multiple runs. The PR
+description tracks progress and state for handoff
+between runs. Messy incremental commits are fine.
+
+**Final PR** (branch: `botocore-sync`, ready):
+Clean result for human review. Created only when
+work is complete and tests pass. Changes are
+squashed from the WIP branch.
+
+For simple changes (relax, small bumps), skip the
+WIP PR and go directly to the final PR.
+
+## Step 0: Check for feedback issue
+
+Check for an open feedback issue:
+```
+gh issue list --label botocore-sync-feedback \
+  --state open --json number,title,body,comments \
+  --jq '.[0]'
+```
+
+If an open feedback issue exists:
+- Read the issue body and ALL comments
+- Look for human responses (not bot-authored)
+- If humans answered questions: use those answers
+  to guide your decisions in subsequent steps.
+  If the answers reveal reusable patterns, update
+  `CLAUDE.md` or `docs/override-patterns.md`.
+- If questions are still unanswered: do NOT create
+  a duplicate. Later steps may add new questions
+  as a comment (see Step 8).
+
+## Step 1: Check existing PR state
+
+Check for BOTH PRs:
+```
+# WIP PR
+gh pr list --head botocore-sync-wip --state open \
+  --json number,title,body,commits,comments \
+  --jq '.[0]'
+
+# Final PR
+gh pr list --head botocore-sync --state all \
+  --json number,state,comments,reviews,commits \
+  --jq '.[0]'
+```
+
+**If a WIP PR exists:**
+This is a continuation of previous work. Read the
+WIP PR description to understand progress and
+remaining tasks. Checkout `botocore-sync-wip`,
+skip to Step 4b and continue from where the
+previous run left off. If $LATEST_BOTOCORE differs
+from what the WIP targets, ignore the newer version
+and finish the current WIP first.
+
+**If no WIP but a final PR exists:**
+
+*Closed/merged:*
+- If merged: check if the merged version already
+  covers $LATEST_BOTOCORE. If so, exit.
+- Otherwise: proceed to Step 2.
+
+*Open — check if "dirty":*
+A PR is dirty if ANY of these are true:
+- Has commits not authored by github-actions[bot]
+  or claude[bot]
+- Has review comments or review threads
+- Has requested-changes reviews
+
+Check with:
+```
+# Non-bot commits
+gh pr view PR_NUM --json commits --jq \
+  '[.commits[] | select(
+    .authors[0].login != "github-actions[bot]" and
+    .authors[0].login != "claude[bot]"
+  )] | length'
+
+# Review comments
+gh api repos/REPO/pulls/PR_NUM/comments \
+  --jq 'length'
+
+# Reviews with comments or requested changes
+gh api repos/REPO/pulls/PR_NUM/reviews \
+  --jq '[.[] | select(
+    .state == "CHANGES_REQUESTED" or
+    (.state == "COMMENTED" and .body != "")
+  )] | length'
+```
+
+*Open + clean:* Reset branch to origin/main,
+proceed to Step 2.
+
+*Open + dirty:* Proceed to Step 2 to determine
+update type, then:
+- If **relax**: safe to apply in-place on the
+  dirty branch. Only update `pyproject.toml`
+  upper bound, `aiobotocore/__init__.py` version,
+  `CHANGES.rst`, and `uv.lock`. Do NOT reset
+  the branch. Update PR title and description.
+- If **bump**: do NOT modify the branch. Post a
+  comment on the PR (replacing any previous
+  botocore-sync-bot comment) stating:
+  "Botocore $LATEST_BOTOCORE is available but
+  requires code changes. Upgrade is blocked on
+  this PR. [botocore diff link]"
+  To replace, search for comments containing
+  "botocore-sync-bot" and delete before posting.
+  Then exit.
+
+**No PRs at all:** Proceed to Step 2.
+
+## Step 2: Analyze the botocore diff
+
+Determine the last supported botocore version:
+upper bound in pyproject.toml minus one patch
+(e.g. `< 1.42.31` → last supported is `1.42.30`).
+
+Download both versions and diff botocore source:
+```
+pip download botocore==OLD --no-deps -d /tmp/old
+pip download botocore==$LATEST_BOTOCORE \
+  --no-deps -d /tmp/new
+```
+Extract and diff the `botocore/` directories.
+
+Categorize changes:
+a) JSON schema/model updates only (no action)
+b) Changes to code we already patch (files with a
+   corresponding `aiobotocore/*.py` override)
+c) New logic in files we override: new classes,
+   methods, network calls, I/O, blocking code, or
+   new use of classes we subclass
+d) Changes in files we don't override (no action)
+
+## Step 3: Determine update type
+
+Install and run hash tests:
+```
+pip install uv
+uv sync --all-extras
+uv pip install "botocore==$LATEST_BOTOCORE"
+uv run pytest tests/test_patches.py -x -v 2>&1
+```
+
+Combine diff analysis with hash results:
+
+**Relax** (patch version bump) — ALL true:
+- All test_patches.py hashes pass
+- No new logic in overridden files needs async
+- Changes limited to schemas, docs, untouched files
+
+**Bump** (minor version bump) — ANY true:
+- Hash tests fail (patched code changed)
+- New logic in overridden files needs async
+
+**Major bump**: breaking API changes affecting
+aiobotocore's public interface (rare — flag for
+human review if detected).
+
+If this is a dirty final PR, apply the dirty-PR
+logic from Step 1 now and potentially exit.
+
+**If DRY_RUN is true:** Output the analysis to
+stdout (it will appear in the workflow run log
+and job summary). Include: categorized diff
+summary, hash test results, recommended update
+type, and list of files that would need changes.
+Do NOT create branches, make code changes, create
+PRs, or post comments. Exit after output.
+
+**If update type is bump and ENABLE_BUMP is false:**
+Go to Step 8 to create a feedback issue describing
+what changes are needed. Do not attempt code changes.
+
+## Step 4a: Relax path
+
+1. `pyproject.toml`: change upper bound to one patch
+   above $LATEST_BOTOCORE. Keep lower bound unchanged.
+2. `aiobotocore/__init__.py`: increment PATCH version.
+3. `CHANGES.rst`: add entry at top with today's date:
+   ```
+   X.Y.Z (YYYY-MM-DD)
+   ^^^^^^^^^^^^^^^^^^^
+   * relax botocore dependency specification
+   ```
+   `^` underline must match header length exactly.
+4. If new botocore functions we depend on appear,
+   add their hashes to `test_patches.py`.
+5. Run `uv lock` to update `uv.lock`.
+6. Go directly to Step 6 (no WIP PR needed).
+
+## Step 4b: Bump path
+
+Read `docs/override-patterns.md` for the patterns.
+Check Step 0 for any human guidance from the
+feedback issue.
+
+If you encounter ambiguities or design decisions
+where multiple valid approaches exist, go to
+Step 8 to request feedback instead of guessing.
+
+1. For each changed/new function needing porting:
+   a. Diff old vs new botocore source.
+   b. Find corresponding `aiobotocore/*.py` file.
+   c. Port changes following the patterns:
+      - Subclass with `Aio` prefix
+      - Override sync methods as async
+      - Use `resolve_awaitable()` for mixed
+        callbacks
+      - Register async components at session init
+      - Keep method signatures identical
+      - Keep diffs from botocore minimal
+   d. Update hashes in `test_patches.py`.
+2. Port relevant botocore tests to
+   `tests/botocore_tests/`. Follow existing patterns:
+   - `async def test_*()` (no pytest.mark.asyncio)
+   - Use `AioSession`, `StubbedSession`
+   - Use `AioAWSResponse` for mocked responses
+3. `pyproject.toml`: update BOTH bounds. Lower =
+   $LATEST_BOTOCORE, upper = one patch above.
+4. `aiobotocore/__init__.py`: increment MINOR version,
+   reset patch to 0.
+5. `CHANGES.rst`: add entry:
+   ```
+   X.Y.0 (YYYY-MM-DD)
+   ^^^^^^^^^^^^^^^^^^^
+   * bump botocore dependency specification
+   ```
+6. Run `uv lock` to update `uv.lock`.
+
+If you complete all tasks, go to Step 5.
+If you run out of turns or time, go to Step 5b.
+
+## Step 5: Validate
+
+Run `uv run pytest tests/test_patches.py -x -v`.
+Fix remaining failures. Repeat until passing.
+
+If all tests pass, go to Step 6.
+If tests fail and you cannot fix them, go to
+Step 5b to save progress.
+
+## Step 5b: Save progress to WIP PR
+
+You did not finish in this run. Save your work:
+
+1. Commit all changes to `botocore-sync-wip`.
+2. Push to `botocore-sync-wip` branch.
+3. Create or update the WIP draft PR with a
+   description that contains ALL information
+   needed for the next run to continue:
+
+   ```
+   ### Botocore sync WIP: [VERSION]
+
+   **Target:** botocore [VERSION]
+   **Botocore diff:** [URL]
+   **Type:** bump (minor)
+
+   ### Completed
+   - [x] Analysis: [summary of categorized changes]
+   - [x] Ported: [file] ([what was done])
+   - [x] Ported: [file] ([what was done])
+
+   ### Remaining
+   - [ ] Port: [file] ([what needs to be done])
+   - [ ] Port tests for [file]
+   - [ ] Update version, changelog, lock
+
+   ### Decisions made
+   [Any design decisions, approaches chosen, and
+   why — so the next run doesn't re-decide]
+
+   ### Context for next run
+   [Anything the next run needs to know:
+   - Which botocore functions changed and how
+   - Which hash failures were already addressed
+   - Any tricky areas or gotchas discovered
+   - References to feedback issue if applicable]
+
+   ### Blockers
+   [If waiting on feedback issue, link it here]
+   ```
+
+4. Exit. The next scheduled run will pick up
+   from this WIP PR.
+
+## Step 6: Finalize
+
+All work is complete and tests pass.
+
+Build botocore diff URL between last supported
+version and new target:
+`https://github.com/boto/botocore/compare/OLD...NEW`
+
+**If a WIP PR exists:** squash the WIP branch
+changes into a single commit on `botocore-sync`:
+```
+git checkout -B botocore-sync origin/main
+git merge --squash botocore-sync-wip
+git commit
+git push origin botocore-sync --force-with-lease
+```
+
+**If no WIP PR:** commit directly to
+`botocore-sync` and push.
+
+Create or update the final PR:
+- Base: `main`
+- Title: `Relax botocore dependency specification`
+  or `Bump botocore dependency specification`
+- Body:
+  ```
+  ### Description of Change
+  This PR [relaxes/bumps] the botocore dependency
+  to support version [VERSION].
+
+  **Type:** [Relax (patch) / Bump (minor)]
+  **Botocore diff:** [URL]
+
+  ### What changed in botocore
+  [Summary of upstream changes, categorized:
+  schema-only, patched code, new logic, etc.]
+
+  ### What changed in aiobotocore
+  [For bumps: list of files modified, new classes
+  added, tests ported. For relax: "Version bounds
+  updated only, no code changes."]
+
+  ### Reviewer checklist
+  Please verify before approving:
+  - [ ] Botocore diff reviewed — changes correctly
+        categorized as relax vs bump
+  - [ ] For bumps: async overrides follow patterns
+        in `docs/override-patterns.md`
+  - [ ] For bumps: new/changed tests pass and
+        cover the ported functionality
+  - [ ] `test_patches.py` hashes are up to date
+  - [ ] Version bump in `__init__.py` is correct
+        (patch for relax, minor for bump)
+  - [ ] `CHANGES.rst` entry added
+  - [ ] No unrelated changes included
+
+  ### How to help
+  - Review the botocore diff link above
+  - Check aiobotocore changes match botocore
+  - If something looks wrong, leave a review
+    comment — the bot will attempt to fix
+    straightforward issues automatically
+  - Use `@claude` to ask questions or request
+    modifications
+  - Approve and merge when satisfied
+
+  ### Checklist
+  * [x] Followed CONTRIBUTING.rst
+  * [x] Updated test_patches.py
+  * [x] Botocore diff: [URL]
+  ```
+
+If a WIP PR exists, close it (post a comment
+linking to the final PR first).
+
+## Step 7: Learn and document patterns
+
+After completing any bump, or after receiving
+feedback that resolves an ambiguity, check if the
+decision reveals a reusable pattern.
+
+If so, update the appropriate doc:
+- `CLAUDE.md`: for quick-reference additions
+- `docs/override-patterns.md`: for new patterns
+
+Include doc updates in the same commit.
+
+## Step 8: Request feedback
+
+Use this step when you encounter ambiguities,
+design decisions, or unresolvable failures.
+
+Check for an existing open feedback issue:
+```
+gh issue list --label botocore-sync-feedback \
+  --state open --json number,body,comments \
+  --jq '.[0]'
+```
+
+**If no open issue exists:** create one:
+- Title: `Botocore sync: feedback needed for
+  $LATEST_BOTOCORE`
+- Label: `botocore-sync-feedback`
+- Body:
+  ```
+  ## Botocore sync needs your input
+
+  Botocore [VERSION] introduces changes that
+  require design decisions before porting.
+
+  **Botocore diff:** [link]
+  **Sync PR:** [link if exists]
+  **WIP PR:** [link if exists]
+
+  ## Questions
+
+  [Numbered list of questions, each with:
+  - Context: what changed and why it matters
+  - Options: valid approaches considered
+  - Trade-offs: pros/cons of each option]
+
+  ## How to respond
+
+  Reply with your answers. You can:
+  - Answer questions directly
+  - Ask `@claude` for more context (e.g.
+    "@claude show me the botocore diff for
+    question 2")
+  - Provide partial answers — the bot will
+    proceed with what it can and ask follow-ups
+  - Suggest a different approach entirely
+
+  Once resolved, the bot will apply decisions
+  on its next run. Close this issue when done.
+  ```
+
+**If an open issue exists:** read body and all
+comments. Check if current questions have been
+asked or answered:
+- Already asked and unanswered: do not repeat.
+- Already answered: use the answer (should have
+  been picked up in Step 0).
+- New questions: add a comment with new
+  questions and context. Delete any stale bot
+  comment before posting (so it appears at
+  the bottom).
+
+Save progress to WIP PR (Step 5b) if you have
+partial work, then exit.

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -1,6 +1,9 @@
 ---
 name: Botocore Sync
 
+# yamllint disable-line rule:line-length
+run-name: "Botocore Sync${{ inputs.botocore_version && format(': {0}', inputs.botocore_version) || '' }}"
+
 permissions: {}
 
 on:
@@ -112,6 +115,17 @@ jobs:
             needs = "true"
         with open(os.environ["GITHUB_OUTPUT"], "a") as f:
             f.write(f"needs_update={needs}\n")
+        summary = os.environ["GITHUB_STEP_SUMMARY"]
+        with open(summary, "a") as f:
+            f.write(f"## Botocore Sync Detection\n")
+            f.write(f"| | Version |\n|-|-|\n")
+            f.write(f"| PyPI latest | {pypi} |\n")
+            f.write(f"| Target | {latest} |\n")
+            f.write(f"| Supported range | "
+                    f"{lower} — {upper} |\n")
+            action = "**Update needed**" if needs == "true" \
+                else "Up to date"
+            f.write(f"| Action | {action} |\n")
         PYEOF
 
   sync:
@@ -161,6 +175,23 @@ jobs:
           patched code changed. New botocore logic may also need
           async overrides even if no existing hashes break.
 
+          ## Two-PR model
+
+          This bot uses two PRs for complex changes:
+
+          **WIP PR** (branch: `botocore-sync-wip`, draft):
+          Accumulates work across multiple runs. The PR
+          description tracks progress and state for handoff
+          between runs. Messy incremental commits are fine.
+
+          **Final PR** (branch: `botocore-sync`, ready):
+          Clean result for human review. Created only when
+          work is complete and tests pass. Changes are
+          squashed from the WIP branch.
+
+          For simple changes (relax, small bumps), skip the
+          WIP PR and go directly to the final PR.
+
           ## Step 0: Check for feedback issue
 
           Check for an open feedback issue:
@@ -179,26 +210,40 @@ jobs:
             `CLAUDE.md` or `docs/override-patterns.md`.
           - If questions are still unanswered: do NOT create
             a duplicate. Later steps may add new questions
-            as a comment (see Step 7).
+            as a comment (see Step 8).
 
           ## Step 1: Check existing PR state
 
-          Check for an existing `botocore-sync` PR:
+          Check for BOTH PRs:
           ```
+          # WIP PR
+          gh pr list --head botocore-sync-wip --state open \
+            --json number,title,body,commits,comments \
+            --jq '.[0]'
+
+          # Final PR
           gh pr list --head botocore-sync --state all \
             --json number,state,comments,reviews,commits \
             --jq '.[0]'
           ```
 
-          Determine the scenario:
+          **If a WIP PR exists:**
+          This is a continuation of previous work. Read the
+          WIP PR description to understand progress and
+          remaining tasks. Checkout `botocore-sync-wip`,
+          skip to Step 4b and continue from where the
+          previous run left off. If $LATEST_BOTOCORE differs
+          from what the WIP targets, ignore the newer version
+          and finish the current WIP first.
 
-          **No PR or closed/merged PR:**
+          **If no WIP but a final PR exists:**
+
+          *Closed/merged:*
           - If merged: check if the merged version already
-            covers $LATEST_BOTOCORE. If so, exit — no action.
-          - Otherwise: proceed to Step 2. Create a fresh
-            `botocore-sync` branch from `origin/main`.
+            covers $LATEST_BOTOCORE. If so, exit.
+          - Otherwise: proceed to Step 2.
 
-          **Open PR — check if "dirty":**
+          *Open — check if "dirty":*
           A PR is dirty if ANY of these are true:
           - Has commits not authored by github-actions[bot]
             or claude[bot]
@@ -226,26 +271,27 @@ jobs:
             )] | length'
           ```
 
-          **Open + clean:** Reset branch to origin/main,
+          *Open + clean:* Reset branch to origin/main,
           proceed to Step 2.
 
-          **Open + dirty:** Proceed to Step 2 to determine
+          *Open + dirty:* Proceed to Step 2 to determine
           update type, then:
-          - If **relax**: safe to apply in-place on the dirty
-            branch. Only update `pyproject.toml` upper bound,
-            `aiobotocore/__init__.py` version, `CHANGES.rst`,
-            and `uv.lock`. Do NOT reset the branch. Update
-            the PR title and description.
+          - If **relax**: safe to apply in-place on the
+            dirty branch. Only update `pyproject.toml`
+            upper bound, `aiobotocore/__init__.py` version,
+            `CHANGES.rst`, and `uv.lock`. Do NOT reset
+            the branch. Update PR title and description.
           - If **bump**: do NOT modify the branch. Post a
             comment on the PR (replacing any previous
             botocore-sync-bot comment) stating:
             "Botocore $LATEST_BOTOCORE is available but
             requires code changes. Upgrade is blocked on
             this PR. [botocore diff link]"
-            To replace a previous comment, search for
-            comments containing "botocore-sync-bot" and
-            delete them before posting the new one.
+            To replace, search for comments containing
+            "botocore-sync-bot" and delete before posting.
             Then exit.
+
+          **No PRs at all:** Proceed to Step 2.
 
           ## Step 2: Analyze the botocore diff
 
@@ -285,7 +331,7 @@ jobs:
           **Relax** (patch version bump) — ALL true:
           - All test_patches.py hashes pass
           - No new logic in overridden files needs async
-          - Changes limited to schemas, docs, or untouched files
+          - Changes limited to schemas, docs, untouched files
 
           **Bump** (minor version bump) — ANY true:
           - Hash tests fail (patched code changed)
@@ -295,8 +341,8 @@ jobs:
           aiobotocore's public interface (rare — flag for
           human review if detected).
 
-          If this is a dirty PR, apply the dirty-PR logic
-          from Step 1 now and potentially exit.
+          If this is a dirty final PR, apply the dirty-PR
+          logic from Step 1 now and potentially exit.
 
           ## Step 4a: Relax path
 
@@ -313,6 +359,7 @@ jobs:
           4. If new botocore functions we depend on appear,
              add their hashes to `test_patches.py`.
           5. Run `uv lock` to update `uv.lock`.
+          6. Go directly to Step 6 (no WIP PR needed).
 
           ## Step 4b: Bump path
 
@@ -321,10 +368,8 @@ jobs:
           feedback issue.
 
           If you encounter ambiguities or design decisions
-          where multiple valid approaches exist (e.g. how to
-          handle a new botocore class, whether something needs
-          async override, how to structure the port), go to
-          Step 7 to request feedback instead of guessing.
+          where multiple valid approaches exist, go to
+          Step 8 to request feedback instead of guessing.
 
           1. For each changed/new function needing porting:
              a. Diff old vs new botocore source.
@@ -332,7 +377,8 @@ jobs:
              c. Port changes following the patterns:
                 - Subclass with `Aio` prefix
                 - Override sync methods as async
-                - Use `resolve_awaitable()` for mixed callbacks
+                - Use `resolve_awaitable()` for mixed
+                  callbacks
                 - Register async components at session init
                 - Keep method signatures identical
                 - Keep diffs from botocore minimal
@@ -354,38 +400,95 @@ jobs:
              ```
           6. Run `uv lock` to update `uv.lock`.
 
+          If you complete all tasks, go to Step 5.
+          If you run out of turns or time, go to Step 5b.
+
           ## Step 5: Validate
 
           Run `uv run pytest tests/test_patches.py -x -v`.
           Fix remaining failures. Repeat until passing.
 
-          ## Step 6: Commit, push, and create/update PR
+          If all tests pass, go to Step 6.
+          If tests fail and you cannot fix them, go to
+          Step 5b to save progress.
 
-          Commit all changes. Push to `botocore-sync` branch.
+          ## Step 5b: Save progress to WIP PR
 
-          Build botocore diff URL between last supported version
-          and new target:
+          You did not finish in this run. Save your work:
+
+          1. Commit all changes to `botocore-sync-wip`.
+          2. Push to `botocore-sync-wip` branch.
+          3. Create or update the WIP draft PR with a
+             description that contains ALL information
+             needed for the next run to continue:
+
+             ```
+             ### Botocore sync WIP: [VERSION]
+
+             **Target:** botocore [VERSION]
+             **Botocore diff:** [URL]
+             **Type:** bump (minor)
+
+             ### Completed
+             - [x] Analysis: [summary of categorized changes]
+             - [x] Ported: [file] ([what was done])
+             - [x] Ported: [file] ([what was done])
+
+             ### Remaining
+             - [ ] Port: [file] ([what needs to be done])
+             - [ ] Port tests for [file]
+             - [ ] Update version, changelog, lock
+
+             ### Decisions made
+             [Any design decisions, approaches chosen, and
+             why — so the next run doesn't re-decide]
+
+             ### Context for next run
+             [Anything the next run needs to know:
+             - Which botocore functions changed and how
+             - Which hash failures were already addressed
+             - Any tricky areas or gotchas discovered
+             - References to feedback issue if applicable]
+
+             ### Blockers
+             [If waiting on feedback issue, link it here]
+             ```
+
+          4. Exit. The next scheduled run will pick up
+             from this WIP PR.
+
+          ## Step 6: Finalize
+
+          All work is complete and tests pass.
+
+          Build botocore diff URL between last supported
+          version and new target:
           `https://github.com/boto/botocore/compare/OLD...NEW`
 
-          Check if a PR already exists:
+          **If a WIP PR exists:** squash the WIP branch
+          changes into a single commit on `botocore-sync`:
           ```
-          gh pr list --head botocore-sync --json number \
-            --jq '.[0].number'
+          git checkout -B botocore-sync origin/main
+          git merge --squash botocore-sync-wip
+          git commit
+          git push origin botocore-sync --force-with-lease
           ```
 
-          Create or update the PR:
+          **If no WIP PR:** commit directly to
+          `botocore-sync` and push.
+
+          Create or update the final PR:
           - Base: `main`
           - Title: `Relax botocore dependency specification`
             or `Bump botocore dependency specification`
-          - Body format:
+          - Body:
             ```
             ### Description of Change
             This PR [relaxes/bumps] the botocore dependency
             to support version [VERSION].
 
             **Type:** [Relax (patch) / Bump (minor)]
-            **Botocore diff:** [link between last supported
-            version and new target]
+            **Botocore diff:** [URL]
 
             ### What changed in botocore
             [Summary of upstream changes, categorized:
@@ -402,8 +505,8 @@ jobs:
                   categorized as relax vs bump
             - [ ] For bumps: async overrides follow patterns
                   in `docs/override-patterns.md`
-            - [ ] For bumps: new/changed tests pass and cover
-                  the ported functionality
+            - [ ] For bumps: new/changed tests pass and
+                  cover the ported functionality
             - [ ] `test_patches.py` hashes are up to date
             - [ ] Version bump in `__init__.py` is correct
                   (patch for relax, minor for bump)
@@ -412,13 +515,12 @@ jobs:
 
             ### How to help
             - Review the botocore diff link above
-            - Check the aiobotocore changes match the
-              botocore changes
+            - Check aiobotocore changes match botocore
             - If something looks wrong, leave a review
               comment — the bot will attempt to fix
               straightforward issues automatically
-            - Use `@claude` in a comment to ask questions
-              about the changes or request modifications
+            - Use `@claude` to ask questions or request
+              modifications
             - Approve and merge when satisfied
 
             ### Checklist
@@ -427,7 +529,22 @@ jobs:
             * [x] Botocore diff: [URL]
             ```
 
-          ## Step 7: Request feedback or handle failures
+          If a WIP PR exists, close it (post a comment
+          linking to the final PR first).
+
+          ## Step 7: Learn and document patterns
+
+          After completing any bump, or after receiving
+          feedback that resolves an ambiguity, check if the
+          decision reveals a reusable pattern.
+
+          If so, update the appropriate doc:
+          - `CLAUDE.md`: for quick-reference additions
+          - `docs/override-patterns.md`: for new patterns
+
+          Include doc updates in the same commit.
+
+          ## Step 8: Request feedback
 
           Use this step when you encounter ambiguities,
           design decisions, or unresolvable failures.
@@ -443,7 +560,7 @@ jobs:
           - Title: `Botocore sync: feedback needed for
             $LATEST_BOTOCORE`
           - Label: `botocore-sync-feedback`
-          - Body format:
+          - Body:
             ```
             ## Botocore sync needs your input
 
@@ -452,65 +569,43 @@ jobs:
 
             **Botocore diff:** [link]
             **Sync PR:** [link if exists]
+            **WIP PR:** [link if exists]
 
             ## Questions
 
-            [Numbered list of specific questions, each with:
+            [Numbered list of questions, each with:
             - Context: what changed and why it matters
-            - Options: the valid approaches considered
+            - Options: valid approaches considered
             - Trade-offs: pros/cons of each option]
 
             ## How to respond
 
-            Reply to this issue with your answers. You can:
+            Reply with your answers. You can:
             - Answer questions directly
-            - Ask `@claude` for more context about any
-              question (e.g. "@claude show me the botocore
-              diff for question 2")
+            - Ask `@claude` for more context (e.g.
+              "@claude show me the botocore diff for
+              question 2")
             - Provide partial answers — the bot will
               proceed with what it can and ask follow-ups
             - Suggest a different approach entirely
 
-            Once all questions are resolved, the bot will
-            apply your decisions on its next run. A
-            maintainer should close this issue when done.
+            Once resolved, the bot will apply decisions
+            on its next run. Close this issue when done.
             ```
 
-          **If an open issue exists:** read the body and
-          all comments. Check if your current questions
-          have already been asked or answered:
+          **If an open issue exists:** read body and all
+          comments. Check if current questions have been
+          asked or answered:
           - Already asked and unanswered: do not repeat.
           - Already answered: use the answer (should have
             been picked up in Step 0).
-          - New questions: add a comment with the new
-            questions, botocore diff URL, and context.
-            Delete any previous bot comment that is now
-            stale before posting the new one (so it
-            appears at the bottom).
+          - New questions: add a comment with new
+            questions and context. Delete any stale bot
+            comment before posting (so it appears at
+            the bottom).
 
-          Do NOT push broken changes. If you requested
-          feedback, exit without modifying the branch.
-
-          ## Step 8: Learn and document patterns
-
-          After completing any bump (Step 4b), or after
-          receiving feedback that resolves an ambiguity,
-          check if the decision reveals a reusable pattern.
-
-          If so, update the appropriate doc:
-          - `CLAUDE.md`: for quick-reference additions
-          - `docs/override-patterns.md`: for new patterns
-
-          Examples of learnable patterns:
-          - "New credential provider types always need
-            async override"
-          - "Changes to retry logic require updating
-            both retryhandler.py and the hash"
-          - "New HTTP features need both AIOHTTPSession
-            and HttpxSession implementations"
-
-          Include these doc updates in the same commit
-          as the bump changes.
+          Save progress to WIP PR (Step 5b) if you have
+          partial work, then exit.
         # yamllint enable rule:line-length
         claude_args: |
           --max-turns 50

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -1,0 +1,232 @@
+---
+name: Botocore Sync
+
+permissions: {}
+
+on:
+  schedule:
+  # Every 3 days at 10:00 UTC
+  - cron: '0 10 */3 * *'
+  workflow_dispatch:
+    inputs:
+      botocore_version:
+        description: >-
+          Target botocore version (leave empty to auto-detect latest)
+        required: false
+        type: string
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      latest_botocore: ${{ steps.check.outputs.latest_botocore }}
+      current_upper: ${{ steps.check.outputs.current_upper }}
+      needs_update: ${{ steps.check.outputs.needs_update }}
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+    - name: Check for new botocore version
+      id: check
+      env:
+        INPUT_VERSION: ${{ inputs.botocore_version }}
+      run: |
+        # Validate manual input if provided
+        if [ -n "$INPUT_VERSION" ]; then
+          if ! echo "$INPUT_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid version format: $INPUT_VERSION"
+            exit 1
+          fi
+          latest="$INPUT_VERSION"
+        else
+          latest=$(curl -s https://pypi.org/pypi/botocore/json \
+            | python3 -c "import sys,json; print(json.load(sys.stdin)['info']['version'])")
+        fi
+        echo "latest_botocore=$latest" >> "$GITHUB_OUTPUT"
+
+        # Get current upper bound from pyproject.toml
+        upper=$(python3 -c "
+        import re
+        text = open('pyproject.toml').read()
+        m = re.search(r'botocore\s*>=\s*[\d.]+,\s*<\s*([\d.]+)', text)
+        print(m.group(1))
+        ")
+        echo "current_upper=$upper" >> "$GITHUB_OUTPUT"
+
+        # Compare versions using env vars (not string interpolation)
+        LATEST="$latest" UPPER="$upper" python3 << 'PYEOF'
+        import os
+        from packaging.version import Version
+        latest = os.environ["LATEST"]
+        upper = os.environ["UPPER"]
+        needs = "true" if Version(latest) >= Version(upper) else "false"
+        print(f"Latest: {latest}, upper bound: {upper}, needs update: {needs}")
+        with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+            f.write(f"needs_update={needs}\n")
+        PYEOF
+
+  sync:
+    needs: detect
+    if: needs.detect.outputs.needs_update == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        fetch-depth: 0
+
+    - uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6  # v1
+      env:
+        LATEST_BOTOCORE: ${{ needs.detect.outputs.latest_botocore }}
+        CURRENT_UPPER: ${{ needs.detect.outputs.current_upper }}
+      with:
+        anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+        prompt: |
+          You are a botocore sync bot for aiobotocore. Update aiobotocore to
+          support botocore version $LATEST_BOTOCORE (current upper bound is
+          $CURRENT_UPPER).
+
+          ## Background
+
+          aiobotocore adds async functionality to botocore by subclassing and
+          monkey-patching botocore classes. The aiobotocore source files mirror
+          botocore's file structure (e.g. `aiobotocore/credentials.py` overrides
+          classes from `botocore/credentials.py`). Because of this tight
+          coupling, aiobotocore pins to a narrow range of botocore versions.
+
+          `tests/test_patches.py` contains SHA1 hashes of specific botocore
+          source code that aiobotocore depends on. When botocore changes code
+          that aiobotocore patches, hashes break, signaling porting is needed.
+
+          Read `CONTRIBUTING.rst` for the full upgrade process documentation.
+
+          ## Step 1: Set up the branch
+
+          ```
+          git fetch origin botocore-sync 2>/dev/null && git checkout botocore-sync && git reset --hard origin/main || git checkout -b botocore-sync origin/main
+          ```
+
+          ## Step 2: Install and test
+
+          ```
+          pip install uv
+          uv sync --all-extras
+          uv pip install "botocore==$LATEST_BOTOCORE"
+          uv run pytest tests/test_patches.py -x -v 2>&1
+          ```
+
+          ## Step 3: Determine update type
+
+          - If ALL tests pass → **relax** (extend upper bound only)
+          - If ANY tests fail → **bump** (code changes required)
+
+          ## Step 4a: Relax path (all hashes pass)
+
+          1. `pyproject.toml`: change the botocore upper bound from
+             `< $CURRENT_UPPER` to `< X` where X is one patch above
+             $LATEST_BOTOCORE. Keep the lower bound unchanged.
+          2. `aiobotocore/__init__.py`: increment the PATCH version.
+          3. `CHANGES.rst`: add entry at top with today's date:
+             ```
+             X.Y.Z (YYYY-MM-DD)
+             ^^^^^^^^^^^^^^^^^^^
+             * relax botocore dependency specification
+             ```
+             The `^` underline must match the header length exactly.
+          4. If any new botocore functions appear that we depend on, add
+             their hashes to `test_patches.py`.
+          5. Run `uv lock` to update `uv.lock`.
+
+          ## Step 4b: Bump path (hash failures)
+
+          1. From test failures, identify which botocore functions changed.
+          2. For each changed function:
+             a. Get the botocore source for the OLD version ($CURRENT_UPPER
+                minus one patch) and NEW version ($LATEST_BOTOCORE).
+                Use `pip download botocore==VERSION --no-deps -d /tmp/boto_dl`
+                then extract and compare, or use inspect.getsource().
+             b. Diff old vs new to understand the changes.
+             c. Find the corresponding aiobotocore file. Our files mirror
+                botocore's structure: `botocore/X.py` → `aiobotocore/X.py`.
+             d. Port changes to the aiobotocore version:
+                - Convert synchronous calls to async/await
+                - Subclass new classes with `Aio` prefix
+                - Register new async classes where botocore registers sync ones
+                - Keep method signatures identical
+                - Keep diffs from botocore as small as possible
+             e. Update the hash in `test_patches.py`.
+          3. Port relevant botocore tests to `tests/botocore_tests/`.
+             Check existing files there for the async test pattern.
+          4. `pyproject.toml`: update BOTH lower and upper bounds.
+             Lower = $LATEST_BOTOCORE, upper = one patch above.
+          5. `aiobotocore/__init__.py`: increment the MINOR version, reset
+             patch to 0.
+          6. `CHANGES.rst`: add entry:
+             ```
+             X.Y.0 (YYYY-MM-DD)
+             ^^^^^^^^^^^^^^^^^^^
+             * bump botocore dependency specification
+             ```
+          7. Run `uv lock` to update `uv.lock`.
+
+          ## Step 5: Validate
+
+          Run `uv run pytest tests/test_patches.py -x -v` again. Fix any
+          remaining failures. Repeat until passing.
+
+          ## Step 6: Commit, push, and create/update PR
+
+          Commit all changes. Push to the `botocore-sync` branch.
+
+          Build the botocore diff URL:
+          `https://github.com/boto/botocore/compare/OLD...NEW`
+          where OLD is the previous upper bound minus one patch version,
+          and NEW is $LATEST_BOTOCORE.
+
+          Check if a PR already exists:
+          ```
+          gh pr list --head botocore-sync --json number --jq '.[0].number'
+          ```
+
+          If a PR exists, push will update it. If not, create one:
+          - Base: `main`
+          - Title: `Relax botocore dependency specification` or
+                   `Bump botocore dependency specification`
+          - Body template:
+            ```
+            ### Description of Change
+            This PR intends to improve general compatibility of `aiobotocore`
+            within the Python ecosystem by [relaxing/bumping] the dependency
+            specification of `botocore`.
+
+            ### Assumptions
+            Upstream contains [no changes that require/minor changes that
+            require/several changes that require] adjustments to the
+            aiobotocore codebase.
+
+            ### Checklist when updating botocore versions
+            * [x] I have read and followed CONTRIBUTING.rst
+            * [x] I have updated test_patches.py where/if appropriate
+            * [x] I have added URL to diff: DIFF_URL
+
+            ### Changes
+            [List the specific changes made, if any]
+            ```
+
+          ## Step 7: Handle failures
+
+          If you cannot resolve test failures after reasonable effort, open
+          a GitHub issue:
+          - Title: `Botocore sync: manual intervention needed for VERSION`
+          - Body: explain what failed, which functions changed, what you
+            attempted, and include the botocore diff URL.
+          - Do NOT leave the PR in a broken state — either fix it or don't
+            push broken changes.
+        claude_args: |
+          --max-turns 50

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -82,6 +82,7 @@ jobs:
     if: needs.detect.outputs.needs_update == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment: claude
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
     # yamllint disable-line rule:line-length
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        persist-credentials: false
 
     - name: Check for new botocore version
       id: check
@@ -94,6 +96,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         fetch-depth: 0
+        persist-credentials: false
 
     # yamllint disable-line rule:line-length
     - uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -67,13 +67,14 @@ jobs:
         ")
         echo "current_upper=$upper" >> "$GITHUB_OUTPUT"
 
-        # Compare versions
+        # Compare versions (tuple comparison, no deps)
         LATEST="$latest" UPPER="$upper" python3 << 'PYEOF'
         import os
-        from packaging.version import Version
+        def ver(s):
+            return tuple(int(x) for x in s.split("."))
         latest = os.environ["LATEST"]
         upper = os.environ["UPPER"]
-        needs = "true" if Version(latest) >= Version(upper) else "false"
+        needs = "true" if ver(latest) >= ver(upper) else "false"
         print(f"Latest: {latest}, upper: {upper}, update: {needs}")
         with open(os.environ["GITHUB_OUTPUT"], "a") as f:
             f.write(f"needs_update={needs}\n")
@@ -109,59 +110,111 @@ jobs:
         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
         # yamllint disable rule:line-length
         prompt: |
-          You are a botocore sync bot for aiobotocore. Update
-          aiobotocore to support botocore $LATEST_BOTOCORE
+          You are a botocore sync bot for aiobotocore. Your goal:
+          update aiobotocore to support botocore $LATEST_BOTOCORE
           (current upper bound: $CURRENT_UPPER).
 
           ## Background
 
           aiobotocore adds async functionality to botocore by
-          subclassing and monkey-patching botocore classes. Source
-          files mirror botocore's structure (e.g.
-          `aiobotocore/credentials.py` overrides classes from
-          `botocore/credentials.py`). Because of this tight
-          coupling, aiobotocore pins to a narrow botocore range.
+          subclassing (never monkey-patching). Source files mirror
+          botocore's structure. See `docs/override-patterns.md`
+          for the full pattern reference. See `CONTRIBUTING.rst`
+          for the upgrade process.
 
-          `tests/test_patches.py` hashes specific botocore source
-          that aiobotocore depends on. Hash failures signal that
-          patched code changed. However, hashes alone are NOT
-          sufficient — new botocore logic (new classes, network
-          calls, I/O, or use of classes we override) may also
-          need async overrides even if no existing hashes break.
+          `tests/test_patches.py` hashes botocore source we
+          depend on. Hash failures are a SIGNAL (not a gate) that
+          patched code changed. New botocore logic may also need
+          async overrides even if no existing hashes break.
 
-          Read `CONTRIBUTING.rst` for full upgrade documentation.
+          ## Step 1: Check existing PR state
 
-          ## Step 1: Set up the branch
-
+          Check for an existing `botocore-sync` PR:
           ```
-          git fetch origin botocore-sync 2>/dev/null \
-            && git checkout botocore-sync \
-            && git reset --hard origin/main \
-            || git checkout -b botocore-sync origin/main
+          gh pr list --head botocore-sync --state all \
+            --json number,state,comments,reviews,commits \
+            --jq '.[0]'
           ```
+
+          Determine the scenario:
+
+          **No PR or closed/merged PR:**
+          - If merged: check if the merged version already
+            covers $LATEST_BOTOCORE. If so, exit — no action.
+          - Otherwise: proceed to Step 2. Create a fresh
+            `botocore-sync` branch from `origin/main`.
+
+          **Open PR — check if "dirty":**
+          A PR is dirty if ANY of these are true:
+          - Has commits not authored by github-actions[bot]
+            or claude[bot]
+          - Has review comments or review threads
+          - Has requested-changes reviews
+
+          Check with:
+          ```
+          # Non-bot commits
+          gh pr view PR_NUM --json commits --jq \
+            '[.commits[] | select(
+              .authors[0].login != "github-actions[bot]" and
+              .authors[0].login != "claude[bot]"
+            )] | length'
+
+          # Review comments
+          gh api repos/REPO/pulls/PR_NUM/comments \
+            --jq 'length'
+
+          # Reviews with comments or requested changes
+          gh api repos/REPO/pulls/PR_NUM/reviews \
+            --jq '[.[] | select(
+              .state == "CHANGES_REQUESTED" or
+              (.state == "COMMENTED" and .body != "")
+            )] | length'
+          ```
+
+          **Open + clean:** Reset branch to origin/main,
+          proceed to Step 2.
+
+          **Open + dirty:** Proceed to Step 2 to determine
+          update type, then:
+          - If **relax**: safe to apply in-place on the dirty
+            branch. Only update `pyproject.toml` upper bound,
+            `aiobotocore/__init__.py` version, `CHANGES.rst`,
+            and `uv.lock`. Do NOT reset the branch. Update
+            the PR title and description.
+          - If **bump**: do NOT modify the branch. Post a
+            comment on the PR (replacing any previous
+            botocore-sync-bot comment) stating:
+            "Botocore $LATEST_BOTOCORE is available but
+            requires code changes. Upgrade is blocked on
+            this PR. [botocore diff link]"
+            To replace a previous comment, search for
+            comments containing "botocore-sync-bot" and
+            delete them before posting the new one.
+            Then exit.
 
           ## Step 2: Analyze the botocore diff
 
           Determine the last supported botocore version:
-          the upper bound in pyproject.toml minus one patch
-          (e.g. if `< 1.42.31` then last supported is `1.42.30`).
+          upper bound in pyproject.toml minus one patch
+          (e.g. `< 1.42.31` → last supported is `1.42.30`).
 
-          Download both versions and diff the botocore source:
+          Download both versions and diff botocore source:
           ```
           pip download botocore==OLD --no-deps -d /tmp/old
-          pip download botocore==$LATEST_BOTOCORE --no-deps \
-            -d /tmp/new
+          pip download botocore==$LATEST_BOTOCORE \
+            --no-deps -d /tmp/new
           ```
           Extract and diff the `botocore/` directories.
 
           Categorize changes:
-          a) JSON schema/model updates only (service definitions)
-          b) Changes to code we already patch (files that have a
+          a) JSON schema/model updates only (no action)
+          b) Changes to code we already patch (files with a
              corresponding `aiobotocore/*.py` override)
-          c) New logic in files we override: new classes, methods,
-             network calls, I/O operations, blocking code, or
+          c) New logic in files we override: new classes,
+             methods, network calls, I/O, blocking code, or
              new use of classes we subclass
-          d) New logic in files we don't override (no action)
+          d) Changes in files we don't override (no action)
 
           ## Step 3: Determine update type
 
@@ -173,29 +226,28 @@ jobs:
           uv run pytest tests/test_patches.py -x -v 2>&1
           ```
 
-          Combine the diff analysis with hash test results:
+          Combine diff analysis with hash results:
 
-          **Relax** (patch version bump): ALL of these are true:
+          **Relax** (patch version bump) — ALL true:
           - All test_patches.py hashes pass
-          - No new logic in files we override needs async
-            treatment
-          - Changes are limited to JSON schemas, docs, or
-            files we don't touch
+          - No new logic in overridden files needs async
+          - Changes limited to schemas, docs, or untouched files
 
-          **Bump** (minor version bump): ANY of these are true:
+          **Bump** (minor version bump) — ANY true:
           - Hash tests fail (patched code changed)
-          - New classes/methods/logic in files we override
-            needs async conversion
+          - New logic in overridden files needs async
 
-          **Major bump**: breaking API changes that affect
-          aiobotocore's public interface (rare, flag for human
-          review if detected).
+          **Major bump**: breaking API changes affecting
+          aiobotocore's public interface (rare — flag for
+          human review if detected).
+
+          If this is a dirty PR, apply the dirty-PR logic
+          from Step 1 now and potentially exit.
 
           ## Step 4a: Relax path
 
-          1. `pyproject.toml`: change botocore upper bound to
-             one patch above $LATEST_BOTOCORE. Keep lower bound
-             unchanged.
+          1. `pyproject.toml`: change upper bound to one patch
+             above $LATEST_BOTOCORE. Keep lower bound unchanged.
           2. `aiobotocore/__init__.py`: increment PATCH version.
           3. `CHANGES.rst`: add entry at top with today's date:
              ```
@@ -203,28 +255,31 @@ jobs:
              ^^^^^^^^^^^^^^^^^^^
              * relax botocore dependency specification
              ```
-             The `^` underline must match header length exactly.
-          4. If new botocore functions appear that we depend on,
+             `^` underline must match header length exactly.
+          4. If new botocore functions we depend on appear,
              add their hashes to `test_patches.py`.
           5. Run `uv lock` to update `uv.lock`.
 
           ## Step 4b: Bump path
 
+          Read `docs/override-patterns.md` for the patterns.
+
           1. For each changed/new function needing porting:
-             a. Diff old vs new botocore source to understand
-                what changed.
-             b. Find the corresponding `aiobotocore/*.py` file.
-             c. Port changes:
-                - Convert synchronous calls to async/await
-                - Subclass new classes with `Aio` prefix
-                - Register new async classes where botocore
-                  registers sync ones
+             a. Diff old vs new botocore source.
+             b. Find corresponding `aiobotocore/*.py` file.
+             c. Port changes following the patterns:
+                - Subclass with `Aio` prefix
+                - Override sync methods as async
+                - Use `resolve_awaitable()` for mixed callbacks
+                - Register async components at session init
                 - Keep method signatures identical
                 - Keep diffs from botocore minimal
              d. Update hashes in `test_patches.py`.
           2. Port relevant botocore tests to
-             `tests/botocore_tests/`. Follow existing async
-             test patterns there.
+             `tests/botocore_tests/`. Follow existing patterns:
+             - `async def test_*()` (no pytest.mark.asyncio)
+             - Use `AioSession`, `StubbedSession`
+             - Use `AioAWSResponse` for mocked responses
           3. `pyproject.toml`: update BOTH bounds. Lower =
              $LATEST_BOTOCORE, upper = one patch above.
           4. `aiobotocore/__init__.py`: increment MINOR version,
@@ -239,15 +294,15 @@ jobs:
 
           ## Step 5: Validate
 
-          Run `uv run pytest tests/test_patches.py -x -v` again.
-          Fix any remaining failures. Repeat until passing.
+          Run `uv run pytest tests/test_patches.py -x -v`.
+          Fix remaining failures. Repeat until passing.
 
           ## Step 6: Commit, push, and create/update PR
 
           Commit all changes. Push to `botocore-sync` branch.
 
-          Build the botocore diff URL between the last supported
-          version and the new target:
+          Build botocore diff URL between last supported version
+          and new target:
           `https://github.com/boto/botocore/compare/OLD...NEW`
 
           Check if a PR already exists:
@@ -256,14 +311,13 @@ jobs:
             --jq '.[0].number'
           ```
 
-          If a PR exists, update its body. If not, create one:
+          Create or update the PR:
           - Base: `main`
-          - Title: `Relax botocore dependency specification` or
-                   `Bump botocore dependency specification`
+          - Title: `Relax botocore dependency specification`
+            or `Bump botocore dependency specification`
           - Body MUST include:
             - Description of change (relax or bump)
-            - Botocore diff URL (between last supported version
-              and new target)
+            - Botocore diff URL
             - Summary of what changed in botocore
             - List of aiobotocore changes made (if bump)
             - Checklist referencing CONTRIBUTING.rst
@@ -273,8 +327,8 @@ jobs:
           If you cannot resolve failures after reasonable effort,
           open a GitHub issue:
           - Title: Botocore sync: manual intervention needed
-          - Body: what failed, which functions changed, what you
-            tried, and the botocore diff URL.
+          - Body: what failed, which functions changed, what
+            you tried, and the botocore diff URL.
           - Do NOT push broken changes.
         # yamllint enable rule:line-length
         claude_args: |

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -18,6 +18,22 @@ on:
           (leave empty to auto-detect latest)
         required: false
         type: string
+      enable_bump:
+        description: >-
+          Enable bump path (code changes).
+          When false, bumps create a feedback
+          issue instead of attempting code changes.
+        required: false
+        type: boolean
+        default: false
+      dry_run:
+        description: >-
+          Analyze only — output results to the
+          workflow run log. No branches, PRs, or
+          code changes.
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: botocore-sync
@@ -132,7 +148,7 @@ jobs:
     needs: detect
     if: needs.detect.outputs.needs_update == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     environment: claude
     permissions:
       contents: write
@@ -147,6 +163,15 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
 
+    - name: Read prompt
+      id: prompt
+      run: |
+        {
+          echo 'PROMPT<<PROMPT_EOF'
+          cat .github/botocore-sync-prompt.md
+          echo 'PROMPT_EOF'
+        } >> "$GITHUB_OUTPUT"
+
     # yamllint disable-line rule:line-length
     - uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6
       env:
@@ -154,458 +179,12 @@ jobs:
           ${{ needs.detect.outputs.latest_botocore }}
         CURRENT_UPPER: >-
           ${{ needs.detect.outputs.current_upper }}
+        ENABLE_BUMP: >-
+          ${{ inputs.enable_bump || 'false' }}
+        DRY_RUN: >-
+          ${{ inputs.dry_run || 'false' }}
       with:
         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-        # yamllint disable rule:line-length
-        prompt: |
-          You are a botocore sync bot for aiobotocore. Your goal:
-          update aiobotocore to support botocore $LATEST_BOTOCORE
-          (current upper bound: $CURRENT_UPPER).
-
-          ## Background
-
-          aiobotocore adds async functionality to botocore by
-          subclassing (never monkey-patching). Source files mirror
-          botocore's structure. See `docs/override-patterns.md`
-          for the full pattern reference. See `CONTRIBUTING.rst`
-          for the upgrade process.
-
-          `tests/test_patches.py` hashes botocore source we
-          depend on. Hash failures are a SIGNAL (not a gate) that
-          patched code changed. New botocore logic may also need
-          async overrides even if no existing hashes break.
-
-          ## Two-PR model
-
-          This bot uses two PRs for complex changes:
-
-          **WIP PR** (branch: `botocore-sync-wip`, draft):
-          Accumulates work across multiple runs. The PR
-          description tracks progress and state for handoff
-          between runs. Messy incremental commits are fine.
-
-          **Final PR** (branch: `botocore-sync`, ready):
-          Clean result for human review. Created only when
-          work is complete and tests pass. Changes are
-          squashed from the WIP branch.
-
-          For simple changes (relax, small bumps), skip the
-          WIP PR and go directly to the final PR.
-
-          ## Step 0: Check for feedback issue
-
-          Check for an open feedback issue:
-          ```
-          gh issue list --label botocore-sync-feedback \
-            --state open --json number,title,body,comments \
-            --jq '.[0]'
-          ```
-
-          If an open feedback issue exists:
-          - Read the issue body and ALL comments
-          - Look for human responses (not bot-authored)
-          - If humans answered questions: use those answers
-            to guide your decisions in subsequent steps.
-            If the answers reveal reusable patterns, update
-            `CLAUDE.md` or `docs/override-patterns.md`.
-          - If questions are still unanswered: do NOT create
-            a duplicate. Later steps may add new questions
-            as a comment (see Step 8).
-
-          ## Step 1: Check existing PR state
-
-          Check for BOTH PRs:
-          ```
-          # WIP PR
-          gh pr list --head botocore-sync-wip --state open \
-            --json number,title,body,commits,comments \
-            --jq '.[0]'
-
-          # Final PR
-          gh pr list --head botocore-sync --state all \
-            --json number,state,comments,reviews,commits \
-            --jq '.[0]'
-          ```
-
-          **If a WIP PR exists:**
-          This is a continuation of previous work. Read the
-          WIP PR description to understand progress and
-          remaining tasks. Checkout `botocore-sync-wip`,
-          skip to Step 4b and continue from where the
-          previous run left off. If $LATEST_BOTOCORE differs
-          from what the WIP targets, ignore the newer version
-          and finish the current WIP first.
-
-          **If no WIP but a final PR exists:**
-
-          *Closed/merged:*
-          - If merged: check if the merged version already
-            covers $LATEST_BOTOCORE. If so, exit.
-          - Otherwise: proceed to Step 2.
-
-          *Open — check if "dirty":*
-          A PR is dirty if ANY of these are true:
-          - Has commits not authored by github-actions[bot]
-            or claude[bot]
-          - Has review comments or review threads
-          - Has requested-changes reviews
-
-          Check with:
-          ```
-          # Non-bot commits
-          gh pr view PR_NUM --json commits --jq \
-            '[.commits[] | select(
-              .authors[0].login != "github-actions[bot]" and
-              .authors[0].login != "claude[bot]"
-            )] | length'
-
-          # Review comments
-          gh api repos/REPO/pulls/PR_NUM/comments \
-            --jq 'length'
-
-          # Reviews with comments or requested changes
-          gh api repos/REPO/pulls/PR_NUM/reviews \
-            --jq '[.[] | select(
-              .state == "CHANGES_REQUESTED" or
-              (.state == "COMMENTED" and .body != "")
-            )] | length'
-          ```
-
-          *Open + clean:* Reset branch to origin/main,
-          proceed to Step 2.
-
-          *Open + dirty:* Proceed to Step 2 to determine
-          update type, then:
-          - If **relax**: safe to apply in-place on the
-            dirty branch. Only update `pyproject.toml`
-            upper bound, `aiobotocore/__init__.py` version,
-            `CHANGES.rst`, and `uv.lock`. Do NOT reset
-            the branch. Update PR title and description.
-          - If **bump**: do NOT modify the branch. Post a
-            comment on the PR (replacing any previous
-            botocore-sync-bot comment) stating:
-            "Botocore $LATEST_BOTOCORE is available but
-            requires code changes. Upgrade is blocked on
-            this PR. [botocore diff link]"
-            To replace, search for comments containing
-            "botocore-sync-bot" and delete before posting.
-            Then exit.
-
-          **No PRs at all:** Proceed to Step 2.
-
-          ## Step 2: Analyze the botocore diff
-
-          Determine the last supported botocore version:
-          upper bound in pyproject.toml minus one patch
-          (e.g. `< 1.42.31` → last supported is `1.42.30`).
-
-          Download both versions and diff botocore source:
-          ```
-          pip download botocore==OLD --no-deps -d /tmp/old
-          pip download botocore==$LATEST_BOTOCORE \
-            --no-deps -d /tmp/new
-          ```
-          Extract and diff the `botocore/` directories.
-
-          Categorize changes:
-          a) JSON schema/model updates only (no action)
-          b) Changes to code we already patch (files with a
-             corresponding `aiobotocore/*.py` override)
-          c) New logic in files we override: new classes,
-             methods, network calls, I/O, blocking code, or
-             new use of classes we subclass
-          d) Changes in files we don't override (no action)
-
-          ## Step 3: Determine update type
-
-          Install and run hash tests:
-          ```
-          pip install uv
-          uv sync --all-extras
-          uv pip install "botocore==$LATEST_BOTOCORE"
-          uv run pytest tests/test_patches.py -x -v 2>&1
-          ```
-
-          Combine diff analysis with hash results:
-
-          **Relax** (patch version bump) — ALL true:
-          - All test_patches.py hashes pass
-          - No new logic in overridden files needs async
-          - Changes limited to schemas, docs, untouched files
-
-          **Bump** (minor version bump) — ANY true:
-          - Hash tests fail (patched code changed)
-          - New logic in overridden files needs async
-
-          **Major bump**: breaking API changes affecting
-          aiobotocore's public interface (rare — flag for
-          human review if detected).
-
-          If this is a dirty final PR, apply the dirty-PR
-          logic from Step 1 now and potentially exit.
-
-          ## Step 4a: Relax path
-
-          1. `pyproject.toml`: change upper bound to one patch
-             above $LATEST_BOTOCORE. Keep lower bound unchanged.
-          2. `aiobotocore/__init__.py`: increment PATCH version.
-          3. `CHANGES.rst`: add entry at top with today's date:
-             ```
-             X.Y.Z (YYYY-MM-DD)
-             ^^^^^^^^^^^^^^^^^^^
-             * relax botocore dependency specification
-             ```
-             `^` underline must match header length exactly.
-          4. If new botocore functions we depend on appear,
-             add their hashes to `test_patches.py`.
-          5. Run `uv lock` to update `uv.lock`.
-          6. Go directly to Step 6 (no WIP PR needed).
-
-          ## Step 4b: Bump path
-
-          Read `docs/override-patterns.md` for the patterns.
-          Check Step 0 for any human guidance from the
-          feedback issue.
-
-          If you encounter ambiguities or design decisions
-          where multiple valid approaches exist, go to
-          Step 8 to request feedback instead of guessing.
-
-          1. For each changed/new function needing porting:
-             a. Diff old vs new botocore source.
-             b. Find corresponding `aiobotocore/*.py` file.
-             c. Port changes following the patterns:
-                - Subclass with `Aio` prefix
-                - Override sync methods as async
-                - Use `resolve_awaitable()` for mixed
-                  callbacks
-                - Register async components at session init
-                - Keep method signatures identical
-                - Keep diffs from botocore minimal
-             d. Update hashes in `test_patches.py`.
-          2. Port relevant botocore tests to
-             `tests/botocore_tests/`. Follow existing patterns:
-             - `async def test_*()` (no pytest.mark.asyncio)
-             - Use `AioSession`, `StubbedSession`
-             - Use `AioAWSResponse` for mocked responses
-          3. `pyproject.toml`: update BOTH bounds. Lower =
-             $LATEST_BOTOCORE, upper = one patch above.
-          4. `aiobotocore/__init__.py`: increment MINOR version,
-             reset patch to 0.
-          5. `CHANGES.rst`: add entry:
-             ```
-             X.Y.0 (YYYY-MM-DD)
-             ^^^^^^^^^^^^^^^^^^^
-             * bump botocore dependency specification
-             ```
-          6. Run `uv lock` to update `uv.lock`.
-
-          If you complete all tasks, go to Step 5.
-          If you run out of turns or time, go to Step 5b.
-
-          ## Step 5: Validate
-
-          Run `uv run pytest tests/test_patches.py -x -v`.
-          Fix remaining failures. Repeat until passing.
-
-          If all tests pass, go to Step 6.
-          If tests fail and you cannot fix them, go to
-          Step 5b to save progress.
-
-          ## Step 5b: Save progress to WIP PR
-
-          You did not finish in this run. Save your work:
-
-          1. Commit all changes to `botocore-sync-wip`.
-          2. Push to `botocore-sync-wip` branch.
-          3. Create or update the WIP draft PR with a
-             description that contains ALL information
-             needed for the next run to continue:
-
-             ```
-             ### Botocore sync WIP: [VERSION]
-
-             **Target:** botocore [VERSION]
-             **Botocore diff:** [URL]
-             **Type:** bump (minor)
-
-             ### Completed
-             - [x] Analysis: [summary of categorized changes]
-             - [x] Ported: [file] ([what was done])
-             - [x] Ported: [file] ([what was done])
-
-             ### Remaining
-             - [ ] Port: [file] ([what needs to be done])
-             - [ ] Port tests for [file]
-             - [ ] Update version, changelog, lock
-
-             ### Decisions made
-             [Any design decisions, approaches chosen, and
-             why — so the next run doesn't re-decide]
-
-             ### Context for next run
-             [Anything the next run needs to know:
-             - Which botocore functions changed and how
-             - Which hash failures were already addressed
-             - Any tricky areas or gotchas discovered
-             - References to feedback issue if applicable]
-
-             ### Blockers
-             [If waiting on feedback issue, link it here]
-             ```
-
-          4. Exit. The next scheduled run will pick up
-             from this WIP PR.
-
-          ## Step 6: Finalize
-
-          All work is complete and tests pass.
-
-          Build botocore diff URL between last supported
-          version and new target:
-          `https://github.com/boto/botocore/compare/OLD...NEW`
-
-          **If a WIP PR exists:** squash the WIP branch
-          changes into a single commit on `botocore-sync`:
-          ```
-          git checkout -B botocore-sync origin/main
-          git merge --squash botocore-sync-wip
-          git commit
-          git push origin botocore-sync --force-with-lease
-          ```
-
-          **If no WIP PR:** commit directly to
-          `botocore-sync` and push.
-
-          Create or update the final PR:
-          - Base: `main`
-          - Title: `Relax botocore dependency specification`
-            or `Bump botocore dependency specification`
-          - Body:
-            ```
-            ### Description of Change
-            This PR [relaxes/bumps] the botocore dependency
-            to support version [VERSION].
-
-            **Type:** [Relax (patch) / Bump (minor)]
-            **Botocore diff:** [URL]
-
-            ### What changed in botocore
-            [Summary of upstream changes, categorized:
-            schema-only, patched code, new logic, etc.]
-
-            ### What changed in aiobotocore
-            [For bumps: list of files modified, new classes
-            added, tests ported. For relax: "Version bounds
-            updated only, no code changes."]
-
-            ### Reviewer checklist
-            Please verify before approving:
-            - [ ] Botocore diff reviewed — changes correctly
-                  categorized as relax vs bump
-            - [ ] For bumps: async overrides follow patterns
-                  in `docs/override-patterns.md`
-            - [ ] For bumps: new/changed tests pass and
-                  cover the ported functionality
-            - [ ] `test_patches.py` hashes are up to date
-            - [ ] Version bump in `__init__.py` is correct
-                  (patch for relax, minor for bump)
-            - [ ] `CHANGES.rst` entry added
-            - [ ] No unrelated changes included
-
-            ### How to help
-            - Review the botocore diff link above
-            - Check aiobotocore changes match botocore
-            - If something looks wrong, leave a review
-              comment — the bot will attempt to fix
-              straightforward issues automatically
-            - Use `@claude` to ask questions or request
-              modifications
-            - Approve and merge when satisfied
-
-            ### Checklist
-            * [x] Followed CONTRIBUTING.rst
-            * [x] Updated test_patches.py
-            * [x] Botocore diff: [URL]
-            ```
-
-          If a WIP PR exists, close it (post a comment
-          linking to the final PR first).
-
-          ## Step 7: Learn and document patterns
-
-          After completing any bump, or after receiving
-          feedback that resolves an ambiguity, check if the
-          decision reveals a reusable pattern.
-
-          If so, update the appropriate doc:
-          - `CLAUDE.md`: for quick-reference additions
-          - `docs/override-patterns.md`: for new patterns
-
-          Include doc updates in the same commit.
-
-          ## Step 8: Request feedback
-
-          Use this step when you encounter ambiguities,
-          design decisions, or unresolvable failures.
-
-          Check for an existing open feedback issue:
-          ```
-          gh issue list --label botocore-sync-feedback \
-            --state open --json number,body,comments \
-            --jq '.[0]'
-          ```
-
-          **If no open issue exists:** create one:
-          - Title: `Botocore sync: feedback needed for
-            $LATEST_BOTOCORE`
-          - Label: `botocore-sync-feedback`
-          - Body:
-            ```
-            ## Botocore sync needs your input
-
-            Botocore [VERSION] introduces changes that
-            require design decisions before porting.
-
-            **Botocore diff:** [link]
-            **Sync PR:** [link if exists]
-            **WIP PR:** [link if exists]
-
-            ## Questions
-
-            [Numbered list of questions, each with:
-            - Context: what changed and why it matters
-            - Options: valid approaches considered
-            - Trade-offs: pros/cons of each option]
-
-            ## How to respond
-
-            Reply with your answers. You can:
-            - Answer questions directly
-            - Ask `@claude` for more context (e.g.
-              "@claude show me the botocore diff for
-              question 2")
-            - Provide partial answers — the bot will
-              proceed with what it can and ask follow-ups
-            - Suggest a different approach entirely
-
-            Once resolved, the bot will apply decisions
-            on its next run. Close this issue when done.
-            ```
-
-          **If an open issue exists:** read body and all
-          comments. Check if current questions have been
-          asked or answered:
-          - Already asked and unanswered: do not repeat.
-          - Already answered: use the answer (should have
-            been picked up in Step 0).
-          - New questions: add a comment with new
-            questions and context. Delete any stale bot
-            comment before posting (so it appears at
-            the bottom).
-
-          Save progress to WIP PR (Step 5b) if you have
-          partial work, then exit.
-        # yamllint enable rule:line-length
+        prompt: ${{ steps.prompt.outputs.PROMPT }}
         claude_args: |
           --max-turns 50

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -161,6 +161,26 @@ jobs:
           patched code changed. New botocore logic may also need
           async overrides even if no existing hashes break.
 
+          ## Step 0: Check for feedback issue
+
+          Check for an open feedback issue:
+          ```
+          gh issue list --label botocore-sync-feedback \
+            --state open --json number,title,body,comments \
+            --jq '.[0]'
+          ```
+
+          If an open feedback issue exists:
+          - Read the issue body and ALL comments
+          - Look for human responses (not bot-authored)
+          - If humans answered questions: use those answers
+            to guide your decisions in subsequent steps.
+            If the answers reveal reusable patterns, update
+            `CLAUDE.md` or `docs/override-patterns.md`.
+          - If questions are still unanswered: do NOT create
+            a duplicate. Later steps may add new questions
+            as a comment (see Step 7).
+
           ## Step 1: Check existing PR state
 
           Check for an existing `botocore-sync` PR:
@@ -297,6 +317,14 @@ jobs:
           ## Step 4b: Bump path
 
           Read `docs/override-patterns.md` for the patterns.
+          Check Step 0 for any human guidance from the
+          feedback issue.
+
+          If you encounter ambiguities or design decisions
+          where multiple valid approaches exist (e.g. how to
+          handle a new botocore class, whether something needs
+          async override, how to structure the port), go to
+          Step 7 to request feedback instead of guessing.
 
           1. For each changed/new function needing porting:
              a. Diff old vs new botocore source.
@@ -356,14 +384,90 @@ jobs:
             - List of aiobotocore changes made (if bump)
             - Checklist referencing CONTRIBUTING.rst
 
-          ## Step 7: Handle failures
+          ## Step 7: Request feedback or handle failures
 
-          If you cannot resolve failures after reasonable effort,
-          open a GitHub issue:
-          - Title: Botocore sync: manual intervention needed
-          - Body: what failed, which functions changed, what
-            you tried, and the botocore diff URL.
-          - Do NOT push broken changes.
+          Use this step when you encounter ambiguities,
+          design decisions, or unresolvable failures.
+
+          Check for an existing open feedback issue:
+          ```
+          gh issue list --label botocore-sync-feedback \
+            --state open --json number,body,comments \
+            --jq '.[0]'
+          ```
+
+          **If no open issue exists:** create one:
+          - Title: `Botocore sync: feedback needed for
+            $LATEST_BOTOCORE`
+          - Label: `botocore-sync-feedback`
+          - Body format:
+            ```
+            ## Botocore sync needs your input
+
+            Botocore [VERSION] introduces changes that
+            require design decisions before porting.
+
+            **Botocore diff:** [link]
+            **Sync PR:** [link if exists]
+
+            ## Questions
+
+            [Numbered list of specific questions, each with:
+            - Context: what changed and why it matters
+            - Options: the valid approaches considered
+            - Trade-offs: pros/cons of each option]
+
+            ## How to respond
+
+            Reply to this issue with your answers. You can:
+            - Answer questions directly
+            - Ask `@claude` for more context about any
+              question (e.g. "@claude show me the botocore
+              diff for question 2")
+            - Provide partial answers — the bot will
+              proceed with what it can and ask follow-ups
+            - Suggest a different approach entirely
+
+            Once all questions are resolved, the bot will
+            apply your decisions on its next run. A
+            maintainer should close this issue when done.
+            ```
+
+          **If an open issue exists:** read the body and
+          all comments. Check if your current questions
+          have already been asked or answered:
+          - Already asked and unanswered: do not repeat.
+          - Already answered: use the answer (should have
+            been picked up in Step 0).
+          - New questions: add a comment with the new
+            questions, botocore diff URL, and context.
+            Delete any previous bot comment that is now
+            stale before posting the new one (so it
+            appears at the bottom).
+
+          Do NOT push broken changes. If you requested
+          feedback, exit without modifying the branch.
+
+          ## Step 8: Learn and document patterns
+
+          After completing any bump (Step 4b), or after
+          receiving feedback that resolves an ambiguity,
+          check if the decision reveals a reusable pattern.
+
+          If so, update the appropriate doc:
+          - `CLAUDE.md`: for quick-reference additions
+          - `docs/override-patterns.md`: for new patterns
+
+          Examples of learnable patterns:
+          - "New credential provider types always need
+            async override"
+          - "Changes to retry logic require updating
+            both retryhandler.py and the hash"
+          - "New HTTP features need both AIOHTTPSession
+            and HttpxSession implementations"
+
+          Include these doc updates in the same commit
+          as the bump changes.
         # yamllint enable rule:line-length
         claude_args: |
           --max-turns 50

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -16,6 +16,9 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: botocore-sync
+
 jobs:
   detect:
     runs-on: ubuntu-latest

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -109,23 +109,27 @@ jobs:
         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
         # yamllint disable rule:line-length
         prompt: |
-          You are a botocore sync bot for aiobotocore. Update aiobotocore to
-          support botocore version $LATEST_BOTOCORE (current upper bound is
-          $CURRENT_UPPER).
+          You are a botocore sync bot for aiobotocore. Update
+          aiobotocore to support botocore $LATEST_BOTOCORE
+          (current upper bound: $CURRENT_UPPER).
 
           ## Background
 
-          aiobotocore adds async functionality to botocore by subclassing and
-          monkey-patching botocore classes. The aiobotocore source files mirror
-          botocore's file structure (e.g. `aiobotocore/credentials.py` overrides
-          classes from `botocore/credentials.py`). Because of this tight
-          coupling, aiobotocore pins to a narrow range of botocore versions.
+          aiobotocore adds async functionality to botocore by
+          subclassing and monkey-patching botocore classes. Source
+          files mirror botocore's structure (e.g.
+          `aiobotocore/credentials.py` overrides classes from
+          `botocore/credentials.py`). Because of this tight
+          coupling, aiobotocore pins to a narrow botocore range.
 
-          `tests/test_patches.py` contains SHA1 hashes of specific botocore
-          source code that aiobotocore depends on. When botocore changes code
-          that aiobotocore patches, hashes break, signaling porting is needed.
+          `tests/test_patches.py` hashes specific botocore source
+          that aiobotocore depends on. Hash failures signal that
+          patched code changed. However, hashes alone are NOT
+          sufficient — new botocore logic (new classes, network
+          calls, I/O, or use of classes we override) may also
+          need async overrides even if no existing hashes break.
 
-          Read `CONTRIBUTING.rst` for the full upgrade process documentation.
+          Read `CONTRIBUTING.rst` for full upgrade documentation.
 
           ## Step 1: Set up the branch
 
@@ -136,8 +140,32 @@ jobs:
             || git checkout -b botocore-sync origin/main
           ```
 
-          ## Step 2: Install and test
+          ## Step 2: Analyze the botocore diff
 
+          Determine the last supported botocore version:
+          the upper bound in pyproject.toml minus one patch
+          (e.g. if `< 1.42.31` then last supported is `1.42.30`).
+
+          Download both versions and diff the botocore source:
+          ```
+          pip download botocore==OLD --no-deps -d /tmp/old
+          pip download botocore==$LATEST_BOTOCORE --no-deps \
+            -d /tmp/new
+          ```
+          Extract and diff the `botocore/` directories.
+
+          Categorize changes:
+          a) JSON schema/model updates only (service definitions)
+          b) Changes to code we already patch (files that have a
+             corresponding `aiobotocore/*.py` override)
+          c) New logic in files we override: new classes, methods,
+             network calls, I/O operations, blocking code, or
+             new use of classes we subclass
+          d) New logic in files we don't override (no action)
+
+          ## Step 3: Determine update type
+
+          Install and run hash tests:
           ```
           pip install uv
           uv sync --all-extras
@@ -145,65 +173,69 @@ jobs:
           uv run pytest tests/test_patches.py -x -v 2>&1
           ```
 
-          ## Step 3: Determine update type
+          Combine the diff analysis with hash test results:
 
-          - If ALL tests pass → **relax** (extend upper bound only)
-          - If ANY tests fail → **bump** (code changes required)
+          **Relax** (patch version bump): ALL of these are true:
+          - All test_patches.py hashes pass
+          - No new logic in files we override needs async
+            treatment
+          - Changes are limited to JSON schemas, docs, or
+            files we don't touch
 
-          ## Step 4a: Relax path (all hashes pass)
+          **Bump** (minor version bump): ANY of these are true:
+          - Hash tests fail (patched code changed)
+          - New classes/methods/logic in files we override
+            needs async conversion
 
-          1. `pyproject.toml`: change the botocore upper bound from
-             `< $CURRENT_UPPER` to `< X` where X is one patch above
-             $LATEST_BOTOCORE. Keep the lower bound unchanged.
-          2. `aiobotocore/__init__.py`: increment the PATCH version.
+          **Major bump**: breaking API changes that affect
+          aiobotocore's public interface (rare, flag for human
+          review if detected).
+
+          ## Step 4a: Relax path
+
+          1. `pyproject.toml`: change botocore upper bound to
+             one patch above $LATEST_BOTOCORE. Keep lower bound
+             unchanged.
+          2. `aiobotocore/__init__.py`: increment PATCH version.
           3. `CHANGES.rst`: add entry at top with today's date:
              ```
              X.Y.Z (YYYY-MM-DD)
              ^^^^^^^^^^^^^^^^^^^
              * relax botocore dependency specification
              ```
-             The `^` underline must match the header length exactly.
-          4. If any new botocore functions appear that we depend on,
+             The `^` underline must match header length exactly.
+          4. If new botocore functions appear that we depend on,
              add their hashes to `test_patches.py`.
           5. Run `uv lock` to update `uv.lock`.
 
-          ## Step 4b: Bump path (hash failures)
+          ## Step 4b: Bump path
 
-          1. From test failures, identify which botocore functions
-             changed.
-          2. For each changed function:
-             a. Get the botocore source for the OLD version
-                ($CURRENT_UPPER minus one patch) and NEW version
-                ($LATEST_BOTOCORE). Use
-                `pip download botocore==VERSION --no-deps -d /tmp/`
-                then extract and compare, or use
-                inspect.getsource().
-             b. Diff old vs new to understand the changes.
-             c. Find the corresponding aiobotocore file. Our files
-                mirror botocore's structure:
-                `botocore/X.py` → `aiobotocore/X.py`.
-             d. Port changes to the aiobotocore version:
+          1. For each changed/new function needing porting:
+             a. Diff old vs new botocore source to understand
+                what changed.
+             b. Find the corresponding `aiobotocore/*.py` file.
+             c. Port changes:
                 - Convert synchronous calls to async/await
                 - Subclass new classes with `Aio` prefix
                 - Register new async classes where botocore
                   registers sync ones
                 - Keep method signatures identical
-                - Keep diffs from botocore as small as possible
-             e. Update the hash in `test_patches.py`.
-          3. Port relevant botocore tests to
-             `tests/botocore_tests/`. Check existing files there
-             for the async test pattern.
-          4. `pyproject.toml`: update BOTH lower and upper bounds.
-             Lower = $LATEST_BOTOCORE, upper = one patch above.
-          5. `aiobotocore/__init__.py`: increment the MINOR version,
+                - Keep diffs from botocore minimal
+             d. Update hashes in `test_patches.py`.
+          2. Port relevant botocore tests to
+             `tests/botocore_tests/`. Follow existing async
+             test patterns there.
+          3. `pyproject.toml`: update BOTH bounds. Lower =
+             $LATEST_BOTOCORE, upper = one patch above.
+          4. `aiobotocore/__init__.py`: increment MINOR version,
              reset patch to 0.
-          6. `CHANGES.rst`: add entry:
+          5. `CHANGES.rst`: add entry:
              ```
              X.Y.0 (YYYY-MM-DD)
              ^^^^^^^^^^^^^^^^^^^
              * bump botocore dependency specification
              ```
-          7. Run `uv lock` to update `uv.lock`.
+          6. Run `uv lock` to update `uv.lock`.
 
           ## Step 5: Validate
 
@@ -212,12 +244,11 @@ jobs:
 
           ## Step 6: Commit, push, and create/update PR
 
-          Commit all changes. Push to the `botocore-sync` branch.
+          Commit all changes. Push to `botocore-sync` branch.
 
-          Build the botocore diff URL:
+          Build the botocore diff URL between the last supported
+          version and the new target:
           `https://github.com/boto/botocore/compare/OLD...NEW`
-          where OLD is the previous upper bound minus one patch
-          version, and NEW is $LATEST_BOTOCORE.
 
           Check if a PR already exists:
           ```
@@ -225,25 +256,26 @@ jobs:
             --jq '.[0].number'
           ```
 
-          If a PR exists, push will update it. If not, create one:
+          If a PR exists, update its body. If not, create one:
           - Base: `main`
           - Title: `Relax botocore dependency specification` or
                    `Bump botocore dependency specification`
-          - Body should include:
+          - Body MUST include:
             - Description of change (relax or bump)
-            - Assumptions about upstream changes
+            - Botocore diff URL (between last supported version
+              and new target)
+            - Summary of what changed in botocore
+            - List of aiobotocore changes made (if bump)
             - Checklist referencing CONTRIBUTING.rst
-            - URL to botocore diff
-            - List of specific changes made
 
           ## Step 7: Handle failures
 
-          If you cannot resolve test failures after reasonable
-          effort, open a GitHub issue:
+          If you cannot resolve failures after reasonable effort,
+          open a GitHub issue:
           - Title: Botocore sync: manual intervention needed
-          - Body: explain what failed, which functions changed,
-            what you attempted, and include the botocore diff URL.
-          - Do NOT leave the PR in a broken state.
+          - Body: what failed, which functions changed, what you
+            tried, and the botocore diff URL.
+          - Do NOT push broken changes.
         # yamllint enable rule:line-length
         claude_args: |
           --max-turns 50

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -11,21 +11,27 @@ on:
     inputs:
       botocore_version:
         description: >-
-          Target botocore version (leave empty to auto-detect latest)
+          Target botocore version
+          (leave empty to auto-detect latest)
         required: false
         type: string
 
 jobs:
   detect:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
     outputs:
-      latest_botocore: ${{ steps.check.outputs.latest_botocore }}
-      current_upper: ${{ steps.check.outputs.current_upper }}
-      needs_update: ${{ steps.check.outputs.needs_update }}
+      latest_botocore: >-
+        ${{ steps.check.outputs.latest_botocore }}
+      current_upper: >-
+        ${{ steps.check.outputs.current_upper }}
+      needs_update: >-
+        ${{ steps.check.outputs.needs_update }}
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+    # yamllint disable-line rule:line-length
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
     - name: Check for new botocore version
       id: check
@@ -34,14 +40,17 @@ jobs:
       run: |
         # Validate manual input if provided
         if [ -n "$INPUT_VERSION" ]; then
-          if ! echo "$INPUT_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::Invalid version format: $INPUT_VERSION"
+          pattern='^[0-9]+\.[0-9]+\.[0-9]+$'
+          if ! echo "$INPUT_VERSION" | grep -qE "$pattern"; then
+            echo "::error::Invalid version format"
             exit 1
           fi
           latest="$INPUT_VERSION"
         else
           latest=$(curl -s https://pypi.org/pypi/botocore/json \
-            | python3 -c "import sys,json; print(json.load(sys.stdin)['info']['version'])")
+            | python3 -c \
+            "import sys,json; \
+            print(json.load(sys.stdin)['info']['version'])")
         fi
         echo "latest_botocore=$latest" >> "$GITHUB_OUTPUT"
 
@@ -49,19 +58,21 @@ jobs:
         upper=$(python3 -c "
         import re
         text = open('pyproject.toml').read()
-        m = re.search(r'botocore\s*>=\s*[\d.]+,\s*<\s*([\d.]+)', text)
+        m = re.search(
+            r'botocore\s*>=\s*[\d.]+,\s*<\s*([\d.]+)',
+            text)
         print(m.group(1))
         ")
         echo "current_upper=$upper" >> "$GITHUB_OUTPUT"
 
-        # Compare versions using env vars (not string interpolation)
+        # Compare versions
         LATEST="$latest" UPPER="$upper" python3 << 'PYEOF'
         import os
         from packaging.version import Version
         latest = os.environ["LATEST"]
         upper = os.environ["UPPER"]
         needs = "true" if Version(latest) >= Version(upper) else "false"
-        print(f"Latest: {latest}, upper bound: {upper}, needs update: {needs}")
+        print(f"Latest: {latest}, upper: {upper}, update: {needs}")
         with open(os.environ["GITHUB_OUTPUT"], "a") as f:
             f.write(f"needs_update={needs}\n")
         PYEOF
@@ -75,18 +86,24 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
       actions: read
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+    # yamllint disable-line rule:line-length
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         fetch-depth: 0
 
-    - uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6  # v1
+    # yamllint disable-line rule:line-length
+    - uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6
       env:
-        LATEST_BOTOCORE: ${{ needs.detect.outputs.latest_botocore }}
-        CURRENT_UPPER: ${{ needs.detect.outputs.current_upper }}
+        LATEST_BOTOCORE: >-
+          ${{ needs.detect.outputs.latest_botocore }}
+        CURRENT_UPPER: >-
+          ${{ needs.detect.outputs.current_upper }}
       with:
         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+        # yamllint disable rule:line-length
         prompt: |
           You are a botocore sync bot for aiobotocore. Update aiobotocore to
           support botocore version $LATEST_BOTOCORE (current upper bound is
@@ -109,7 +126,10 @@ jobs:
           ## Step 1: Set up the branch
 
           ```
-          git fetch origin botocore-sync 2>/dev/null && git checkout botocore-sync && git reset --hard origin/main || git checkout -b botocore-sync origin/main
+          git fetch origin botocore-sync 2>/dev/null \
+            && git checkout botocore-sync \
+            && git reset --hard origin/main \
+            || git checkout -b botocore-sync origin/main
           ```
 
           ## Step 2: Install and test
@@ -139,34 +159,40 @@ jobs:
              * relax botocore dependency specification
              ```
              The `^` underline must match the header length exactly.
-          4. If any new botocore functions appear that we depend on, add
-             their hashes to `test_patches.py`.
+          4. If any new botocore functions appear that we depend on,
+             add their hashes to `test_patches.py`.
           5. Run `uv lock` to update `uv.lock`.
 
           ## Step 4b: Bump path (hash failures)
 
-          1. From test failures, identify which botocore functions changed.
+          1. From test failures, identify which botocore functions
+             changed.
           2. For each changed function:
-             a. Get the botocore source for the OLD version ($CURRENT_UPPER
-                minus one patch) and NEW version ($LATEST_BOTOCORE).
-                Use `pip download botocore==VERSION --no-deps -d /tmp/boto_dl`
-                then extract and compare, or use inspect.getsource().
+             a. Get the botocore source for the OLD version
+                ($CURRENT_UPPER minus one patch) and NEW version
+                ($LATEST_BOTOCORE). Use
+                `pip download botocore==VERSION --no-deps -d /tmp/`
+                then extract and compare, or use
+                inspect.getsource().
              b. Diff old vs new to understand the changes.
-             c. Find the corresponding aiobotocore file. Our files mirror
-                botocore's structure: `botocore/X.py` → `aiobotocore/X.py`.
+             c. Find the corresponding aiobotocore file. Our files
+                mirror botocore's structure:
+                `botocore/X.py` → `aiobotocore/X.py`.
              d. Port changes to the aiobotocore version:
                 - Convert synchronous calls to async/await
                 - Subclass new classes with `Aio` prefix
-                - Register new async classes where botocore registers sync ones
+                - Register new async classes where botocore
+                  registers sync ones
                 - Keep method signatures identical
                 - Keep diffs from botocore as small as possible
              e. Update the hash in `test_patches.py`.
-          3. Port relevant botocore tests to `tests/botocore_tests/`.
-             Check existing files there for the async test pattern.
+          3. Port relevant botocore tests to
+             `tests/botocore_tests/`. Check existing files there
+             for the async test pattern.
           4. `pyproject.toml`: update BOTH lower and upper bounds.
              Lower = $LATEST_BOTOCORE, upper = one patch above.
-          5. `aiobotocore/__init__.py`: increment the MINOR version, reset
-             patch to 0.
+          5. `aiobotocore/__init__.py`: increment the MINOR version,
+             reset patch to 0.
           6. `CHANGES.rst`: add entry:
              ```
              X.Y.0 (YYYY-MM-DD)
@@ -177,8 +203,8 @@ jobs:
 
           ## Step 5: Validate
 
-          Run `uv run pytest tests/test_patches.py -x -v` again. Fix any
-          remaining failures. Repeat until passing.
+          Run `uv run pytest tests/test_patches.py -x -v` again.
+          Fix any remaining failures. Repeat until passing.
 
           ## Step 6: Commit, push, and create/update PR
 
@@ -186,47 +212,34 @@ jobs:
 
           Build the botocore diff URL:
           `https://github.com/boto/botocore/compare/OLD...NEW`
-          where OLD is the previous upper bound minus one patch version,
-          and NEW is $LATEST_BOTOCORE.
+          where OLD is the previous upper bound minus one patch
+          version, and NEW is $LATEST_BOTOCORE.
 
           Check if a PR already exists:
           ```
-          gh pr list --head botocore-sync --json number --jq '.[0].number'
+          gh pr list --head botocore-sync --json number \
+            --jq '.[0].number'
           ```
 
           If a PR exists, push will update it. If not, create one:
           - Base: `main`
           - Title: `Relax botocore dependency specification` or
                    `Bump botocore dependency specification`
-          - Body template:
-            ```
-            ### Description of Change
-            This PR intends to improve general compatibility of `aiobotocore`
-            within the Python ecosystem by [relaxing/bumping] the dependency
-            specification of `botocore`.
-
-            ### Assumptions
-            Upstream contains [no changes that require/minor changes that
-            require/several changes that require] adjustments to the
-            aiobotocore codebase.
-
-            ### Checklist when updating botocore versions
-            * [x] I have read and followed CONTRIBUTING.rst
-            * [x] I have updated test_patches.py where/if appropriate
-            * [x] I have added URL to diff: DIFF_URL
-
-            ### Changes
-            [List the specific changes made, if any]
-            ```
+          - Body should include:
+            - Description of change (relax or bump)
+            - Assumptions about upstream changes
+            - Checklist referencing CONTRIBUTING.rst
+            - URL to botocore diff
+            - List of specific changes made
 
           ## Step 7: Handle failures
 
-          If you cannot resolve test failures after reasonable effort, open
-          a GitHub issue:
-          - Title: `Botocore sync: manual intervention needed for VERSION`
-          - Body: explain what failed, which functions changed, what you
-            attempted, and include the botocore diff URL.
-          - Do NOT leave the PR in a broken state — either fix it or don't
-            push broken changes.
+          If you cannot resolve test failures after reasonable
+          effort, open a GitHub issue:
+          - Title: Botocore sync: manual intervention needed
+          - Body: explain what failed, which functions changed,
+            what you attempted, and include the botocore diff URL.
+          - Do NOT leave the PR in a broken state.
+        # yamllint enable rule:line-length
         claude_args: |
           --max-turns 50

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -377,12 +377,55 @@ jobs:
           - Base: `main`
           - Title: `Relax botocore dependency specification`
             or `Bump botocore dependency specification`
-          - Body MUST include:
-            - Description of change (relax or bump)
-            - Botocore diff URL
-            - Summary of what changed in botocore
-            - List of aiobotocore changes made (if bump)
-            - Checklist referencing CONTRIBUTING.rst
+          - Body format:
+            ```
+            ### Description of Change
+            This PR [relaxes/bumps] the botocore dependency
+            to support version [VERSION].
+
+            **Type:** [Relax (patch) / Bump (minor)]
+            **Botocore diff:** [link between last supported
+            version and new target]
+
+            ### What changed in botocore
+            [Summary of upstream changes, categorized:
+            schema-only, patched code, new logic, etc.]
+
+            ### What changed in aiobotocore
+            [For bumps: list of files modified, new classes
+            added, tests ported. For relax: "Version bounds
+            updated only, no code changes."]
+
+            ### Reviewer checklist
+            Please verify before approving:
+            - [ ] Botocore diff reviewed — changes correctly
+                  categorized as relax vs bump
+            - [ ] For bumps: async overrides follow patterns
+                  in `docs/override-patterns.md`
+            - [ ] For bumps: new/changed tests pass and cover
+                  the ported functionality
+            - [ ] `test_patches.py` hashes are up to date
+            - [ ] Version bump in `__init__.py` is correct
+                  (patch for relax, minor for bump)
+            - [ ] `CHANGES.rst` entry added
+            - [ ] No unrelated changes included
+
+            ### How to help
+            - Review the botocore diff link above
+            - Check the aiobotocore changes match the
+              botocore changes
+            - If something looks wrong, leave a review
+              comment — the bot will attempt to fix
+              straightforward issues automatically
+            - Use `@claude` in a comment to ask questions
+              about the changes or request modifications
+            - Approve and merge when satisfied
+
+            ### Checklist
+            * [x] Followed CONTRIBUTING.rst
+            * [x] Updated test_patches.py
+            * [x] Botocore diff: [URL]
+            ```
 
           ## Step 7: Request feedback or handle failures
 

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -40,6 +40,12 @@ jobs:
       env:
         INPUT_VERSION: ${{ inputs.botocore_version }}
       run: |
+        # Get latest botocore version from PyPI
+        pypi_latest=$(curl -s https://pypi.org/pypi/botocore/json \
+          | python3 -c \
+          "import sys,json; \
+          print(json.load(sys.stdin)['info']['version'])")
+
         # Validate manual input if provided
         if [ -n "$INPUT_VERSION" ]; then
           pattern='^[0-9]+\.[0-9]+\.[0-9]+$'
@@ -49,12 +55,10 @@ jobs:
           fi
           latest="$INPUT_VERSION"
         else
-          latest=$(curl -s https://pypi.org/pypi/botocore/json \
-            | python3 -c \
-            "import sys,json; \
-            print(json.load(sys.stdin)['info']['version'])")
+          latest="$pypi_latest"
         fi
         echo "latest_botocore=$latest" >> "$GITHUB_OUTPUT"
+        echo "pypi_latest=$pypi_latest" >> "$GITHUB_OUTPUT"
 
         # Get current upper bound from pyproject.toml
         upper=$(python3 -c "
@@ -69,6 +73,7 @@ jobs:
 
         # Compare versions (tuple comparison, no deps)
         LATEST="$latest" UPPER="$upper" \
+          PYPI_LATEST="$pypi_latest" \
           MANUAL="${INPUT_VERSION:+true}" \
           python3 << 'PYEOF'
         import os, sys
@@ -76,7 +81,12 @@ jobs:
             return tuple(int(x) for x in s.split("."))
         latest = os.environ["LATEST"]
         upper = os.environ["UPPER"]
+        pypi = os.environ["PYPI_LATEST"]
         manual = os.environ.get("MANUAL") == "true"
+        if manual and ver(latest) > ver(pypi):
+            print(f"::error::Version {latest} is newer "
+                  f"than latest PyPI release {pypi}")
+            sys.exit(1)
         if ver(latest) < ver(upper):
             if manual:
                 print(f"::error::Version {latest} is older "

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -68,14 +68,25 @@ jobs:
         echo "current_upper=$upper" >> "$GITHUB_OUTPUT"
 
         # Compare versions (tuple comparison, no deps)
-        LATEST="$latest" UPPER="$upper" python3 << 'PYEOF'
-        import os
+        LATEST="$latest" UPPER="$upper" \
+          MANUAL="${INPUT_VERSION:+true}" \
+          python3 << 'PYEOF'
+        import os, sys
         def ver(s):
             return tuple(int(x) for x in s.split("."))
         latest = os.environ["LATEST"]
         upper = os.environ["UPPER"]
-        needs = "true" if ver(latest) >= ver(upper) else "false"
-        print(f"Latest: {latest}, upper: {upper}, update: {needs}")
+        manual = os.environ.get("MANUAL") == "true"
+        if ver(latest) < ver(upper):
+            if manual:
+                print(f"::error::Version {latest} is older "
+                      f"than current upper bound {upper}")
+                sys.exit(1)
+            print(f"Up to date: {latest} < {upper}")
+            needs = "false"
+        else:
+            print(f"Update needed: {latest} >= {upper}")
+            needs = "true"
         with open(os.environ["GITHUB_OUTPUT"], "a") as f:
             f.write(f"needs_update={needs}\n")
         PYEOF

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -60,19 +60,22 @@ jobs:
         echo "latest_botocore=$latest" >> "$GITHUB_OUTPUT"
         echo "pypi_latest=$pypi_latest" >> "$GITHUB_OUTPUT"
 
-        # Get current upper bound from pyproject.toml
-        upper=$(python3 -c "
+        # Get current bounds from pyproject.toml
+        read -r lower upper << BOUNDS
+        $(python3 -c "
         import re
         text = open('pyproject.toml').read()
         m = re.search(
-            r'botocore\s*>=\s*[\d.]+,\s*<\s*([\d.]+)',
+            r'botocore\s*>=\s*([\d.]+),\s*<\s*([\d.]+)',
             text)
-        print(m.group(1))
+        print(m.group(1), m.group(2))
         ")
+        BOUNDS
+        echo "current_lower=$lower" >> "$GITHUB_OUTPUT"
         echo "current_upper=$upper" >> "$GITHUB_OUTPUT"
 
         # Compare versions (tuple comparison, no deps)
-        LATEST="$latest" UPPER="$upper" \
+        LATEST="$latest" LOWER="$lower" UPPER="$upper" \
           PYPI_LATEST="$pypi_latest" \
           MANUAL="${INPUT_VERSION:+true}" \
           python3 << 'PYEOF'
@@ -80,17 +83,24 @@ jobs:
         def ver(s):
             return tuple(int(x) for x in s.split("."))
         latest = os.environ["LATEST"]
+        lower = os.environ["LOWER"]
         upper = os.environ["UPPER"]
         pypi = os.environ["PYPI_LATEST"]
         manual = os.environ.get("MANUAL") == "true"
-        if manual and ver(latest) > ver(pypi):
-            print(f"::error::Version {latest} is newer "
-                  f"than latest PyPI release {pypi}")
-            sys.exit(1)
+        if manual:
+            if ver(latest) > ver(pypi):
+                print(f"::error::{latest} does not exist "
+                      f"(latest PyPI release: {pypi})")
+                sys.exit(1)
+            if ver(latest) < ver(lower):
+                print(f"::error::{latest} is older than "
+                      f"current lower bound {lower}")
+                sys.exit(1)
         if ver(latest) < ver(upper):
             if manual:
-                print(f"::error::Version {latest} is older "
-                      f"than current upper bound {upper}")
+                print(f"::error::{latest} is already "
+                      f"within supported range "
+                      f"(upper bound: {upper})")
                 sys.exit(1)
             print(f"Up to date: {latest} < {upper}")
             needs = "false"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,39 +26,45 @@ jobs:
   claude:
     # Only trusted authors can trigger @claude interactions.
     # Auto-review on pull_request events is unrestricted.
+    # yamllint disable-line rule:line-length
     if: >-
       (github.event_name == 'pull_request') ||
       (github.event_name == 'issue_comment' &&
        contains(github.event.comment.body, '@claude') &&
        contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'),
-                github.event.comment.author_association)) ||
+       github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' &&
        contains(github.event.comment.body, '@claude') &&
        contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'),
-                github.event.comment.author_association)) ||
+       github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review' &&
        contains(github.event.review.body, '@claude') &&
        contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'),
-                github.event.review.author_association)) ||
+       github.event.review.author_association)) ||
       (github.event_name == 'issues' &&
        (contains(github.event.issue.body, '@claude') ||
-        contains(github.event.issue.title, '@claude')) &&
+       contains(github.event.issue.title, '@claude')) &&
        contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'),
-                github.event.issue.author_association))
+       github.event.issue.author_association))
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
       actions: read
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+    # yamllint disable-line rule:line-length
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         fetch-depth: 1
 
-    - uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6  # v1
+    # yamllint disable-line rule:line-length
+    - uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6
       with:
         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+        # yamllint disable rule:line-length
         prompt: |
           This is aiobotocore, a Python async library wrapping botocore for asyncio.
 
@@ -78,3 +84,4 @@ jobs:
           Use the repository's CLAUDE.md for guidance on style and conventions.
         claude_args: |
           --disallowedTools "Bash(gh pr merge:*),Bash(gh pr close:*),Bash(gh issue close:*)"
+        # yamllint enable rule:line-length

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -48,6 +48,7 @@ jobs:
        github.event.issue.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment: claude
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,80 @@
+---
+name: Claude Code
+
+permissions: {}
+
+on:
+  pull_request:
+    types:
+    - opened
+    - synchronize
+  issue_comment:
+    types:
+    - created
+  pull_request_review_comment:
+    types:
+    - created
+  pull_request_review:
+    types:
+    - submitted
+  issues:
+    types:
+    - opened
+    - assigned
+
+jobs:
+  claude:
+    # Only trusted authors can trigger @claude interactions.
+    # Auto-review on pull_request events is unrestricted.
+    if: >-
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'issue_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'),
+                github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'),
+                github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' &&
+       contains(github.event.review.body, '@claude') &&
+       contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'),
+                github.event.review.author_association)) ||
+      (github.event_name == 'issues' &&
+       (contains(github.event.issue.body, '@claude') ||
+        contains(github.event.issue.title, '@claude')) &&
+       contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'),
+                github.event.issue.author_association))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        fetch-depth: 1
+
+    - uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6  # v1
+      with:
+        anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+        prompt: |
+          This is aiobotocore, a Python async library wrapping botocore for asyncio.
+
+          When reviewing pull requests, focus on:
+          - Code correctness and potential bugs
+          - Security implications
+          - Performance considerations
+          - Python best practices and async patterns
+          - Resource cleanup (async context managers, session/client lifecycle)
+
+          When working on issues, you may create branches and pull requests
+          to implement fixes or features. Use branch prefix `claude/`.
+
+          IMPORTANT: Never merge or close pull requests. Never close issues.
+          These actions require human approval.
+
+          Use the repository's CLAUDE.md for guidance on style and conventions.
+        claude_args: |
+          --disallowedTools "Bash(gh pr merge:*),Bash(gh pr close:*),Bash(gh issue close:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -60,6 +60,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         fetch-depth: 1
+        persist-credentials: false
 
     # yamllint disable-line rule:line-length
     - uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -77,6 +77,18 @@ jobs:
           - Python best practices and async patterns
           - Resource cleanup (async context managers, session/client lifecycle)
 
+          Check the PR author type with:
+          `gh pr view $PR_NUMBER --json author --jq '.author.login'`
+
+          If the PR was created by a bot (github-actions[bot], claude[bot],
+          dependabot[bot], etc.), after posting your review, attempt to fix
+          any straightforward issues you found by pushing a commit to the
+          PR branch. Only fix clear-cut issues (style, missing types,
+          simple bugs). Do not attempt complex refactors.
+
+          If the PR was created by a human, review only. Never push
+          commits to human PRs during auto-review.
+
           When working on issues, you may create branches and pull requests
           to implement fixes or features. Use branch prefix `claude/`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,8 @@ Run before committing:
 uv run pre-commit run --all --show-diff-on-failure
 ```
 
-This runs: `check-yaml`, `end-of-file-fixer`, `trailing-whitespace`, `ruff-check`, `ruff-format`, `uv-lock`, `yamllint --strict`, `check-github-workflows`, `check-github-workflows-require-timeout`, `check-dependabot`, `check-readthedocs`.
-
 Key constraints:
-- YAML lines must be ≤80 chars (use `# yamllint disable-line rule:line-length` for unavoidable exceptions like SHA-pinned actions)
+- YAML lines must be ≤80 chars (`# yamllint disable-line rule:line-length` for exceptions)
 - All workflow jobs must have `timeout-minutes`
 - Python code formatted with `ruff`
 
@@ -27,3 +25,28 @@ See `CONTRIBUTING.rst` "How to Upgrade Botocore" section. Key files:
 - `aiobotocore/__init__.py` — aiobotocore version
 - `tests/test_patches.py` — SHA1 hashes of patched botocore code
 - `CHANGES.rst` — changelog
+
+# How aiobotocore overrides botocore
+
+aiobotocore makes botocore async by **subclassing** (never monkey-patching). Each override follows the same pattern: subclass with `Aio` prefix, override sync methods with `async def`, call `await` on I/O operations.
+
+See [docs/override-patterns.md](docs/override-patterns.md) for the full reference of patterns, wiring, and test porting.
+
+## Quick reference
+
+**Override chain** (how a client call flows):
+`AioSession.create_client()` → `AioClientCreator.create_client()` → `AioBaseClient._make_api_call()` → `AioEndpoint._send_request()` → `AIOHTTPSession.send()`
+
+**Key files and what they override:**
+
+| aiobotocore file | botocore equivalent | What it does |
+|-|-|-|
+| session.py | session.py | Registers async components, returns async client context |
+| client.py | client.py | Async client creation and API calls |
+| endpoint.py | endpoint.py | Async HTTP request/response |
+| httpsession.py | httpsession.py | aiohttp-based HTTP (replaces urllib3) |
+| credentials.py | credentials.py | Async credential refresh with asyncio.Lock |
+| hooks.py | hooks.py | Event emitter that awaits async handlers |
+| args.py | args.py | Wires AioEndpointCreator + AioConfig |
+| config.py | config.py | Adds connector_args, http_session_cls |
+| _helpers.py | (none) | `resolve_awaitable()` — awaits if coroutine, returns if not |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# Pre-commit checks
+
+Run before committing:
+
+```
+uv run pre-commit run --all --show-diff-on-failure
+```
+
+This runs: `check-yaml`, `end-of-file-fixer`, `trailing-whitespace`, `ruff-check`, `ruff-format`, `uv-lock`, `yamllint --strict`, `check-github-workflows`, `check-github-workflows-require-timeout`, `check-dependabot`, `check-readthedocs`.
+
+Key constraints:
+- YAML lines must be ≤80 chars (use `# yamllint disable-line rule:line-length` for unavoidable exceptions like SHA-pinned actions)
+- All workflow jobs must have `timeout-minutes`
+- Python code formatted with `ruff`
+
+# Tests
+
+```
+uv run make mototest    # moto-based tests (CI runs these)
+uv run pytest -sv tests/test_patches.py  # hash validation
+```
+
+# Botocore version updates
+
+See `CONTRIBUTING.rst` "How to Upgrade Botocore" section. Key files:
+- `pyproject.toml` — botocore version range
+- `aiobotocore/__init__.py` — aiobotocore version
+- `tests/test_patches.py` — SHA1 hashes of patched botocore code
+- `CHANGES.rst` — changelog

--- a/docs/override-patterns.md
+++ b/docs/override-patterns.md
@@ -1,0 +1,158 @@
+# aiobotocore Override Patterns
+
+## Architecture
+
+aiobotocore never monkey-patches botocore. It subclasses botocore
+classes, overrides methods with async versions, and wires the async
+classes in at session creation time via component registration.
+
+## Pattern 1: Subclass + async override
+
+The most common pattern. Subclass with `Aio` prefix, override the
+method as `async def`, await I/O calls.
+
+```python
+# aiobotocore/client.py
+class AioBaseClient(BaseClient):
+    async def _make_api_call(self, operation_name, api_params):
+        # Same logic as BaseClient._make_api_call but with:
+        # - await on endpoint._send_request()
+        # - await on event hooks
+        ...
+```
+
+Files using this: `client.py`, `endpoint.py`, `credentials.py`,
+`session.py`, `args.py`, `signers.py`, `paginate.py`, `waiter.py`.
+
+## Pattern 2: Component registration at session init
+
+`AioSession.__init__()` calls parent then replaces components:
+
+```python
+# aiobotocore/session.py:87
+class AioSession(Session):
+    def _register_response_parser_factory(self):
+        self._components.register_component(
+            'response_parser_factory',
+            AioResponseParserFactory()
+        )
+```
+
+This ensures all clients created from the session use async
+components. The registration happens for: response parsers,
+credential resolvers, smart defaults factory.
+
+## Pattern 3: HTTP session replacement
+
+botocore uses urllib3 (sync). aiobotocore replaces the entire
+HTTP layer:
+
+- `AioEndpoint.__init__()` requires an `http_session` parameter
+  (aiobotocore/endpoint.py:68)
+- `AioEndpoint._send()` calls `await self.http_session.send()`
+- `AIOHTTPSession` (aiobotocore/httpsession.py) wraps aiohttp
+- `HttpxSession` (aiobotocore/httpxsession.py) wraps httpx
+- `AioConfig.http_session_cls` selects which HTTP backend to use
+
+The HTTP session is created during `AioEndpointCreator.create_endpoint()`
+and managed as an async context manager by `AioBaseClient`.
+
+## Pattern 4: Credential async layer
+
+Credential providers/fetchers that do network I/O (IMDS, STS,
+SSO, container) need async versions:
+
+```python
+# aiobotocore/credentials.py
+class AioRefreshableCredentials(RefreshableCredentials):
+    def __init__(self, ...):
+        ...
+        self._refresh_lock = asyncio.Lock()  # replaces threading.Lock
+
+    async def _protected_refresh(self, is_mandatory):
+        async with self._refresh_lock:
+            ...
+```
+
+Key async credential classes: `AioRefreshableCredentials`,
+`AioDeferredRefreshableCredentials`, `AioCachedCredentialFetcher`,
+`AioAssumeRoleCredentialFetcher`, `AioSSOCredentialFetcher`,
+`AioInstanceMetadataProvider`, `AioContainerProvider`,
+`AioLoginCredentialFetcher`.
+
+The credential resolver chain is built in
+`aiobotocore/credentials.py:create_credential_resolver()` which
+mirrors botocore's but uses Aio providers.
+
+## Pattern 5: resolve_awaitable
+
+```python
+# aiobotocore/_helpers.py
+async def resolve_awaitable(obj):
+    if inspect.isawaitable(obj):
+        return await obj
+    return obj
+```
+
+Used when code handles mixed sync/async callbacks — primarily in
+the event hook system (`AioHierarchicalEmitter._emit()` in
+hooks.py:68). botocore's built-in handlers are sync, but
+aiobotocore overrides may be async. `resolve_awaitable` lets the
+emitter handle both transparently.
+
+## Pattern 6: Event hook system
+
+`AioHierarchicalEmitter` (hooks.py:48) subclasses botocore's
+emitter. Its `_emit()` method awaits each handler response via
+`resolve_awaitable()`. This means:
+
+- Stock botocore handlers (sync) work unchanged
+- aiobotocore can register async handlers
+- No need to wrap every botocore handler
+
+## Pattern 7: AioConfig
+
+`AioConfig(botocore.client.Config)` (config.py:42) adds:
+- `connector_args`: aiohttp connector tuning (ssl, keepalive, etc.)
+- `http_session_cls`: pluggable HTTP backend class
+
+Custom merge logic preserves these fields when configs are combined.
+
+## Pattern 8: Async context managers
+
+Clients must be used as async context managers:
+
+```python
+async with session.create_client('s3') as client:
+    await client.get_object(...)
+```
+
+`AioSession.create_client()` returns a `ClientCreatorContext`
+(session.py:129) which is an async context manager. On exit,
+it closes the HTTP session. This is enforced —
+`AioBaseClient.__aexit__()` closes the HTTP session and
+`AioBaseClient.__del__()` warns if the client wasn't properly
+closed.
+
+## Test porting pattern
+
+Tests in `tests/botocore_tests/` are adapted from botocore's
+test suite:
+
+1. Copy the relevant test from botocore's `tests/unit/` or
+   `tests/functional/`
+2. Replace `botocore.session.Session` with `AioSession`
+3. Replace `botocore.stub.Stubber` usage with
+   `tests/botocore_tests/helpers.py:StubbedSession`
+4. Convert test functions to `async def test_*()`
+   (no `@pytest.mark.asyncio` needed — `asyncio_mode = "auto"`)
+5. Add `await` to client calls and context managers
+6. Replace `unittest.mock.patch` with async-compatible mocking
+   where needed
+7. Use `AioAWSResponse` instead of `AWSResponse` for mocked
+   responses
+8. Add docstring: "Taken from [botocore URL] and adapted for
+   asyncio and pytest"
+
+See `tests/botocore_tests/unit/test_credentials.py` for a
+comprehensive example.


### PR DESCRIPTION
## Summary

Adds two GitHub Actions workflows, a CLAUDE.md, and override pattern documentation.

### 1. Claude Code (`.github/workflows/claude.yml`)

AI-powered PR review and issue assistant using [claude-code-action](https://github.com/anthropics/claude-code-action).

**Capabilities:**
- **Auto-review** (all PRs, any author): reviews on open and push
- **`@claude` in PR comments** (org members, owners, collaborators only): ask questions, request explanations
- **`@claude` in issues** (org members, owners, collaborators only): can create branches and PRs (prefix: `claude/`)
- **Bot PR auto-fix** (automatic): on PRs created by bots, attempts to fix straightforward review findings by pushing a commit
- **Human PR review** (automatic): review only, never pushes commits

**What Claude cannot do:**
- Merge or close PRs (`--disallowedTools`)
- Close issues (`--disallowedTools`)
- Change repo settings, secrets, or permissions

**Security:**
- Author association check on all `@claude` triggers
- Dedicated `claude` environment for secret access
- `persist-credentials: false` on checkout (verified: claude-code-action manages its own git auth independently)
- Action pinned by full commit SHA

### 2. Botocore Sync (`.github/workflows/botocore-sync.yml` + `.github/botocore-sync-prompt.md`)

Automated botocore version tracking — like dependabot but purpose-built for aiobotocore's tight coupling with botocore.

**Two-PR model for complex changes:**
- **WIP PR** (`botocore-sync-wip`, draft): accumulates work across multiple runs. PR description tracks all state for handoff — completed tasks, remaining work, decisions made, context for next run.
- **Final PR** (`botocore-sync`, ready): clean squashed result for human review. Simple changes (relax) skip the WIP and go directly here.

**Workflow steps:**
1. Check feedback issue for human guidance
2. Check PR state (no PR / clean / dirty / WIP in progress)
3. Analyze botocore source diff (categorize: schema, patched code, new logic)
4. Run `test_patches.py` as signal, combine with diff analysis
5. Determine update type (relax / bump / major)
6. Make changes or save progress to WIP PR
7. Finalize: squash WIP → final PR, or commit directly
8. Learn: codify new patterns into docs

**Dirty PR handling:**
- Dirty + relax: apply version bump in-place (preserves human work)
- Dirty + bump: abort, post/replace sticky comment with diff link

**Feedback loop:**
- Ambiguities create a `botocore-sync-feedback` labeled issue
- Issues include numbered questions with context, options, trade-offs
- Humans answer directly or use `@claude` for more context
- Bot applies answers on next run, codifies patterns into docs

**Workflow dispatch inputs:**
- `botocore_version`: target version (validated against lower bound, upper bound, and PyPI latest)
- `enable_bump`: enable code-change path (default: false — relax only to start)
- `dry_run`: analyze only, output to workflow run log (no branches/PRs/changes)

**Safeguards:**
- Concurrency group (queues, does not cancel)
- Detection job: `contents: read` only
- 60-minute timeout for sync job
- PyPI data via env vars (no string interpolation)
- Dedicated `claude` environment for secrets
- Informative run names and job summaries in workflow UI
- Prompt extracted to `.github/botocore-sync-prompt.md` (maintainable)
- Action pinned by full commit SHA

**Bot PR auto-fix:** Claude's review workflow detects bot-authored PRs and attempts to fix straightforward review findings. Human PRs get review comments only.

### 3. CLAUDE.md

Concise reference for Claude and contributors: pre-commit checks, test commands, override file mapping, and call chain.

### 4. docs/override-patterns.md

Detailed reference for how aiobotocore overrides botocore: subclassing, component registration, HTTP replacement, credential async, resolve_awaitable, event hooks, AioConfig, context managers, test porting. Referenced by both CLAUDE.md and the botocore-sync prompt.

### Setup completed

- `ANTHROPIC_API_KEY` in `claude` environment
- Claude Code GitHub App installed
- Gemini Code Assist uninstalled
- Non-functional `copilot_code_review` ruleset rule removed

### Future enhancements (deferred)

- Cost/token tracking via `execution_file` parsing → job summary
- Enable bump automation after relax path is proven reliable

## Test plan

- [x] Claude Code check passes
- [x] CI/CD passes (all Python versions)
- [x] zizmor security findings resolved
- [x] All review comments addressed
- [x] persist-credentials: false verified compatible with claude-code-action
- [ ] Test `@claude` on a PR after merge to `main`
- [ ] Test `@claude` on an issue after merge to `main`
- [ ] Manually trigger Botocore Sync workflow (dry run first)
- [ ] Verify external contributor `@claude` does NOT trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)