### PR TITLE
Cache botocore repo, git hints, yamllint 120, pre-commit checks

### DIFF
--- a/.github/botocore-sync-prompt.md
+++ b/.github/botocore-sync-prompt.md
@@ -178,14 +178,17 @@ update type, then:
 
 ## Step 2: Analyze the botocore diff
 
-Download both versions and diff botocore source:
+A bare clone of botocore is cached at `/tmp/botocore`.
+Diff between the two versions using git:
 ```
-pip download botocore==$LAST_SUPPORTED \
-  --no-deps -d /tmp/old
-pip download botocore==$LATEST_BOTOCORE \
-  --no-deps -d /tmp/new
+git -C /tmp/botocore diff $LAST_SUPPORTED..$LATEST_BOTOCORE \
+  -- botocore/
 ```
-Extract and diff the `botocore/` directories.
+
+To view a specific file at a version:
+```
+git -C /tmp/botocore show $VERSION:botocore/path/file.py
+```
 
 Categorize changes:
 a) JSON schema/model updates only (no action)

--- a/.github/botocore-sync-prompt.md
+++ b/.github/botocore-sync-prompt.md
@@ -35,6 +35,16 @@ gh api repos/REPO/issues/NUM/comments --jq \
   )]'
 ```
 
+## Pre-commit checks
+
+Before committing ANY changes, run:
+```
+uv run pre-commit run --all --show-diff-on-failure
+```
+Fix any failures before committing. This catches
+yamllint, ruff format, trailing whitespace, and
+other issues that would fail CI.
+
 ## Git operations
 
 ### Commit signing

--- a/.github/botocore-sync-prompt.md
+++ b/.github/botocore-sync-prompt.md
@@ -237,15 +237,24 @@ uv pip install "botocore==$LATEST_BOTOCORE"
 uv run pytest tests/test_patches.py -x -v 2>&1
 ```
 
-Combine diff analysis with hash results:
+Combine diff analysis with hash test results.
+The diff analysis is the PRIMARY factor for
+determining relax vs bump. Hash tests are a
+SIGNAL that helps confirm the analysis — they
+catch changes to code we already patch, but do
+NOT catch new logic that needs async overrides.
 
-**Relax** (patch version bump) — ALL true:
-- All test_patches.py hashes pass
-- No new logic in overridden files needs async
+**Relax** (patch version bump) — based on diff:
+- No code changes in files we override
+- No new logic needing async treatment
 - Changes limited to schemas, docs, untouched files
+- Hash tests passing CONFIRMS this (but hashes
+  passing alone is NOT sufficient for relax)
 
 **Bump** (minor version bump) — ANY true:
-- Hash tests fail (patched code changed)
+- Code changes in files we override (hashes may
+  or may not fail depending on whether we patch
+  the specific changed function)
 - New logic in overridden files needs async
 
 **Major bump**: breaking API changes affecting

