### PR TITLE
Add /analyze-pr-feedback and auto-address reviewer feedback on claude[bot] PRs

### DIFF
--- a/.claude/commands/analyze-pr-feedback.md
+++ b/.claude/commands/analyze-pr-feedback.md
@@ -1,0 +1,121 @@
+---
+description: Fetch all review threads + top-level PR comments and surface the ones that need Claude's attention
+---
+
+Fetch every piece of reviewer feedback on the PR — review threads AND top-level PR comments — then filter to the
+items that actually need Claude to do something. Use this whenever you need to address reviewer feedback, either
+proactively (auto-review on claude[bot] PRs) or in response to an `@claude` mention.
+
+## Arguments
+
+- `--focus=<databaseId>` (optional): the triggering comment's `databaseId`. If set, prioritize the thread
+  containing this comment in your output and analysis. Other threads are still returned as context but ranked
+  after the focused one.
+
+If `--focus` is omitted, all surviving threads are returned unranked.
+
+## Step 1: Fetch everything
+
+Assumes `$REPO` and `$NUMBER` are set by the workflow environment.
+
+```
+gh api graphql -f query='
+  query($o:String!, $n:String!, $p:Int!) {
+    repository(owner:$o, name:$n) {
+      pullRequest(number:$p) {
+        reviewThreads(first:100) {
+          nodes {
+            id isResolved isOutdated path line
+            comments(first:50) {
+              nodes {
+                databaseId
+                author { login __typename }
+                authorAssociation
+                createdAt
+                body
+                url
+              }
+            }
+          }
+        }
+        comments(last:100) {
+          nodes {
+            databaseId
+            author { login __typename }
+            authorAssociation
+            createdAt
+            body
+            url
+          }
+        }
+      }
+    }
+  }' -F o=${REPO%/*} -F n=${REPO#*/} -F p=$NUMBER
+```
+
+## Step 2: Apply filters
+
+Apply ALL of these in order. Skip any item that fails any one filter.
+
+### Filter 1 — Author must be trusted
+
+`authorAssociation` must be `MEMBER`, `OWNER`, or `COLLABORATOR`. Skip `NONE`, `FIRST_TIMER`,
+`FIRST_TIME_CONTRIBUTOR`, `CONTRIBUTOR`, `MANNEQUIN`.
+
+### Filter 2 — Last entry must NOT be claude[bot]
+
+For review threads: check the last element of `comments.nodes` (sorted by `createdAt`).
+For top-level PR comments: the comment itself is its own "thread"; check its author.
+
+If `author.login == "claude"` AND `author.__typename == "Bot"`, skip — claude already replied last, reviewer has
+the ball. (Remember: GraphQL strips `[bot]` suffix, so bare `"claude"` + `Bot` type is the match.)
+
+### Filter 3 — Item must represent actionable work for Claude
+
+An item is actionable if it asks Claude to do something concrete: change code, fix a bug, answer a specific
+question about code, or modify the PR. Items that do NOT pass this filter:
+
+- Comments addressed to other users (e.g. `@jakob-keller working on this...`) — human-to-human status chatter.
+- Progress / status updates (e.g. "still working on this", "LGTM once CI passes", "thanks!").
+- Praise, acknowledgements, or tangential discussion unrelated to code.
+- Meta-review chatter (e.g. "let me re-review this later").
+- Explicit skip / ignore directives (e.g. "ignore this, I'll handle it").
+
+When in doubt, skip. A wrong reply from Claude is more disruptive than a missing one. Mention skipped items
+briefly in whatever caller-side summary you produce instead of replying on-thread.
+
+## Step 3: Output structured list
+
+For each surviving item, emit:
+
+```
+- thread_id: <review thread id, or "top-level" for PR comments>
+  path: <file path, or null for top-level>
+  line: <line number, or null for top-level>
+  parent_comment_id: <databaseId of the first comment — target for reply>
+  last_comment_author: <login>
+  last_comment_body: <first 200 chars>
+  thread_url: <permalink>
+  is_focus: <true if --focus matched this thread, else false>
+```
+
+If `--focus` was provided and matched a thread, sort that thread first. Otherwise output in `createdAt` order.
+
+## What the caller does next
+
+This command returns data only — no replies, no commits. The caller decides how to handle each item:
+
+1. **Already addressed in a prior commit** → caller replies `Addressed in commit <short-SHA> — <permalink>` on
+   the thread. No duplicate fix.
+2. **Not yet addressed, confidence >= 80** → caller pushes a targeted signed commit via
+   `mcp__github_file_ops__commit_files`, then replies with the new SHA and one-line explanation.
+3. **Ambiguous or risky** → caller replies asking for clarification. No speculative fix.
+
+Reply targets:
+- Inline thread: `gh api repos/$REPO/pulls/$NUMBER/comments/$PARENT_COMMENT_ID/replies --method POST -f body=...`
+- Top-level comment: `gh api repos/$REPO/issues/$NUMBER/comments --method POST -f body=...`
+  (quote the original's first line in a blockquote so context is preserved).
+
+Before posting any reply or pushing any commit, **read the current code state** with `git log -p -- <path>`,
+`git blame`, and direct Read of the file. Do not assume the repo state matches what the reviewer saw when they
+wrote the comment; a prior Claude run may have already fixed the issue.

--- a/.claude/commands/analyze-pr-feedback.md
+++ b/.claude/commands/analyze-pr-feedback.md
@@ -1,22 +1,27 @@
 ---
-description: Fetch all review threads + top-level PR comments and surface the ones that need Claude's attention
+description: Fetch every PR comment + reply (including resolved), synthesize the discussion, and produce a grouped action plan
 ---
 
-Fetch every piece of reviewer feedback on the PR — review threads AND top-level PR comments — then filter to the
-items that actually need Claude to do something. Use this whenever you need to address reviewer feedback, either
-proactively (auto-review on claude[bot] PRs) or in response to an `@claude` mention.
+Fetch every piece of reviewer feedback on the PR — review threads and top-level PR comments, including resolved
+ones — then synthesize the discussion as context and produce a grouped action plan. Use this whenever you need
+to address reviewer feedback, either proactively (auto-review on claude[bot] PRs) or in response to an `@claude`
+mention.
+
+**Do not process threads in isolation.** Read the entire comment history first, including threads that are
+already resolved or already ended with a claude[bot] reply, to build a coherent picture of what the reviewer
+cares about. A single comment often makes no sense without the surrounding thread; a thread often makes no
+sense without the PR-wide context of prior discussions. Only after synthesis should you decide actions.
 
 ## Arguments
 
-- `--focus=<databaseId>` (optional): the triggering comment's `databaseId`. If set, prioritize the thread
-  containing this comment in your output and analysis. Other threads are still returned as context but ranked
-  after the focused one.
-
-If `--focus` is omitted, all surviving threads are returned unranked.
+- `--focus=<databaseId>` (optional): the triggering comment's `databaseId`. If set, the thread containing this
+  comment is guaranteed to appear in the action plan (assuming it passes filters) and is ranked first. Other
+  items are still included — the focus doesn't narrow scope, it only prioritizes.
 
 ## Step 1: Fetch everything
 
-Assumes `$REPO` and `$NUMBER` are set by the workflow environment.
+Assumes `$REPO` and `$NUMBER` are set by the workflow environment. Include resolved threads too — they are
+context even though you won't act on them.
 
 ```
 gh api graphql -f query='
@@ -48,74 +53,143 @@ gh api graphql -f query='
             url
           }
         }
+        reviews(last:50) {
+          nodes {
+            state
+            body
+            author { login __typename }
+            authorAssociation
+            submittedAt
+          }
+        }
       }
     }
   }' -F o=${REPO%/*} -F n=${REPO#*/} -F p=$NUMBER
 ```
 
-## Step 2: Apply filters
+## Step 2: Synthesize the discussion into three buckets
 
-Apply ALL of these in order. Skip any item that fails any one filter.
+Read every thread, every reply, and every top-level comment in chronological order. **Do not act on anything
+yet.** Build an internal synthesis with these three explicit buckets — this is the core output of the
+synthesis step:
 
-### Filter 1 — Author must be trusted
+### Bucket A — What was asked
 
-`authorAssociation` must be `MEMBER`, `OWNER`, or `COLLABORATOR`. Skip `NONE`, `FIRST_TIMER`,
-`FIRST_TIME_CONTRIBUTOR`, `CONTRIBUTOR`, `MANNEQUIN`.
+Every concrete request from trusted reviewers across the full PR history, including requests that have
+already been addressed. Group related asks together (e.g. "three comments about CHANGES.rst convention"
+becomes one grouped ask).
 
-### Filter 2 — Last entry must NOT be claude[bot]
+### Bucket B — What was done
 
-For review threads: check the last element of `comments.nodes` (sorted by `createdAt`).
-For top-level PR comments: the comment itself is its own "thread"; check its author.
+For each ask in Bucket A, record what has already happened in response:
+- A claude[bot] reply explaining what was done (or why not) + the commit SHA.
+- A commit on the branch that addresses the ask, even without an explicit reply.
+- The reviewer acknowledged the fix (`isResolved: true`, or a follow-up comment like "thanks, fixed").
+- Nothing yet.
 
-If `author.login == "claude"` AND `author.__typename == "Bot"`, skip — claude already replied last, reviewer has
-the ball. (Remember: GraphQL strips `[bot]` suffix, so bare `"claude"` + `Bot` type is the match.)
+Use `git log -p -- <path>` and `Read` of the affected files to verify — do not assume the response matches
+what the reviewer asked for; confirm the current code state.
 
-### Filter 3 — Item must represent actionable work for Claude
+### Bucket C — What is being asked that isn't resolved
 
-An item is actionable if it asks Claude to do something concrete: change code, fix a bug, answer a specific
-question about code, or modify the PR. Items that do NOT pass this filter:
+The set difference: items from Bucket A where Bucket B is empty, or where the response didn't fully
+address the ask. These are the candidates for action.
 
-- Comments addressed to other users (e.g. `@jakob-keller working on this...`) — human-to-human status chatter.
-- Progress / status updates (e.g. "still working on this", "LGTM once CI passes", "thanks!").
-- Praise, acknowledgements, or tangential discussion unrelated to code.
-- Meta-review chatter (e.g. "let me re-review this later").
-- Explicit skip / ignore directives (e.g. "ignore this, I'll handle it").
+Filter Bucket C to what's actually actionable for Claude:
 
-When in doubt, skip. A wrong reply from Claude is more disruptive than a missing one. Mention skipped items
-briefly in whatever caller-side summary you produce instead of replying on-thread.
+1. **Trusted author** — `authorAssociation` is `MEMBER`, `OWNER`, or `COLLABORATOR`. Others go to context,
+   never to action.
+2. **Not engaged by claude** — the most recent comment in the thread is not from `claude[bot]`
+   (`author.login == "claude" && author.__typename == "Bot"`). If claude already replied last, the
+   reviewer has the ball — belongs in Bucket B, not C.
+3. **Actionable work for Claude** — the ask is a concrete code change, bug fix, code-level answer, or
+   modification. Skip:
+   - Comments addressed to other users (e.g. `@jakob-keller working on this...`) — human-to-human chatter.
+   - Progress / status updates, praise, tangential discussion.
+   - Meta-review chatter or explicit skip directives ("ignore this, I'll handle it").
 
-## Step 3: Output structured list
+   When in doubt, skip and note the item in the summary instead of acting. A wrong reply is more disruptive
+   than a missing one.
 
-For each surviving item, emit:
+Bucket C items are what become actions. Multiple items are common on a PR with real back-and-forth — plan
+for multiple actions in one run, grouped where related.
 
+## Step 4: For each action, pick an outcome
+
+Before acting on any item, **read the current code state** with `git log -p -- <path>` and `Read` of the
+file. The repo may already contain the fix from a prior Claude run; don't duplicate it.
+
+Three outcomes per action (or per group of related actions):
+
+1. **Already addressed in a prior commit** — reply `Addressed in commit <short-SHA> — <permalink>` on each
+   relevant thread. No new commit.
+2. **Not yet addressed, confidence >= 80** — push one targeted signed commit via
+   `mcp__github_file_ops__commit_files` that addresses the whole group, then reply on each relevant thread
+   with the new SHA and a one-line explanation.
+3. **Ambiguous or risky** — reply asking for clarification. No speculative fixes.
+
+## Step 5: Reply targets
+
+- **Inline review thread**: reply in the same thread so discussion stays attached to the code line:
+  ```
+  gh api repos/$REPO/pulls/$NUMBER/comments/$PARENT_COMMENT_ID/replies \
+    --method POST -f body='…reply text…'
+  ```
+  `$PARENT_COMMENT_ID` is the first comment's `databaseId` in that thread's `comments.nodes`.
+
+- **Top-level PR comment**: reply as a new top-level comment that quotes the original's first line so context
+  is preserved:
+  ```
+  gh api repos/$REPO/issues/$NUMBER/comments \
+    --method POST -f body='> <reviewer>: <quoted first line>\n\n…reply text…'
+  ```
+
+## Output contract
+
+Before you act on anything, write out an explicit plan with these sections. Keep it structured — this is
+your internal checklist, and the final top-level summary reply renders from the same data.
+
+### Replies needed
+
+For each item in Bucket C (after filters), list:
 ```
-- thread_id: <review thread id, or "top-level" for PR comments>
-  path: <file path, or null for top-level>
-  line: <line number, or null for top-level>
-  parent_comment_id: <databaseId of the first comment — target for reply>
-  last_comment_author: <login>
-  last_comment_body: <first 200 chars>
-  thread_url: <permalink>
-  is_focus: <true if --focus matched this thread, else false>
+- thread_url: <permalink>
+  kind: <"review_thread" | "top_level_comment">
+  parent_comment_id: <databaseId to use as the reply target>
+  path: <file path or null>
+  line: <line number or null>
+  last_author: <login>
+  last_comment_preview: <first 200 chars>
+  planned_outcome: <"already-fixed" | "fix-now" | "ask-clarification">
+  planned_commit_group: <group name, or null if no commit planned>
 ```
 
-If `--focus` was provided and matched a thread, sort that thread first. Otherwise output in `createdAt` order.
+This is the explicit "which comments need to be replied to" list. After acting, every entry here MUST
+have had a reply posted. Before exiting, re-run a check of the form "for each parent_comment_id in my
+plan, did I POST a reply?" to catch any skipped items.
 
-## What the caller does next
+### Commit groups
 
-This command returns data only — no replies, no commits. The caller decides how to handle each item:
+For each planned `fix-now` group, list:
+```
+- group: <short name>
+  threads: [<list of thread_urls this group addresses>]
+  change_summary: <one-line description of what the commit will do>
+```
 
-1. **Already addressed in a prior commit** → caller replies `Addressed in commit <short-SHA> — <permalink>` on
-   the thread. No duplicate fix.
-2. **Not yet addressed, confidence >= 80** → caller pushes a targeted signed commit via
-   `mcp__github_file_ops__commit_files`, then replies with the new SHA and one-line explanation.
-3. **Ambiguous or risky** → caller replies asking for clarification. No speculative fix.
+One commit per group; multiple threads can share a group.
 
-Reply targets:
-- Inline thread: `gh api repos/$REPO/pulls/$NUMBER/comments/$PARENT_COMMENT_ID/replies --method POST -f body=...`
-- Top-level comment: `gh api repos/$REPO/issues/$NUMBER/comments --method POST -f body=...`
-  (quote the original's first line in a blockquote so context is preserved).
+### Final top-level summary
 
-Before posting any reply or pushing any commit, **read the current code state** with `git log -p -- <path>`,
-`git blame`, and direct Read of the file. Do not assume the repo state matches what the reviewer saw when they
-wrote the comment; a prior Claude run may have already fixed the issue.
+When posting the run-level summary reply (via the parent prompt's Cleanup section), include:
+
+- **Discussion summary** (1–3 sentences): what the reviewer has raised, what patterns emerged across
+  resolved + unresolved history.
+- **Bucket A — What was asked**: the full list, grouped.
+- **Bucket B — What was done**: per ask, the commit SHA or the resolution. Include items done in prior
+  runs, not just this one.
+- **Bucket C — What's still outstanding**: per ask, the planned action or "awaiting reviewer clarification".
+- **Per-thread replies**: permalinks to every reply you posted this run.
+
+This way the reviewer can scan one comment and understand the state of every discussion thread, rather
+than chasing N separate replies.

--- a/.claude/commands/analyze-pr-feedback.md
+++ b/.claude/commands/analyze-pr-feedback.md
@@ -17,6 +17,9 @@ sense without the PR-wide context of prior discussions. Only after synthesis sho
 - `--focus=<databaseId>` (optional): the triggering comment's `databaseId`. If set, the thread containing this
   comment is guaranteed to appear in the action plan (assuming it passes filters) and is ranked first. Other
   items are still included — the focus doesn't narrow scope, it only prioritizes.
+- `--resolve` (optional): after posting a "fixed" or "already-addressed" reply on a thread, call the GraphQL
+  `resolveReviewThread` mutation to mark the thread resolved. Opt-in only — never resolve automatically.
+  Do NOT resolve threads where the outcome was `ask-clarification` (the reviewer still has the ball).
 
 ## Step 1: Fetch everything
 
@@ -122,11 +125,28 @@ file. The repo may already contain the fix from a prior Claude run; don't duplic
 Three outcomes per action (or per group of related actions):
 
 1. **Already addressed in a prior commit** — reply `Addressed in commit <short-SHA> — <permalink>` on each
-   relevant thread. No new commit.
+   relevant thread. No new commit. If `--resolve` was passed, resolve the thread.
 2. **Not yet addressed, confidence >= 80** — push one targeted signed commit via
-   `mcp__github_file_ops__commit_files` that addresses the whole group, then reply on each relevant thread
-   with the new SHA and a one-line explanation.
-3. **Ambiguous or risky** — reply asking for clarification. No speculative fixes.
+   `mcp__github_file_ops__commit_files` that addresses the whole group. **Before posting the reply, validate
+   the commit** — run `uv run pre-commit run --all --show-diff-on-failure` at minimum, and any task-specific
+   tests relevant to the change (e.g. `uv run pytest tests/test_patches.py -x` for botocore overrides). Only
+   after validation passes, reply on each relevant thread with the new SHA and a one-line explanation. If
+   `--resolve` was passed, resolve the thread. If validation fails, fix forward or downgrade to
+   `ask-clarification`.
+3. **Ambiguous or risky** — reply asking for clarification. No speculative fixes. Do NOT resolve the thread
+   even if `--resolve` was passed.
+
+To resolve a thread (GraphQL mutation — only when all of: `--resolve` flag AND outcome is 1 or 2 AND the
+post-commit validation passed):
+```
+gh api graphql -f query='
+  mutation($tid: ID!) {
+    resolveReviewThread(input: {threadId: $tid}) {
+      thread { isResolved }
+    }
+  }' -F tid=$THREAD_ID
+```
+`$THREAD_ID` is the `id` field (not `databaseId`) from the `reviewThreads.nodes` entry.
 
 ## Step 5: Reply targets
 

--- a/.github/claude-review-prompt.md
+++ b/.github/claude-review-prompt.md
@@ -52,9 +52,9 @@ address their findings if they are actionable.
 
 ### Address reviewer feedback on claude[bot]-authored PRs
 
-When the PR was authored by `claude[bot]` specifically (not other bots), go through open reviewer feedback
-and address or acknowledge each outstanding item — don't rely on your own `/review-pr` findings alone. The
-reviewer's inline threads may have been posted days ago and need explicit handling on this run.
+When the PR was authored by `claude[bot]` specifically (not other bots), also go through open reviewer
+feedback and address or acknowledge each outstanding item — don't rely on your own `/review-pr` findings
+alone. Reviewer threads may have been posted days ago and need explicit handling on this run.
 
 Check PR author first:
 ```
@@ -62,81 +62,12 @@ gh api repos/$REPO/pulls/$NUMBER --jq '.user.login'
 # Proceed ONLY if this equals "claude[bot]"
 ```
 
-Fetch every review thread plus top-level PR comments in one GraphQL call.
+Then run `/analyze-pr-feedback` (no `--focus` — we want all items, none is the trigger). The command fetches
+every review thread plus top-level PR comments, applies filters (trusted author, last reply not claude,
+actionable work), and returns the items that need attention.
 
-```
-gh api graphql -f query='
-  query($o:String!, $n:String!, $p:Int!) {
-    repository(owner:$o, name:$n) {
-      pullRequest(number:$p) {
-        reviewThreads(first:100) {
-          nodes {
-            id isResolved isOutdated path line
-            comments(first:50) {
-              nodes {
-                databaseId author { login __typename } authorAssociation
-                createdAt body url
-              }
-            }
-          }
-        }
-        comments(last:100) {
-          nodes {
-            databaseId author { login __typename } authorAssociation
-            createdAt body url
-          }
-        }
-      }
-    }
-  }' -F o=${REPO%/*} -F n=${REPO#*/} -F p=$NUMBER
-```
-
-**Filter before acting.** Apply ALL of these filters in order — skip anything that fails any one of them:
-
-1. **Author must be trusted** — MEMBER, OWNER, or COLLABORATOR. Skip comments from NONE/FIRST_TIMER/etc.
-2. **Most recent comment in the thread is NOT from claude[bot]** — if claude already replied last, the
-   reviewer has the ball. Skip. (This is the "last reply from claude" exit rule.)
-3. **The item must represent actionable work for Claude** — i.e. a request for a code change, a bug report,
-   a question about specific code that needs a code answer, or a directive to modify something. **Skip items
-   that don't ask Claude to do anything.** In particular:
-   - Comments addressed to other users (e.g. `@jakob-keller working on this...`) — they're human-to-human
-     status updates, not requests for Claude.
-   - General progress / status updates (e.g. "still working on this", "LGTM once CI passes", "thanks!").
-   - Praise, acknowledgements, or tangential discussion unrelated to the code change.
-   - Meta-comments about the review process itself (e.g. "let me re-review this later").
-   - Comments that explicitly say Claude should skip / ignore / wait (e.g. "ignore this, I'll handle it").
-
-   When in doubt, err on the side of skipping and mention the item briefly in the `/review-pr` summary
-   instead of acting on it. A wrong reply from Claude is more disruptive than a missing one.
-
-For each thread / top-level comment that survives all three filters, **analyze the current code state
-before acting** —
-don't blindly re-fix what you already fixed. Check `git log -p -- <path>` and read the current file. Three
-outcomes:
-
-1. **Already addressed in a prior commit**: post a reply on the thread saying
-   `Addressed in commit <short-SHA> — <permalink>`. Do NOT push a duplicate fix. This is the common case on
-   re-runs (e.g. `synchronize` after a base-branch update where you already fixed the issue days ago).
-
-2. **Not yet addressed, confidence >= 80 that the fix is clear-cut**: push a targeted signed commit via
-   `mcp__github_file_ops__commit_files`, then post a reply on the thread with the new SHA and a one-line
-   explanation of what changed.
-
-3. **Not addressed, ambiguous or risky**: post a reply asking the reviewer for clarification or flagging it
-   for human judgment. Do NOT push a speculative fix.
-
-Reply target depends on where the feedback lives:
-- **Inline review thread**: reply in the same thread so the discussion stays attached to the code line:
-  ```
-  gh api repos/$REPO/pulls/$NUMBER/comments/$PARENT_COMMENT_ID/replies \
-    --method POST -f body='…reply text…'
-  ```
-  `$PARENT_COMMENT_ID` is the first comment's `databaseId` in that thread's `comments.nodes`.
-- **Top-level PR comment**: reply as a new top-level comment that quotes the original's first line:
-  ```
-  gh api repos/$REPO/issues/$NUMBER/comments \
-    --method POST -f body='> <reviewer>: <quoted first line>\n\n…reply text…'
-  ```
+For each returned item, follow the 3-outcome rule documented in `/analyze-pr-feedback`: already-fixed →
+reply with commit SHA; not-fixed + confident → push fix + reply; ambiguous → ask for clarification.
 
 These per-thread replies are in addition to `/review-pr`'s summary comment — not a replacement.
 
@@ -203,44 +134,27 @@ To read the triggering comment:
   list `gh api repos/$REPO/pulls/$NUMBER/comments` for any inline comments submitted with the
   review (the review summary body is often empty when the @claude mention is in an inline comment).
 
-### Read the full thread, not just the one comment
+### Pull full context via /analyze-pr-feedback
 
-A single comment is rarely the full context. Before acting, pull the whole conversation so you
-account for replies, counter-proposals, and follow-ups from the reviewer and others.
+A single comment is rarely the full context. Before acting, run `/analyze-pr-feedback` to fetch every review
+thread and top-level PR comment (with the trusted-author / last-reply-not-claude / actionable-work filters
+already applied). When a specific comment triggered this run, pass its databaseId as `--focus`:
 
-For a `pull_request_review_comment` trigger, fetch every unresolved review thread on the PR — including the
-triggering thread (by locating the thread whose `comments.nodes` contains `$COMMENT_ID`). This is a single GraphQL
-call that also exposes each thread's `isResolved` state, which the REST `/comments` endpoint does not:
-```
-gh api graphql -f query='
-  query($owner:String!, $name:String!, $pr:Int!) {
-    repository(owner:$owner, name:$name) {
-      pullRequest(number:$pr) {
-        reviewThreads(first:100) {
-          nodes {
-            isResolved
-            isOutdated
-            path
-            line
-            comments(first:50) {
-              nodes { databaseId author { login } createdAt body url replyTo { databaseId } }
-            }
-          }
-        }
-      }
-    }
-  }' -F owner=aio-libs -F name=aiobotocore -F pr=$NUMBER --jq '
-    .data.repository.pullRequest.reviewThreads.nodes
-      | map(select(.isResolved == false))'
-```
+- `pull_request_review_comment`: `/analyze-pr-feedback --focus=$COMMENT_ID`
+- `issue_comment` (PR): `/analyze-pr-feedback --focus=$COMMENT_ID`
+- `pull_request_review` (CHANGES_REQUESTED or @claude in review body): `/analyze-pr-feedback` (no focus —
+  the review summary itself isn't a review-thread comment, so iterate all items and pay special attention
+  to ones submitted as part of this review)
 
-When the reviewer asks you to address a specific comment, find the thread whose comments contain
-`databaseId == $COMMENT_ID` and read every comment in it (the parent plus all replies, in `createdAt` order).
-When the reviewer says something broad like "address all the PR comments", read every unresolved thread in full
-before deciding what to do.
+Prioritize the focused thread (if any). For broad asks like "address all the PR comments", handle every
+returned item. For narrow asks, use other items as context and only act on the focused one unless the
+reviewer explicitly scopes wider.
 
-In your summary reply, list each thread you touched (with its `url` permalink) and state whether you addressed
-it, replied, or left it alone and why.
+For each item you touch, follow the 3-outcome rule documented in `/analyze-pr-feedback`:
+already-fixed → reply with commit SHA; not-fixed + confident → push fix + reply; ambiguous → clarify.
+
+In your final top-level summary reply (required — see Cleanup below), list each thread you touched (with
+its `url` permalink) and state whether you addressed it, replied, or left it alone and why.
 
 ## Implement the issue (EVENT=issues)
 

--- a/.github/claude-review-prompt.md
+++ b/.github/claude-review-prompt.md
@@ -62,9 +62,7 @@ gh api repos/$REPO/pulls/$NUMBER --jq '.user.login'
 # Proceed ONLY if this equals "claude[bot]"
 ```
 
-Fetch every review thread plus top-level PR comments in one GraphQL call. The filter is: **items from trusted
-authors (MEMBER / OWNER / COLLABORATOR) where the most recent comment in the thread is NOT from claude[bot]**.
-If claude[bot] already replied last, the reviewer has the ball — skip that thread.
+Fetch every review thread plus top-level PR comments in one GraphQL call.
 
 ```
 gh api graphql -f query='
@@ -93,7 +91,26 @@ gh api graphql -f query='
   }' -F o=${REPO%/*} -F n=${REPO#*/} -F p=$NUMBER
 ```
 
-For each thread / top-level comment that needs attention, **analyze the current code state before acting** —
+**Filter before acting.** Apply ALL of these filters in order — skip anything that fails any one of them:
+
+1. **Author must be trusted** — MEMBER, OWNER, or COLLABORATOR. Skip comments from NONE/FIRST_TIMER/etc.
+2. **Most recent comment in the thread is NOT from claude[bot]** — if claude already replied last, the
+   reviewer has the ball. Skip. (This is the "last reply from claude" exit rule.)
+3. **The item must represent actionable work for Claude** — i.e. a request for a code change, a bug report,
+   a question about specific code that needs a code answer, or a directive to modify something. **Skip items
+   that don't ask Claude to do anything.** In particular:
+   - Comments addressed to other users (e.g. `@jakob-keller working on this...`) — they're human-to-human
+     status updates, not requests for Claude.
+   - General progress / status updates (e.g. "still working on this", "LGTM once CI passes", "thanks!").
+   - Praise, acknowledgements, or tangential discussion unrelated to the code change.
+   - Meta-comments about the review process itself (e.g. "let me re-review this later").
+   - Comments that explicitly say Claude should skip / ignore / wait (e.g. "ignore this, I'll handle it").
+
+   When in doubt, err on the side of skipping and mention the item briefly in the `/review-pr` summary
+   instead of acting on it. A wrong reply from Claude is more disruptive than a missing one.
+
+For each thread / top-level comment that survives all three filters, **analyze the current code state
+before acting** —
 don't blindly re-fix what you already fixed. Check `git log -p -- <path>` and read the current file. Three
 outcomes:
 

--- a/.github/claude-review-prompt.md
+++ b/.github/claude-review-prompt.md
@@ -50,6 +50,79 @@ If the PR is from this repo (IS_FORK is false), check the author:
 Also check for review comments from other bots (github-advanced-security[bot], zizmor, etc.) and
 address their findings if they are actionable.
 
+### Address reviewer feedback on claude[bot]-authored PRs
+
+When the PR was authored by `claude[bot]` specifically (not other bots), go through open reviewer feedback
+and address or acknowledge each outstanding item — don't rely on your own `/review-pr` findings alone. The
+reviewer's inline threads may have been posted days ago and need explicit handling on this run.
+
+Check PR author first:
+```
+gh api repos/$REPO/pulls/$NUMBER --jq '.user.login'
+# Proceed ONLY if this equals "claude[bot]"
+```
+
+Fetch every review thread plus top-level PR comments in one GraphQL call. The filter is: **items from trusted
+authors (MEMBER / OWNER / COLLABORATOR) where the most recent comment in the thread is NOT from claude[bot]**.
+If claude[bot] already replied last, the reviewer has the ball — skip that thread.
+
+```
+gh api graphql -f query='
+  query($o:String!, $n:String!, $p:Int!) {
+    repository(owner:$o, name:$n) {
+      pullRequest(number:$p) {
+        reviewThreads(first:100) {
+          nodes {
+            id isResolved isOutdated path line
+            comments(first:50) {
+              nodes {
+                databaseId author { login __typename } authorAssociation
+                createdAt body url
+              }
+            }
+          }
+        }
+        comments(last:100) {
+          nodes {
+            databaseId author { login __typename } authorAssociation
+            createdAt body url
+          }
+        }
+      }
+    }
+  }' -F o=${REPO%/*} -F n=${REPO#*/} -F p=$NUMBER
+```
+
+For each thread / top-level comment that needs attention, **analyze the current code state before acting** —
+don't blindly re-fix what you already fixed. Check `git log -p -- <path>` and read the current file. Three
+outcomes:
+
+1. **Already addressed in a prior commit**: post a reply on the thread saying
+   `Addressed in commit <short-SHA> — <permalink>`. Do NOT push a duplicate fix. This is the common case on
+   re-runs (e.g. `synchronize` after a base-branch update where you already fixed the issue days ago).
+
+2. **Not yet addressed, confidence >= 80 that the fix is clear-cut**: push a targeted signed commit via
+   `mcp__github_file_ops__commit_files`, then post a reply on the thread with the new SHA and a one-line
+   explanation of what changed.
+
+3. **Not addressed, ambiguous or risky**: post a reply asking the reviewer for clarification or flagging it
+   for human judgment. Do NOT push a speculative fix.
+
+Reply target depends on where the feedback lives:
+- **Inline review thread**: reply in the same thread so the discussion stays attached to the code line:
+  ```
+  gh api repos/$REPO/pulls/$NUMBER/comments/$PARENT_COMMENT_ID/replies \
+    --method POST -f body='…reply text…'
+  ```
+  `$PARENT_COMMENT_ID` is the first comment's `databaseId` in that thread's `comments.nodes`.
+- **Top-level PR comment**: reply as a new top-level comment that quotes the original's first line:
+  ```
+  gh api repos/$REPO/issues/$NUMBER/comments \
+    --method POST -f body='> <reviewer>: <quoted first line>\n\n…reply text…'
+  ```
+
+These per-thread replies are in addition to `/review-pr`'s summary comment — not a replacement.
+
 ## Git operations
 
 ### Committing changes


### PR DESCRIPTION
### Description of Change

Two related changes that make auto-review on claude[bot]-authored PRs actually close reviewer-feedback loops:

**1. New `.claude/commands/analyze-pr-feedback.md` slash command** — a shared primitive for fetching every PR comment + reply (including resolved ones), synthesizing the discussion, and producing a grouped action plan. Both the auto-review path (`/review-pr`) and the Respond-to-@claude path now delegate to this command instead of each implementing their own GraphQL fetch and filter rules. Single source of truth for how Claude understands reviewer feedback.

**2. Wired into `claude-review-prompt.md`** — on `pull_request` events for PRs authored by `claude[bot]` specifically (not other bots), `/review-pr` now invokes `/analyze-pr-feedback` after its own diff scan. Per-thread replies + per-group commits, not just a top-level sticky. The Respond-to-@claude section also delegates to the same command (`--focus=$COMMENT_ID` when a comment triggered).

### What `/analyze-pr-feedback` does

Do not process threads in isolation. Read the entire discussion (including resolved threads) first, then act.

1. **Fetch** — one GraphQL call returns every `reviewThreads` entry (resolved and unresolved), every top-level PR comment, and every review body (`reviews(last:50)`). Resolved threads are context; they show what patterns have already been established.

2. **Synthesize into three buckets:**
   - **A — What was asked**: every concrete request across the PR history, grouped by topic.
   - **B — What was done**: the response to each ask (claude reply + commit SHA, branch commit that addresses the ask, reviewer acknowledgement). Verified by `git log -p -- <path>` + reading the current file — not by trusting `isResolved`.
   - **C — What is being asked that isn't resolved**: the set difference. Filtered to actionable work.

3. **Filter Bucket C** with three gates:
   - Trusted author (MEMBER/OWNER/COLLABORATOR).
   - Most recent comment in the thread is not from `claude[bot]` — if claude already replied, the reviewer has the ball.
   - The item is actionable for Claude. Explicit skip list: comments addressed to other users (e.g. `@jakob-keller working on this...`), status updates, praise, meta-review chatter, explicit "ignore this" directives.

4. **Per item/group, pick an outcome:**
   - **Already fixed in a prior commit** → reply `Addressed in commit <SHA> — <permalink>`. No duplicate commit.
   - **Not fixed, confidence ≥ 80** → push one targeted signed commit per group; run pre-commit + task-specific tests before posting the reply; reply with new SHA.
   - **Ambiguous/risky** → ask for clarification. No speculative fixes.

5. **Output contract** — explicit list of `parent_comment_id`s needing replies, planned commit groups, and final top-level summary covering all three buckets with permalinks.

### Optional flags

- `--focus=<databaseId>` — triggering comment id; ranks that thread first without narrowing scope.
- `--resolve` — opt-in; after a successful fix/already-addressed reply, call GraphQL `resolveReviewThread` to mark the thread resolved. Never automatic; never on `ask-clarification` outcomes.

### Prior-art research and what was adopted

Reviewed CodeRabbit's autofix skill, nakamasato's `resolve-gh-review-comment`, alchemiststudios' `coderabbit-fix-flow`, claude-code-action docs, and Copilot Workspace's "Implement all suggestions". Adopted:

- `--resolve` opt-in with `resolveReviewThread` mutation (from nakamasato — correct REST endpoint for thread replies confirmed here too).
- Post-commit validation gate: run pre-commit + task-specific tests between the commit and the "Fixed in X" reply; downgrade outcome if validation fails (from alchemiststudios).

Novel vs. prior art (kept deliberately):

- Checking current code state via `git log` + file Read to detect "already addressed" before acting — everyone else trusts `isResolved`.
- Semantic grouping of related asks into one commit — CodeRabbit sorts by severity, others go one-at-a-time.
- Per-thread replies as primary mechanism — most prior art posts a single summary comment. Per-thread replies preserve discussion context on the code line.

### Motivating incident

Run 24615807829 (auto-review on PR #1546 after PR #1552 merged) actually fixed jakob's latest comment via a targeted commit (`3c748e9` → `3c81dd7`), but never posted a reply on jakob's inline thread — only updated the sticky top-level comment. Two older CHANGES_REQUESTED reviews from 2026-04-13 were not considered at all because they didn't surface in the current diff. `/analyze-pr-feedback` forces the explicit enumeration that the diff-only path was missing.

### Assumptions

- Scoped to `claude[bot]`-authored PRs only for the auto-commit behavior (not `github-actions[bot]` or `dependabot[bot]`). Other bots manage their own PRs.
- GraphQL fetches 100 threads × 50 comments + 100 top-level comments + 50 reviews — sufficient for any realistic PR on this repo.
- The slash command is read-only by itself; all POST/PATCH actions (replies, commits, resolutions) are taken by the caller after following the outcome rubric.
- Prompt-only change; no workflow YAML, no new triggers.

### Checklist for All Submissions

- [ ] CHANGES.rst — N/A, prompt-only change with no library behavior change.
- [ ] Resolving an issue — N/A, follow-up to run 24615807829 on PR #1546.
- [ ] New feature — N/A, internal tooling improvement.

### Checklist when updating botocore and/or aiohttp versions

- [ ] Not applicable — no dependency bump.

### Test plan

- [ ] Re-run PR #1546's auto-review (Update branch or new push) and confirm:
  - `/analyze-pr-feedback` is invoked with no `--focus`.
  - Jakob's three review threads each get a per-thread reply (already-fixed with the 3c81dd7 SHA + permalink, or fix-now if any drift).
  - No duplicate commits for already-addressed items.
  - Your `"@jakob-keller working on this..."` top-level comment is explicitly left alone and noted as non-actionable in the summary.
  - Final top-level summary covers buckets A/B/C with permalinks.
- [ ] @claude in a fresh PR comment on PR #1546 and confirm `/analyze-pr-feedback --focus=$COMMENT_ID` runs and the focused thread is ranked first.
- [ ] Confirm human-authored PRs are unaffected (section scoped to `claude[bot]` author).
- [ ] Confirm dependabot PRs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)