### PR TITLE
Enable commit signing for Claude workflows

### DIFF
--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -211,6 +211,7 @@ jobs:
           ${{ inputs.dry_run || 'false' }}
       with:
         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+        use_commit_signing: true
         display_report: true
         prompt: ${{ steps.prompt.outputs.PROMPT }}
         claude_args: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -84,6 +84,7 @@ jobs:
       id: claude
       with:
         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+        use_commit_signing: true
         display_report: true
         prompt: ${{ steps.prompt.outputs.PROMPT }}
         claude_args: |


### PR DESCRIPTION
Merge queue requires verified signatures. Adds
`use_commit_signing: true` which uses GitHub's API to create
commits — automatically signed and verified by the GitHub App.

No additional secrets or SSH keys needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)