### PR TITLE
Use bun-download-url to actually bypass the GitHub API rate limit

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -102,15 +102,18 @@ jobs:
       run: uv sync
 
     # Pre-install bun so the claude-code-action's bundled setup-bun
-    # step can short-circuit. Without this, setup-bun fetches the
-    # latest bun version from the GitHub API on every run and has
-    # been 403-rate-limited on the claude[bot] installation token,
-    # crashing the action before Claude runs.
+    # step can short-circuit. Use `bun-download-url` (documented in
+    # setup-bun's README as the escape hatch for rate-limited runners)
+    # to point directly at the releases-download CDN — any other input
+    # (latest, a range like '1.2', or the default package.json lookup)
+    # resolves via the GitHub tags API, which gets 403-rate-limited on
+    # the shared installation token.
     - name: Install bun
       # yamllint disable-line rule:line-length
       uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
       with:
-        bun-version: '1.2'
+        # yamllint disable-line rule:line-length
+        bun-download-url: "https://github.com/oven-sh/bun/releases/latest/download/bun-linux-x64.zip"
 
     - name: Read prompt
       id: prompt


### PR DESCRIPTION
### Description of Change

Follow-up bugfix to PR #1552. The `setup-bun` step added there pinned `bun-version: '1.2'`, thinking a minor
range would avoid the GitHub API. It doesn't — `setup-bun` resolves any range spec (including plain `1.2`) via
the `GET /repos/oven-sh/bun/git/refs/tags` API, which is exactly the 403-rate-limited call we were trying to
dodge. Every Claude run since the PR #1552 merge has still been failing at the `Install bun` step with:

```
Error: Failed to fetch url https://api.github.com/repos/oven-sh/bun/git/refs/tags.
(status code: 403, status text: Forbidden)
```

`setup-bun`'s README documents `bun-download-url` as the explicit escape hatch: point the input at the
releases-download CDN and the action skips the API call entirely. Using the
`releases/latest/download/bun-linux-x64.zip` URL since this runner is ubuntu-latest / x64.

### Assumptions

- Only the Claude workflow (`.github/workflows/claude.yml`) is affected; other workflows don't use setup-bun.
- `releases/latest/download/*` URLs are rate-limit-free (they're CDN-backed asset downloads, not REST API
  calls — confirmed by setup-bun's own README which recommends this path).
- ubuntu-latest x64 is the only platform we target for this job; no need for a cross-platform URL template.
- Pinning to `latest` (vs. an exact patch) is fine because the Claude workflow doesn't care about bun
  reproducibility — it just needs bun on PATH for claude-code-action's internal use.

### Checklist for All Submissions

- [ ] CHANGES.rst — N/A, workflow-only change with no library behavior impact.
- [ ] Resolving an issue — N/A, follow-up to PR #1552.
- [ ] New feature — N/A, bugfix.

### Checklist when updating botocore and/or aiohttp versions

- [ ] Not applicable — no dependency bump.

### Test plan

- [ ] Trigger any Claude workflow run (any event) and confirm the `Install bun` step completes successfully
  without a 403.
- [ ] Confirm the subsequent `claude-code-action` step runs Claude to completion (no "bun: command not found"
  tail error).
- [ ] Confirm the next botocore-sync run — which uses `claude.yml`'s approach indirectly — also passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)