--- a/.github/botocore-sync-prompt.md
+++ b/.github/botocore-sync-prompt.md
@@ -35,14 +35,42 @@ gh api repos/REPO/issues/NUM/comments --jq \
   )]'
 ```
 
-## Commit signing requirement
+## Git operations
 
-IMPORTANT: Never use `git commit` or `git push` to
-create commits. Always use the `mcp__github_file_ops__commit_files`
-MCP tool to commit changes. This creates commits via
-the GitHub API which are automatically signed and
-verified. Using git CLI creates unsigned commits that
-will be rejected by branch protection.
+### Commit signing
+IMPORTANT: Never use `git commit` to create commits.
+Always use `mcp__github_file_ops__commit_files` with
+an explicit `branch` parameter. This creates commits
+via the GitHub API which are automatically signed.
+Git CLI commits are unsigned and will be rejected.
+
+Example:
+```
+mcp__github_file_ops__commit_files({
+  branch: "claude/botocore-sync",
+  message: "Relax botocore dependency specification",
+  files: [
+    {path: "pyproject.toml", content: "..."},
+    {path: "aiobotocore/__init__.py", content: "..."}
+  ]
+})
+```
+
+### Branch naming
+Always use the `claude/` prefix for branches:
+- WIP branch: `claude/botocore-sync-wip`
+- Final branch: `claude/botocore-sync`
+- Never push to `main` — it is protected.
+- Never push to branches without `claude/` prefix.
+
+### Avoiding pitfalls
+- `mcp__github_file_ops__commit_files` defaults to the
+  repo's default branch if no `branch` is specified.
+  ALWAYS specify the `branch` parameter explicitly.
+- Do NOT try to push to `main` or any protected branch.
+- `git push` is OK for pushing branches (not commits).
+  Use it after creating the branch with `gh api` or
+  `git checkout -b`.
 
 ## Background
 
@@ -61,12 +89,12 @@ async overrides even if no existing hashes break.
 
 This bot uses two PRs for complex changes:
 
-**WIP PR** (branch: `botocore-sync-wip`, draft):
+**WIP PR** (branch: `claude/botocore-sync-wip`, draft):
 Accumulates work across multiple runs. The PR
 description tracks progress and state for handoff
 between runs. Messy incremental commits are fine.
 
-**Final PR** (branch: `botocore-sync`, ready):
+**Final PR** (branch: `claude/botocore-sync`, ready):
 Clean result for human review. Created only when
 work is complete and tests pass. Changes are
 squashed from the WIP branch.
@@ -100,12 +128,12 @@ If an open feedback issue exists:
 Check for BOTH PRs:
 ```
 # WIP PR
-gh pr list --head botocore-sync-wip --state open \
+gh pr list --head claude/botocore-sync-wip --state open \
   --json number,title,body,commits,comments \
   --jq '.[0]'
 
 # Final PR
-gh pr list --head botocore-sync --state all \
+gh pr list --head claude/botocore-sync --state all \
   --json number,state,comments,reviews,commits \
   --jq '.[0]'
 ```
@@ -113,7 +141,7 @@ gh pr list --head botocore-sync --state all \
 **If a WIP PR exists:**
 This is a continuation of previous work. Read the
 WIP PR description to understand progress and
-remaining tasks. Checkout `botocore-sync-wip`,
+remaining tasks. Checkout `claude/botocore-sync-wip`,
 skip to Step 4b and continue from where the
 previous run left off. If $LATEST_BOTOCORE differs
 from what the WIP targets, ignore the newer version
@@ -311,8 +339,8 @@ Step 5b to save progress.
 
 You did not finish in this run. Save your work:
 
-1. Commit all changes to `botocore-sync-wip`.
-2. Push to `botocore-sync-wip` branch.
+1. Commit all changes to `claude/botocore-sync-wip`.
+2. Push to `claude/botocore-sync-wip` branch.
 3. Create or update the WIP draft PR with a
    description that contains ALL information
    needed for the next run to continue:
@@ -363,14 +391,14 @@ version and new target:
 **If a WIP PR exists:** squash the WIP branch
 changes into a single commit on `botocore-sync`:
 ```
