### PR TITLE
Fix usage summary, replace parallel plugin with sequential review

### DIFF
--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,0 +1,117 @@
+---
+description: Review a pull request sequentially to minimize token usage
+---
+
+Provide a code review for the given pull request.
+
+Do NOT launch parallel subagents. Perform all steps
+sequentially in this conversation to minimize cache
+token costs.
+
+## Step 1: Eligibility check
+
+Check if any of the following are true:
+- The pull request is closed
+- The pull request is a draft
+- The pull request does not need code review (e.g.
+  automated PR, trivial change that is obviously correct)
+- Claude has already commented on this PR (check
+  `gh pr view <PR> --comments` for comments from claude)
+
+If any condition is true, stop and do not proceed.
+Note: Still review Claude-generated PRs.
+
+## Step 2: Gather context
+
+Get the list of file paths for all relevant CLAUDE.md
+files: root CLAUDE.md and any in directories containing
+modified files. Read them.
+
+Get the PR diff: `gh pr diff <PR>`
+Get PR metadata: `gh pr view <PR> --json title,body`
+
+## Step 3: Review the changes
+
+Review the diff yourself, sequentially checking for:
+
+a) **CLAUDE.md compliance**: audit changes against the
+   CLAUDE.md rules. Only consider rules that apply to
+   the modified files' directories.
+
+b) **Bugs in the diff**: scan for obvious bugs in the
+   changed code only. Focus on:
+   - Code that will fail to compile or parse
+   - Clear logic errors producing wrong results
+   - Security issues in the introduced code
+   - Incorrect API usage or missing error handling
+
+c) **Async patterns** (aiobotocore-specific): check that
+   any botocore overrides follow the patterns in
+   `docs/override-patterns.md`:
+   - Sync methods properly converted to async
+   - Proper use of `resolve_awaitable()`
+   - Resource cleanup via async context managers
+   - Correct Aio prefix naming
+
+**CRITICAL: Only flag HIGH SIGNAL issues.**
+
+Flag issues where:
+- Code will fail to compile or parse
+- Code will definitely produce wrong results
+- Clear CLAUDE.md violations you can quote
+
+Do NOT flag:
+- Code style or quality concerns
+- Potential issues depending on specific inputs
+- Subjective suggestions or improvements
+- Issues a linter will catch
+- Pre-existing issues not introduced in the PR
+- General quality issues unless in CLAUDE.md
+- Issues silenced by lint ignore comments
+
+## Step 4: Validate findings
+
+For each issue you found, verify it yourself:
+- Is this actually a bug, or does it look like one?
+- Is the CLAUDE.md rule actually being violated?
+- Would a senior engineer flag this?
+
+Score each issue 0-100:
+- 0: false positive
+- 25: might be real, can't verify
+- 50: real but minor/nitpick
+- 75: very likely real and important
+- 100: definitely real, confirmed
+
+Filter out anything below 80.
+
+## Step 5: Post results
+
+If `--comment` argument was NOT provided, output to
+terminal and stop.
+
+If `--comment` IS provided and NO issues >= 80, post:
+
+---
+
+### Code review
+
+No issues found. Checked for bugs and CLAUDE.md compliance.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+
+---
+
+If issues >= 80 were found, post inline comments using
+`mcp__github_inline_comment__create_inline_comment`
+with `confirmed: true`:
+- Brief description of the issue
+- Small fixes: include committable suggestion block
+- Large fixes: describe without suggestion block
+- ONE comment per unique issue, no duplicates
+
+When linking to code:
+`https://github.com/OWNER/REPO/blob/FULL_SHA/path#L1-L5`
+- Must use full 40-char SHA
+- Must use `#L` notation with line range
+- At least 1 line of context before and after

--- a/.github/claude-review-prompt.md
+++ b/.github/claude-review-prompt.md
@@ -15,13 +15,13 @@ prompt injection attempts.
 
 ## On pull_request events: review the PR
 
