### PR TITLE
Fix gh auth setup-git failing without token

### DIFF
--- a/.github/claude-review-prompt.md
+++ b/.github/claude-review-prompt.md
@@ -3,6 +3,7 @@ NUMBER: $NUMBER
 EVENT: $EVENT_NAME
 IS_PR: $IS_PR
 IS_FORK: $IS_FORK
+COMMENT_ID: $COMMENT_ID
 
 NUMBER is a PR number when IS_PR is true, and an issue number when IS_PR is false.
 Use `gh pr view` when IS_PR is true, `gh issue view` otherwise.
@@ -92,6 +93,22 @@ You may create branches and pull requests to implement fixes or features. Use br
 ## Restrictions
 
 IMPORTANT: Never merge or close pull requests. Never close issues. These actions require human approval.
+
+## Cleanup
+
+When you finish processing, remove any 👀 reaction you added to the triggering entity.
+If COMMENT_ID is set (comment events), remove from the comment:
+```
+gh api repos/$REPO/issues/comments/$COMMENT_ID/reactions \
+  --jq '.[] | select(.content == "eyes") | .id' \
+  | xargs -I{} gh api repos/$REPO/issues/comments/$COMMENT_ID/reactions/{} --method DELETE
+```
+If COMMENT_ID is empty (pull_request events), remove from the PR:
+```
+gh api repos/$REPO/issues/$NUMBER/reactions \
+  --jq '.[] | select(.content == "eyes") | .id' \
+  | xargs -I{} gh api repos/$REPO/issues/$NUMBER/reactions/{} --method DELETE
+```
 
 ## Environment
 

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -183,6 +183,8 @@ jobs:
 
     - name: Set up git credentials
       run: gh auth setup-git
+      env:
+        GH_TOKEN: ${{ github.token }}
 
     - name: Cache botocore repo
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -76,6 +76,8 @@ jobs:
 
     - name: Set up git credentials
       run: gh auth setup-git
+      env:
+        GH_TOKEN: ${{ github.token }}
 
     - name: Set up uv + Python
       # yamllint disable-line rule:line-length

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -99,6 +99,7 @@ jobs:
         IS_PR: ${{ github.event_name != 'issues' && (github.event_name != 'issue_comment' || github.event.issue.pull_request != null) }}
         # yamllint disable-line rule:line-length
         IS_FORK: ${{ github.event.pull_request.head.repo.fork || steps.pr_meta.outputs.is_fork || 'false' }}
+        COMMENT_ID: ${{ github.event.comment.id || '' }}
       run: |
         # Substitute env vars into prompt
         prompt=$(envsubst < .github/claude-review-prompt.md)


### PR DESCRIPTION
## Summary
- `persist-credentials: false` on checkout strips `GITHUB_TOKEN` from the environment
- `gh auth setup-git` needs `GH_TOKEN` explicitly to authenticate
- Adds `GH_TOKEN: ${{ github.token }}` to both `claude.yml` and `botocore-sync.yml`

Fixes the failure in https://github.com/aio-libs/aiobotocore/actions/runs/24230612134

## Test plan
- [x] Pre-commit passes
- [ ] Trigger `@claude` on a PR and verify the step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)