### PR TITLE
Allow claude[bot] to trigger review workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -86,6 +86,7 @@ jobs:
         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
         use_commit_signing: true
         display_report: true
+        allowed_bots: "claude[bot]"
         prompt: ${{ steps.prompt.outputs.PROMPT }}
         claude_args: |
           --dangerously-skip-permissions


### PR DESCRIPTION
Claude-created PRs were rejected with:
> non-human actor: claude (type: Bot). Add bot to allowed_bots list

Adds `allowed_bots: "claude[bot]"` so the review workflow can
process PRs created by Claude (needed for auto-fix on bot PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)