### PR TITLE
Register plugin marketplace, auto-review on open only

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -87,7 +87,9 @@ jobs:
         display_report: true
         show_full_output: true
         prompt: ${{ steps.prompt.outputs.PROMPT }}
-        # yamllint disable-line rule:line-length
+        # yamllint disable rule:line-length
+        plugin_marketplaces: "https://github.com/anthropics/claude-plugins-official.git"
         plugins: "code-review@claude-plugins-official"
+        # yamllint enable rule:line-length
         claude_args: |
           --dangerously-skip-permissions


### PR DESCRIPTION
## Summary

Two fixes:

1. **Register plugin marketplace**: The `plugins` input needs
   the marketplace registered first via `plugin_marketplaces`.
   Added the official Anthropic marketplace Git URL.

2. **Auto-review on PR open only**: Remove `synchronize` trigger.
   Review takes ~13 min per run — triggering on every push is
   too frequent. Use `@claude` for manual re-review after changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)