### PR TITLE
Skip bundled setup-bun via path_to_bun_executable

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -101,13 +101,15 @@ jobs:
     - name: Install dependencies
       run: uv sync
 
-    # Pre-install bun so the claude-code-action's bundled setup-bun
-    # step can short-circuit. Use `bun-download-url` (documented in
-    # setup-bun's README as the escape hatch for rate-limited runners)
-    # to point directly at the releases-download CDN — any other input
-    # (latest, a range like '1.2', or the default package.json lookup)
-    # resolves via the GitHub tags API, which gets 403-rate-limited on
-    # the shared installation token.
+    # Pre-install bun and hand its path to claude-code-action so the
+    # action's bundled setup-bun step (which would otherwise resolve a
+    # `1.3.6` pin via the GitHub tags API and get 403 rate-limited on
+    # the shared installation token) is skipped entirely. The action
+    # has a `path_to_bun_executable` input specifically for this
+    # case: when set, its `Setup Bun` step is bypassed.
+    #
+    # We use `bun-download-url` on our own setup-bun call to point
+    # straight at the releases-download CDN — also to avoid the API.
     - name: Install bun
       # yamllint disable-line rule:line-length
       uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
@@ -170,6 +172,9 @@ jobs:
         # Show tracking comments during long-running runs so reviewers
         # see progress instead of a silent ~30s–30min gap.
         track_progress: true
+        # Skip the action's bundled setup-bun step — we installed bun
+        # ourselves above via the rate-limit-safe download URL.
+        path_to_bun_executable: /home/runner/.bun/bin/bun
         prompt: ${{ steps.prompt.outputs.PROMPT }}
         claude_args: |
           --dangerously-skip-permissions


### PR DESCRIPTION
### Description of Change

Follow-up to PR #1554. That PR made our own `Install bun` step pass, but run 24616386915 showed
claude-code-action's **bundled** `Setup Bun` step runs independently and still hits the same 403:

```
Error: Failed to fetch url https://api.github.com/repos/oven-sh/bun/git/refs/tags.
(status code: 403, status text: Forbidden)
```

Looking at `claude-code-action@v1.0.101`'s `action.yml`, the bundled setup-bun step has:

```yaml
- name: Setup Bun
  if: inputs.path_to_bun_executable == ''
  uses: oven-sh/setup-bun@3d267786...  # v2.1.2
  with:
    bun-version: 1.3.6
    token: ${{ inputs.github_token || github.token }}
```

That `if:` guard means when we pass `path_to_bun_executable`, the action skips its own setup-bun entirely
and uses the path we supply. Exactly the escape hatch we need.

**Change:** pass `path_to_bun_executable: /home/runner/.bun/bin/bun` (the default install location for
setup-bun with our `bun-download-url` configuration) to claude-code-action.

### Bonus: fixes the Node 20 deprecation warning

The bundled setup-bun (v2.1.2, `using: "node20"`) was also the sole source of the
`Node.js 20 actions are deprecated` warning we were seeing on every run. All four of our top-level pinned
actions (`checkout` v6, `setup-uv` v8.1.0, `setup-bun` v2.2.0, `claude-code-action` v1.0.101) are already
on Node 24 — audited with:

```
for action in <pinned SHAs>; do ... grep -oE "node[0-9]+"; done
# all → node24
```

So skipping the nested v2.1.2 step silences the deprecation warning as a side effect. No additional
version bumps needed.

### Assumptions

- `/home/runner/.bun/bin/bun` is the default install location when `oven-sh/setup-bun` downloads directly
  via `bun-download-url` — confirmed in run 24616386915's log: `[command]/home/runner/.bun/bin/bun
  --revision`. If a future setup-bun release changes this path, we'd need to derive it from the step's
  output instead; not an issue today.
- The bundled `setup-bun` `if:` guard semantics won't change in patch releases of claude-code-action. If
  claude-code-action removes or renames `path_to_bun_executable`, the input would silently no-op and we'd
  go back to the 403 — worth flagging on future version bumps.
- We don't need the version pinning that claude-code-action would have used (`bun-version: 1.3.6`);
  `releases/latest` on the CDN is fine since bun is only used by claude-code-action's internal scripts
  which are tested against recent bun releases.

### Checklist for All Submissions

- [ ] CHANGES.rst — N/A, workflow-only change with no library behavior impact.
- [ ] Resolving an issue — N/A, follow-up to PR #1554.
- [ ] New feature — N/A, bugfix.

### Checklist when updating botocore and/or aiohttp versions

- [ ] Not applicable — no dependency bump.

### Test plan

- [ ] Trigger any Claude workflow run and confirm:
  - The `Install bun` step succeeds (unchanged from PR #1554).
  - The `Run anthropics/claude-code-action` step's internal setup-bun is **skipped** (no longer fires at
    all — check for absence of `##[group]Setup Bun` in logs).
  - No `Node.js 20 actions are deprecated` warning appears.
  - Claude runs to completion and posts its sticky PR comment.
- [ ] Confirm the botocore-sync workflow is unaffected (it uses the same workflow pattern indirectly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)