### PR TITLE
Sync prompt fixes and code-review plugin name

### DIFF
--- a/.github/botocore-sync-prompt.md
+++ b/.github/botocore-sync-prompt.md
@@ -7,8 +7,8 @@ update aiobotocore to support botocore $LATEST_BOTOCORE
 The detect job already determined these — use them directly,
 do NOT query PyPI or re-parse pyproject.toml for version info:
 - Target botocore version: $LATEST_BOTOCORE
-- Current exclusive upper bound: $CURRENT_UPPER
-  (last supported version is one patch below this)
+- Current supported range: $CURRENT_LOWER — $LAST_SUPPORTED
+- Exclusive upper bound: $CURRENT_UPPER
 
 ## Configuration
 
@@ -169,13 +169,9 @@ update type, then:
 
 ## Step 2: Analyze the botocore diff
 
-Compute the last supported version from the pre-computed
-upper bound: subtract one from the patch version of
-$CURRENT_UPPER (e.g. 1.42.71 → 1.42.70).
-
 Download both versions and diff botocore source:
 ```
-pip download botocore==LAST_SUPPORTED \
+pip download botocore==$LAST_SUPPORTED \
   --no-deps -d /tmp/old
 pip download botocore==$LATEST_BOTOCORE \
   --no-deps -d /tmp/new

--- a/.github/botocore-sync-prompt.md
+++ b/.github/botocore-sync-prompt.md
@@ -2,12 +2,20 @@ You are a botocore sync bot for aiobotocore. Your goal:
 update aiobotocore to support botocore $LATEST_BOTOCORE
 (current upper bound: $CURRENT_UPPER).
 
+## Pre-computed values
+
+The detect job already determined these — use them directly,
+do NOT query PyPI or re-parse pyproject.toml for version info:
+- Target botocore version: $LATEST_BOTOCORE
+- Current exclusive upper bound: $CURRENT_UPPER
+  (last supported version is one patch below this)
+
 ## Configuration
 
 - ENABLE_BUMP: $ENABLE_BUMP (if false, bumps create a
   feedback issue instead of attempting code changes)
-- DRY_RUN: $DRY_RUN (if true, analyze only — post results
-  as a comment but do not create branches or make changes)
+- DRY_RUN: $DRY_RUN (if true, analyze only — output results
+  to the workflow run log, no branches/PRs/changes)
 
 ## Security
 
@@ -161,13 +169,14 @@ update type, then:
 
 ## Step 2: Analyze the botocore diff
 
-Determine the last supported botocore version:
-upper bound in pyproject.toml minus one patch
-(e.g. `< 1.42.31` → last supported is `1.42.30`).
+Compute the last supported version from the pre-computed
+upper bound: subtract one from the patch version of
+$CURRENT_UPPER (e.g. 1.42.71 → 1.42.70).
 
 Download both versions and diff botocore source:
 ```
-pip download botocore==OLD --no-deps -d /tmp/old
+pip download botocore==LAST_SUPPORTED \
+  --no-deps -d /tmp/old
 pip download botocore==$LATEST_BOTOCORE \
   --no-deps -d /tmp/new
 ```

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -49,6 +49,10 @@ jobs:
         ${{ steps.check.outputs.latest_botocore }}
       current_upper: >-
         ${{ steps.check.outputs.current_upper }}
+      current_lower: >-
+        ${{ steps.check.outputs.current_lower }}
+      last_supported: >-
+        ${{ steps.check.outputs.last_supported }}
       needs_update: >-
         ${{ steps.check.outputs.needs_update }}
     steps:
@@ -140,7 +144,11 @@ jobs:
             print(f"Update needed: {latest} not in {spec}")
             needs = "true"
 
+        # Last supported = highest version in the spec
+        uv = Version(upper)
+        last = f"{uv.major}.{uv.minor}.{uv.micro - 1}"
         with open(out, "a") as f:
+            f.write(f"last_supported={last}\n")
             f.write(f"needs_update={needs}\n")
 
         # Job summary
@@ -192,6 +200,10 @@ jobs:
           ${{ needs.detect.outputs.latest_botocore }}
         CURRENT_UPPER: >-
           ${{ needs.detect.outputs.current_upper }}
+        CURRENT_LOWER: >-
+          ${{ needs.detect.outputs.current_lower }}
+        LAST_SUPPORTED: >-
+          ${{ needs.detect.outputs.last_supported }}
         ENABLE_BUMP: >-
           ${{ inputs.enable_bump || 'false' }}
         DRY_RUN: >-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -88,6 +88,6 @@ jobs:
         show_full_output: true
         prompt: ${{ steps.prompt.outputs.PROMPT }}
         # yamllint disable-line rule:line-length
-        plugins: "code-review@anthropics/claude-code-plugins"
+        plugins: "code-review@claude-code-plugins"
         claude_args: |
           --dangerously-skip-permissions


### PR DESCRIPTION
## Summary

Two fixes:

1. **Use pre-computed values in sync prompt**: The detect job
   already determines target version and bounds. Prompt now
   tells Claude to use `$LATEST_BOTOCORE` and `$CURRENT_UPPER`
   directly instead of re-querying PyPI or re-parsing
   pyproject.toml — saves turns and avoids compound command
   errors.

2. **Fix code-review plugin name**: Was using
   `code-review@anthropics/claude-code-plugins` (wrong),
   corrected to `code-review@claude-code-plugins` per the
   action.yml example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)