### PR TITLE
Fix code-review plugin marketplace name

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -88,6 +88,6 @@ jobs:
         show_full_output: true
         prompt: ${{ steps.prompt.outputs.PROMPT }}
         # yamllint disable-line rule:line-length
-        plugins: "code-review@claude-code-plugins"
+        plugins: "code-review@claude-plugins-official"
         claude_args: |
           --dangerously-skip-permissions


### PR DESCRIPTION
Marketplace is `claude-plugins-official`, not `claude-code-plugins`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)