-git checkout -B botocore-sync origin/main
-git merge --squash botocore-sync-wip
-git commit
-git push origin botocore-sync --force-with-lease
+git checkout -B claude/botocore-sync origin/main
+git merge --squash claude/botocore-sync-wip
+# Then use mcp__github_file_ops__commit_files with
+# branch: "claude/botocore-sync" to create a signed commit
 ```
 
 **If no WIP PR:** commit directly to
-`botocore-sync` and push.
+`claude/botocore-sync` and push.
 
 Create or update the final PR:
 - Base: `main`

--- a/.github/claude-review-prompt.md
+++ b/.github/claude-review-prompt.md
@@ -37,14 +37,25 @@ complex refactors.
 If the PR was created by a human, the review comments
 are sufficient — never push commits to human PRs.
 
-## Commit signing requirement
+## Git operations
 
-IMPORTANT: Never use `git commit` or `git push` to
-create commits. Always use the `mcp__github_file_ops__commit_files`
-MCP tool to commit changes. This creates commits via
-the GitHub API which are automatically signed and
-verified. Using git CLI creates unsigned commits that
-will be rejected by branch protection.
+### Commit signing
+IMPORTANT: Never use `git commit` to create commits.
+Always use `mcp__github_file_ops__commit_files` with
+an explicit `branch` parameter. This creates commits
+via the GitHub API which are automatically signed.
+Git CLI commits are unsigned and will be rejected.
+
+### Branch naming
+Always use `claude/` prefix for branches you create.
+Never push to `main` — it is protected.
+
+### Avoiding pitfalls
+- `mcp__github_file_ops__commit_files` defaults to the
+  default branch if no `branch` is specified. ALWAYS
+  specify `branch` explicitly.
+- When fixing bot PRs, commit to the PR's existing
+  branch — don't create a new one.
 
 ## On @claude interactions: respond to the request
 

--- a/.github/claude-review-prompt.md
+++ b/.github/claude-review-prompt.md
@@ -34,6 +34,10 @@ straightforward issues (confidence >= 80) by pushing
 a commit. Only fix clear-cut issues. Do not attempt
 complex refactors.
 
+Also check for review comments from other bots
+(github-advanced-security[bot], zizmor, etc.) and
+address their findings if they are actionable.
+
 If the PR was created by a human, the review comments
 are sufficient — never push commits to human PRs.
 

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -185,7 +185,8 @@ jobs:
         persist-credentials: false
 
     - name: Cache botocore repo
-      uses: actions/cache@v4
+      # yamllint disable-line rule:line-length
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
       with:
         path: /tmp/botocore
         key: botocore-repo

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -184,6 +184,22 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
 
+    - name: Cache botocore repo
+      uses: actions/cache@v4
+      with:
+        path: /tmp/botocore
+        key: botocore-repo
+
+    - name: Clone or update botocore
+      run: |
+        if [ -d /tmp/botocore/.git ]; then
+          git -C /tmp/botocore fetch --tags --prune
+        else
+          git clone --bare \
+            https://github.com/boto/botocore.git \
+            /tmp/botocore
+        fi
+
     - name: Read prompt
       id: prompt
       run: |

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -1,7 +1,6 @@
 ---
 name: Botocore Sync
 
-# yamllint disable-line rule:line-length
 run-name: "Botocore Sync${{ inputs.botocore_version && format(': {0}', inputs.botocore_version) || '' }}"
 
 permissions: {}
@@ -56,7 +55,6 @@ jobs:
       needs_update: >-
         ${{ steps.check.outputs.needs_update }}
     steps:
-    # yamllint disable-line rule:line-length
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         persist-credentials: false
@@ -178,14 +176,12 @@ jobs:
       id-token: write
       actions: read
     steps:
-    # yamllint disable-line rule:line-length
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         fetch-depth: 0
         persist-credentials: false
 
     - name: Cache botocore repo
-      # yamllint disable-line rule:line-length
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
       with:
         path: /tmp/botocore
@@ -210,7 +206,6 @@ jobs:
           echo 'PROMPT_EOF'
         } >> "$GITHUB_OUTPUT"
 
-    # yamllint disable-line rule:line-length
     - uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6
       id: claude
       env:

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -189,7 +189,7 @@ jobs:
 
     - name: Clone or update botocore
       run: |
-        if [ -d /tmp/botocore/.git ]; then
+        if [ -f /tmp/botocore/HEAD ]; then
           git -C /tmp/botocore fetch --tags --prune
         else
           git clone --bare \

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -233,7 +233,7 @@ jobs:
         prompt: ${{ steps.prompt.outputs.PROMPT }}
         claude_args: |
           --dangerously-skip-permissions
-          --max-turns 50
+          --max-turns 100
         # yamllint disable rule:line-length
         settings: |
           {

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,6 @@ jobs:
   claude:
     # Only trusted authors can trigger @claude interactions.
     # Auto-review on pull_request events is unrestricted.
-    # yamllint disable-line rule:line-length
     if: >-
       (github.event_name == 'pull_request') ||
       (github.event_name == 'issue_comment' &&
@@ -56,7 +55,6 @@ jobs:
       id-token: write
       actions: read
     steps:
-    # yamllint disable-line rule:line-length
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         fetch-depth: 1
@@ -64,10 +62,8 @@ jobs:
 
     - name: Read prompt
       id: prompt
-      # yamllint disable-line rule:line-length
       env:
         REPO: ${{ github.repository }}
-        # yamllint disable-line rule:line-length
         PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         EVENT_NAME: ${{ github.event_name }}
       run: |
@@ -79,7 +75,6 @@ jobs:
           echo 'PROMPT_EOF'
         } >> "$GITHUB_OUTPUT"
 
-    # yamllint disable-line rule:line-length
     - uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6
       id: claude
       with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,6 +1,7 @@
 ---
 name: Claude Code
 
+# yamllint disable-line rule:line-length
 run-name: "Claude: ${{ github.event_name == 'pull_request' && format('Review PR #{0}', github.event.pull_request.number) || github.event_name == 'issues' && format('Issue #{0}', github.event.issue.number) || format('PR #{0} comment', github.event.issue.number || github.event.pull_request.number) }}"
 
 permissions: {}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,6 +1,8 @@
 ---
 name: Claude Code
 
+run-name: "Claude: ${{ github.event_name == 'pull_request' && format('Review PR #{0}', github.event.pull_request.number) || github.event_name == 'issues' && format('Issue #{0}', github.event.issue.number) || format('PR #{0} comment', github.event.issue.number || github.event.pull_request.number) }}"
+
 permissions: {}
 
 on:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,8 +1,19 @@
 ---
 name: Claude Code
 
-# yamllint disable-line rule:line-length
-run-name: "Claude: ${{ github.event_name == 'pull_request' && format('Review PR #{0}', github.event.pull_request.number) || github.event_name == 'issues' && format('Issue #{0}', github.event.issue.number) || format('PR #{0} comment', github.event.issue.number || github.event.pull_request.number) }}"
+run-name: >-
+  Claude:
+  ${{
+    github.event_name == 'pull_request'
+      && format('Review PR #{0}',
+         github.event.pull_request.number)
+    || github.event_name == 'issues'
+      && format('Issue #{0}',
+         github.event.issue.number)
+    || format('PR #{0} comment',
+       github.event.issue.number
+       || github.event.pull_request.number)
+  }}
 
 permissions: {}
 

--- a/.yamllint
+++ b/.yamllint
@@ -2,6 +2,8 @@
 extends: default
 
 rules:
+  line-length:
+    max: 120
   indentation:
     level: error
     indent-sequences: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ uv run pre-commit run --all --show-diff-on-failure
 ```
 
 Key constraints:
