### PR TITLE
Use --dangerously-skip-permissions for CI workflows

### DIFF
--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -202,11 +202,5 @@ jobs:
         show_full_output: true
         prompt: ${{ steps.prompt.outputs.PROMPT }}
         claude_args: |
+          --dangerously-skip-permissions
           --max-turns 50
-        settings: |
-          {
-            "permissions": {
-              "allow": ["*"],
-              "deny": []
-            }
-          }

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -89,10 +89,5 @@ jobs:
         prompt: ${{ steps.prompt.outputs.PROMPT }}
         # yamllint disable-line rule:line-length
         plugins: "code-review@anthropics/claude-code-plugins"
-        settings: |
-          {
-            "permissions": {
-              "allow": ["*"],
-              "deny": []
-            }
-          }
+        claude_args: |
+          --dangerously-skip-permissions


### PR DESCRIPTION
## Summary

The `settings` JSON with `"allow": ["*"]` still blocks compound
Bash commands (pipes, redirects, `&&`) — this is a
[known Claude Code bug](https://github.com/anthropics/claude-code/issues/26796).
`--dangerously-skip-permissions` is the only reliable way to run
unattended in CI.

**Safe here because:**
- Ephemeral runner (destroyed after job)
- `GITHUB_TOKEN` repo-scoped and short-lived
- Branch protection: merge queue + 1 approval + last-push approval
- `--max-turns 50` bounds total actions
- 60-minute timeout bounds wall time
- $30/month API spend limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)