### PR TITLE
Force GitHub API commits for verified signatures

### DIFF
--- a/.github/botocore-sync-prompt.md
+++ b/.github/botocore-sync-prompt.md
@@ -35,6 +35,15 @@ gh api repos/REPO/issues/NUM/comments --jq \
   )]'
 ```
 
+## Commit signing requirement
+
+IMPORTANT: Never use `git commit` or `git push` to
+create commits. Always use the `mcp__github_file_ops__commit_files`
+MCP tool to commit changes. This creates commits via
+the GitHub API which are automatically signed and
+verified. Using git CLI creates unsigned commits that
+will be rejected by branch protection.
+
 ## Background
 
 aiobotocore adds async functionality to botocore by

--- a/.github/claude-review-prompt.md
+++ b/.github/claude-review-prompt.md
@@ -37,6 +37,15 @@ complex refactors.
 If the PR was created by a human, the review comments
 are sufficient — never push commits to human PRs.
 
+## Commit signing requirement
+
+IMPORTANT: Never use `git commit` or `git push` to
+create commits. Always use the `mcp__github_file_ops__commit_files`
+MCP tool to commit changes. This creates commits via
+the GitHub API which are automatically signed and
+verified. Using git CLI creates unsigned commits that
+will be rejected by branch protection.
+
 ## On @claude interactions: respond to the request
 
 For issue_comment, pull_request_review_comment, or

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -218,6 +218,17 @@ jobs:
         claude_args: |
           --dangerously-skip-permissions
           --max-turns 50
+        # yamllint disable rule:line-length
+        settings: |
+          {
+            "hooks": {
+              "PreToolUse": [{
+                "matcher": "Bash",
+                "command": "if echo \"$TOOL_INPUT\" | grep -qE '\\bgit commit\\b'; then echo 'BLOCKED: Use mcp__github_file_ops__commit_files instead of git commit. This ensures commits are signed.' >&2; exit 2; fi"
+              }]
+            }
+          }
+        # yamllint enable rule:line-length
 
     - name: Usage summary
       if: always()

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -213,6 +213,7 @@ jobs:
         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
         use_commit_signing: true
         display_report: true
+        show_full_output: true
         prompt: ${{ steps.prompt.outputs.PROMPT }}
         claude_args: |
           --dangerously-skip-permissions

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -86,6 +86,7 @@ jobs:
         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
         use_commit_signing: true
         display_report: true
+        show_full_output: true
         allowed_bots: "claude[bot]"
         prompt: ${{ steps.prompt.outputs.PROMPT }}
         claude_args: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -91,6 +91,17 @@ jobs:
         prompt: ${{ steps.prompt.outputs.PROMPT }}
         claude_args: |
           --dangerously-skip-permissions
+        # yamllint disable rule:line-length
+        settings: |
+          {
+            "hooks": {
+              "PreToolUse": [{
+                "matcher": "Bash",
+                "command": "if echo \"$TOOL_INPUT\" | grep -qE '\\bgit commit\\b'; then echo 'BLOCKED: Use mcp__github_file_ops__commit_files instead of git commit. This ensures commits are signed.' >&2; exit 2; fi"
+              }]
+            }
+          }
+        # yamllint enable rule:line-length
 
     - name: Usage summary
       if: always()


### PR DESCRIPTION
## Summary

Claude was using `git commit` + `git push` (CLI) which creates
unsigned commits, rejected by branch protection.

Fix: prompts now instruct Claude to use the
`mcp__github_file_ops__commit_files` MCP tool instead. This
tool creates commits via the GitHub API using the Claude App
installation token, which are automatically signed and verified
by GitHub. No SSH keys or GPG keys needed.

Applied to both `claude-review-prompt.md` and
`botocore-sync-prompt.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)