### PR TITLE
Fix Claude bot failing on issue comments

### DIFF
--- a/.github/claude-review-prompt.md
+++ b/.github/claude-review-prompt.md
@@ -1,6 +1,12 @@
 REPO: $REPO
-PR NUMBER: $PR_NUMBER
+NUMBER: $PR_NUMBER
 EVENT: $EVENT_NAME
+
+NOTE: NUMBER above is a PR number when EVENT is
+pull_request or pull_request_review_comment, and an
+issue number when EVENT is issue_comment or issues.
+Use the appropriate gh command (gh pr view vs gh issue
+view) based on the event type.
 
 This is aiobotocore, a Python async library wrapping
 botocore for asyncio.

--- a/.github/claude-review-prompt.md
+++ b/.github/claude-review-prompt.md
@@ -1,5 +1,5 @@
 REPO: $REPO
-NUMBER: $PR_NUMBER
+NUMBER: $NUMBER
 EVENT: $EVENT_NAME
 
 NOTE: NUMBER above is a PR number when EVENT is
@@ -31,7 +31,7 @@ review. This reviews the PR diff checking for:
 
 After the review completes, check the PR author:
 ```
-gh pr view $PR_NUMBER --json author --jq '.author.login'
+gh pr view $NUMBER --json author --jq '.author.login'
 ```
 
 If the PR was created by a bot (github-actions[bot],

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -78,7 +78,7 @@ jobs:
       id: prompt
       env:
         REPO: ${{ github.repository }}
-        PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         EVENT_NAME: ${{ github.event_name }}
       run: |
         # Substitute env vars into prompt


### PR DESCRIPTION
## Summary
- The Claude bot prompt header said `PR NUMBER: <n>` for all GitHub events, including issue comments
- When triggered on issue #1455, Claude tried `gh pr view 1455`, got a 404, and gave up without responding
- Renamed the label to `NUMBER` and added a note explaining it's a PR or issue number depending on the event type

Fixes the failed run: https://github.com/aio-libs/aiobotocore/actions/runs/24069011735

## Test plan
- [ ] Trigger `@claude` on an issue comment and verify Claude responds correctly
- [ ] Verify PR review flow still works on pull_request events

🤖 Generated with [Claude Code](https://claude.com/claude-code)