### PR TITLE
Clean up `test_version.py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,11 +72,9 @@ dev = [
     "docutils >= 0.19, < 0.23", # Used in test_version.py
     "moto[server,s3,sqs,awslambda,dynamodb,cloudformation,sns,batch,ec2,rds] >= 5.1.8, < 6",
     "packaging >= 24.1, < 27", # Used in test_version.py
-    "pip >= 24.3.1, < 27", # Used in test_version.py
     "pre-commit >= 3.5.0, < 5",
     "pytest-rerunfailures >= 16.0.1, < 17", # Used in test_lambda.py
     "time-machine >= 2.15.0, < 4", # Used in test_signers.py
-    "tomli; python_version<'3.11'", # Used in test_version.py
 ]
 awscrt = [
     "botocore[crt]",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,26 +1,14 @@
-import operator
 import re
-import sys
 from datetime import datetime
-from itertools import chain
 from pathlib import Path
-from typing import NamedTuple, Optional
 
 import docutils.frontend
 import docutils.nodes
 import docutils.parsers.rst
 import docutils.utils
 from packaging import version
-from pip._internal.req import InstallRequirement
-from pip._internal.req.constructors import install_req_from_line
-from pip._vendor.packaging.specifiers import SpecifierSet
 
 import aiobotocore
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    import tomli as tomllib
 
 _root_path = Path(__file__).absolute().parent.parent
 
@@ -40,70 +28,6 @@ def _parse_rst(text: str) -> docutils.nodes.document:
     document = docutils.utils.new_document('<rst-doc>', settings=settings)
     parser.parse(text, document)
     return document
-
-
-class VersionInfo(NamedTuple):
-    least_version: str
-    specifier_set: SpecifierSet
-
-
-def _get_requirements_from_pyproject_toml(pyproject_content: str):
-    content = tomllib.loads(pyproject_content)
-
-    return chain(
-        content["project"].get("dependencies", []),
-        *content["project"].get("optional-dependencies", {}).values(),
-    )
-
-
-def _get_boto_module_versions(
-    requirements, ensure_plus_one_patch_range: bool = False
-):
-    module_versions = dict()
-
-    for ver in requirements:
-        if isinstance(ver, str):
-            ver: InstallRequirement = install_req_from_line(ver)
-        elif isinstance(ver, list):
-            assert len(ver) == 1
-            ver: InstallRequirement = install_req_from_line(ver[0])
-        else:
-            assert False, f'Unsupported ver: {ver}'
-
-        module = ver.req.name
-        if module != 'botocore':
-            continue
-
-        # NOTE: don't support complex versioning yet as requirements are unknown
-        gte: Optional[version.Version] = None
-        lt: Optional[version.Version] = None
-        eq: Optional[version.Version] = None
-        for spec in ver.req.specifier:
-            if spec.operator == '>=':
-                assert gte is None
-                gte = version.parse(spec.version)
-            elif spec.operator == '<':
-                assert lt is None
-                lt = version.parse(spec.version)
-            elif spec.operator == '==':
-                assert eq is None
-                eq = version.parse(spec.version)
-            else:
-                assert False, f'unsupported operator: {spec.operator}'
-
-        if ensure_plus_one_patch_range:
-            assert len(gte.release) == len(lt.release) == 3, (
-                f'{module} gte: {gte} diff len than {lt}'
-            )
-            assert lt.release == tuple(
-                map(operator.add, gte.release, (0, 0, 1))
-            ), f'{module} gte: {gte} not one patch off from {lt}'
-
-        module_versions[module] = VersionInfo(
-            gte.public if gte else None, ver.req.specifier
-        )
-
-    return module_versions
 
 
 def test_release_versions():
@@ -148,12 +72,4 @@ def test_release_versions():
 
         assert rst_date >= rst_prev_date, (
             'Current release must be after last release'
-        )
-
-    # get aioboto reqs
-    with (_root_path / 'pyproject.toml').open() as f:
-        content = f.read()
-        _get_boto_module_versions(
-            _get_requirements_from_pyproject_toml(content),
-            False,
         )

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -38,9 +38,7 @@ def test_release_versions():
     assert str(init_version) == aiobotocore.__version__
 
     changes_path = _root_path / 'CHANGES.rst'
-
-    with changes_path.open('r') as f:
-        changes_doc = _parse_rst(f.read())
+    changes_doc = _parse_rst(changes_path.read_text())
 
     rst_ver_str = changes_doc[0][1][0][0]  # ex: 0.11.1 (2020-01-03)
     rst_prev_ver_str = changes_doc[0][2][0][0]

--- a/uv.lock
+++ b/uv.lock
@@ -43,14 +43,12 @@ dev = [
     { name = "docutils" },
     { name = "moto", extra = ["awslambda", "batch", "cloudformation", "dynamodb", "s3", "server"] },
     { name = "packaging" },
-    { name = "pip" },
     { name = "pre-commit", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pre-commit", version = "4.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-rerunfailures", version = "16.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest-rerunfailures", version = "16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "time-machine", version = "2.19.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "time-machine", version = "3.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
 [package.metadata]
@@ -82,11 +80,9 @@ dev = [
     { name = "docutils", specifier = ">=0.19,<0.23" },
     { name = "moto", extras = ["server", "s3", "sqs", "awslambda", "dynamodb", "cloudformation", "sns", "batch", "ec2", "rds"], specifier = ">=5.1.8,<6" },
     { name = "packaging", specifier = ">=24.1,<27" },
-    { name = "pip", specifier = ">=24.3.1,<27" },
     { name = "pre-commit", specifier = ">=3.5.0,<5" },
     { name = "pytest-rerunfailures", specifier = ">=16.0.1,<17" },
     { name = "time-machine", specifier = ">=2.15.0,<4" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
 [[package]]
@@ -1877,15 +1873,6 @@ resolution-markers = [
 sdist = { url = "https://files.pythonhosted.org/packages/72/55/b748445cb4ea6b125626f15379be7c96d1035d4fa3e8fee362fa92298abf/pathable-0.5.0.tar.gz", hash = "sha256:d81938348a1cacb525e7c75166270644782c0fb9c8cecc16be033e71427e0ef1", size = 16655, upload-time = "2026-02-20T08:47:00.748Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/96/5a770e5c461462575474468e5af931cff9de036e7c2b4fea23c1c58d2cbe/pathable-0.5.0-py3-none-any.whl", hash = "sha256:646e3d09491a6351a0c82632a09c02cdf70a252e73196b36d8a15ba0a114f0a6", size = 16867, upload-time = "2026-02-20T08:46:59.536Z" },
-]
-
-[[package]]
-name = "pip"
-version = "26.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description of Change
Clean up `test_version.py` in an effort to achieve #1490

### Assumptions
Marginal benefit of dependency validation in `test_version.py` is negligible, after removing the `awscli` and `boto3` packaging extras in #1435 and #1440. Syntactic errors should be detected by existing tooling (`uv`, `setuptools`).

### Checklist for All Submissions
* [ ] I have added change info to [CHANGES.rst](https://github.com/aio-libs/aiobotocore/blob/main/CHANGES.rst)
* [ ] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature  (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/main/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have added URL to diff: https://github.com/boto/botocore/compare/[CURRENT_BOTO_VERSION_TAG]...[NEW_BOTO_VERSION_TAG]