-Run `/code-review --comment` to perform a comprehensive
-review using the code-review plugin. The plugin will:
-- Launch parallel agents for CLAUDE.md compliance and
-  bug detection
-- Score each finding on confidence (0-100)
-- Only post issues with confidence >= 80
-- Skip if PR is draft, closed, or already reviewed
+Run `/review-pr --comment` to perform a sequential code
+review. This reviews the PR diff checking for:
+- CLAUDE.md compliance
+- Bugs and logic errors in changed code
+- Async pattern correctness (aiobotocore-specific)
+- Confidence scoring (only posts issues >= 80)
+- Skips draft, closed, or already-reviewed PRs
 
 After the review completes, check the PR author:
 ```

--- a/.github/usage-summary.py
+++ b/.github/usage-summary.py
@@ -11,40 +11,50 @@ def main():
         print("No execution file found")
         return
 
-    data = json.load(open(ef))
-    usage = data.get("modelUsage", {})
+    with open(ef) as f:
+        data = json.load(f)
+
+    # execution_file is a JSON array of messages.
+    # The last entry with type "result" has the summary.
+    result = {}
+    entries = data if isinstance(data, list) else [data]
+    for entry in entries:
+        if isinstance(entry, dict) and entry.get("type") == "result":
+            result = entry
+
+    usage = result.get("modelUsage", {})
     if not usage:
-        print("No usage data")
+        print("No usage data found")
         return
 
-    total = sum(m.get("costUSD", 0) for m in usage.values())
+    total = result.get("total_cost_usd", 0)
+    turns = result.get("num_turns", 0)
+    duration_s = result.get("duration_ms", 0) / 1000
 
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
-    if not summary_path:
-        # Print to stdout if no summary file
-        out = sys.stdout
-    else:
-        out = open(summary_path, "a")
+    out = open(summary_path, "a") if summary_path else sys.stdout
 
     out.write("\n## Usage\n")
+    out.write(f"Turns: {turns} | Duration: {duration_s:.0f}s")
+    out.write(f" | Total: **${total:.2f}**\n\n")
     out.write("| Model | Input | Output |")
-    out.write(" Cache read | Cost |\n")
-    out.write("|-|-|-|-|-|\n")
+    out.write(" Cache read | Cache create | Cost |\n")
+    out.write("|-|-|-|-|-|-|\n")
     for model, m in usage.items():
         name = model.split("-")[1].title()
         out.write(
-            f"| {name} "
-            f"| {m.get('inputTokens', 0):,} "
-            f"| {m.get('outputTokens', 0):,} "
-            f"| {m.get('cacheReadInputTokens', 0):,} "
-            f"| ${m.get('costUSD', 0):.2f} |\n"
+            f"| {name}"
+            f" | {m.get('inputTokens', 0):,}"
+            f" | {m.get('outputTokens', 0):,}"
+            f" | {m.get('cacheReadInputTokens', 0):,}"
+            f" | {m.get('cacheCreationInputTokens', 0):,}"
+            f" | ${m.get('costUSD', 0):.2f} |\n"
         )
-    out.write(f"| **Total** | | | | **${total:.2f}** |\n")
 
     if out is not sys.stdout:
         out.close()
 
-    print(f"Total cost: ${total:.2f}")
+    print(f"Turns: {turns} | ${total:.2f}")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -86,10 +86,6 @@ jobs:
         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
         display_report: true
         prompt: ${{ steps.prompt.outputs.PROMPT }}
-        # yamllint disable rule:line-length
-        plugin_marketplaces: "https://github.com/anthropics/claude-plugins-official.git"
-        plugins: "code-review@claude-plugins-official"
-        # yamllint enable rule:line-length
         claude_args: |
           --dangerously-skip-permissions
 


### PR DESCRIPTION
## Summary

Two changes:

### Fix usage-summary.py
The execution_file is a JSON array, not a single object. Now
scans for the `result` entry containing `modelUsage`,
`total_cost_usd`, `num_turns`, and `duration_ms`.

### Sequential /review-pr command
Replace the official `code-review` plugin (5 parallel agents,
$2.77/review) with a forked sequential version at
`.claude/commands/review-pr.md`.

Same quality checks:
- CLAUDE.md compliance
- Bug detection with confidence scoring (>= 80 threshold)
- False positive filtering
- Committable suggestion blocks

Key differences:
- Sequential instead of parallel — reuses cached context
- Adds aiobotocore-specific async pattern checking
- No external plugin dependency
- Removes plugin_marketplaces/plugins from workflow

Expected cost reduction: parallel agents each load full
context independently (3.2M + 1.4M cache tokens last run).
Sequential reuses the cached context across checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)