-- YAML lines must be ≤80 chars (`# yamllint disable-line rule:line-length` for exceptions)
+- YAML lines must be ≤120 chars (`# yamllint disable-line rule:line-length` for exceptions)
 - All workflow jobs must have `timeout-minutes`
 - Python code formatted with `ruff`
 


### PR DESCRIPTION
## Summary

Multiple improvements to the botocore sync and Claude review workflows.

### Botocore sync: cached repo + git diff
- Cache bare clone of boto/botocore between runs (`actions/cache`)
- First run: full clone (~200MB). Subsequent: `git fetch --tags` only
- Prompt uses `git diff OLD..NEW -- botocore/` instead of downloading/extracting PyPI wheels
- Fix bare clone detection (check `HEAD` not `.git` — found by Claude's auto-review)

### Git operation hints
- Always specify `branch` param in `mcp__github_file_ops__commit_files` (defaults to main which is protected)
- Use `claude/` prefix for all branches (`claude/botocore-sync`, `claude/botocore-sync-wip`)
- MCP tool usage example in prompt
- Updated all branch references throughout sync prompt

### Review bot: address other bot findings
- Claude now checks for and addresses findings from other review bots (github-advanced-security, zizmor) on bot PRs

### Relax/bump criteria clarified
- Diff analysis is PRIMARY factor for relax vs bump
- Hash tests are a confirming signal, not a gate
- Hashes passing alone is NOT sufficient for relax

### yamllint line-length raised to 120
- `.yamllint`: `max: 120`
- Removed most `disable-line rule:line-length` comments
- Updated CLAUDE.md to document new limit (found by Claude's auto-review)

### Other
- Increased `--max-turns` from 50 to 100
- Added informative `run-name` to Claude workflow
- Added explicit pre-commit check instruction to sync prompt
- Pinned `actions/cache` to SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)