### PR TITLE
Add continue-on-error to usage summary step

### DIFF
--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -219,6 +219,7 @@ jobs:
 
     - name: Usage summary
       if: always()
+      continue-on-error: true
       env:
         EXEC_FILE: >-
           ${{ steps.claude.outputs.execution_file }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -91,6 +91,7 @@ jobs:
 
     - name: Usage summary
       if: always()
+      continue-on-error: true
       env:
         EXEC_FILE: >-
           ${{ steps.claude.outputs.execution_file }}


### PR DESCRIPTION
Usage summary is informational — a parsing error shouldn't
fail the whole workflow run. Adds `continue-on-error: true`
to both workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)