### PR TITLE
docs: fix README naked URL and CONTRIBUTING Sphinx roles

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -84,16 +84,16 @@ botocore calls eventually called.
 
 The best way I've seen to upgrade botocore support is by performing the following:
 
-1. Download sources of the release of botocore you're trying to upgrade to, and the version of botocore that aiobotocore is currently locked to (see :file:`pyproject.toml`) and do a folder based file comparison of the botocore folders (tools like DiffMerge are nice).
+1. Download sources of the release of botocore you're trying to upgrade to, and the version of botocore that aiobotocore is currently locked to (see ``pyproject.toml``) and do a folder based file comparison of the botocore folders (tools like DiffMerge are nice).
 2. Manually apply the relevant changes to their aiobotocore equivalent(s). Note that sometimes new functions are added which will need to be overridden (like ``__enter__`` -> ``__aenter__``)
-3. Update the "project.optional-dependencies" in :file:`pyproject.toml` to the versions which match the botocore version you are targeting.
+3. Update the "project.optional-dependencies" in ``pyproject.toml`` to the versions which match the botocore version you are targeting.
 4. Now do a directory diff between aiobotocore and your target version botocore directory to ensure the changes were propagated.
 
 See next section describing types of changes we must validate and support.
 
 Hashes of Botocore Code (important)
 -----------------------------------
-Because of the way aiobotocore is implemented (see Background section), it is very tightly coupled with botocore.  The validity of these couplings are enforced in :file:`test_patches.py`.  We also depend on some private properties in aiohttp, and because of this have entries in :file:`test_patches.py` for this too.
+Because of the way aiobotocore is implemented (see Background section), it is very tightly coupled with botocore.  The validity of these couplings are enforced in ``test_patches.py``.  We also depend on some private properties in aiohttp, and because of this have entries in ``test_patches.py`` for this too.
 
 These patches are important to catch cases where botocore functionality was added/removed and needs to be reflected in our overridden methods.  Changes include:
 
@@ -101,14 +101,14 @@ These patches are important to catch cases where botocore functionality was adde
 * classes/methods being moved to new files
 * bodies of overridden methods updated
 
-To ensure we catch and reflect this changes in aiobotocore, the :file:`test_patches.py` file has the hashes of the parts of botocore we need to manually validate changes in.
+To ensure we catch and reflect this changes in aiobotocore, the ``test_patches.py`` file has the hashes of the parts of botocore we need to manually validate changes in.
 
-:file:`test_patches.py` file needs to be updated in two scenarios:
+``test_patches.py`` file needs to be updated in two scenarios:
 
-1. You're bumping the supported botocore/aiohttp version. In this case a failure in :file:`test_patches.py` means you need to validate the section of code in aiohttp/botocore that no longer matches the hash in test_patches.py to see if any changes need to be reflected in aiobotocore which overloads, on depends on the code which triggered the hash mismatch.  This could there are new parameters we weren't expecting, parameters that are no longer passed to said overridden function(s), or an overridden function which calls a modified botocore method.  If this is a whole class collision the checks will be more extensive.
+1. You're bumping the supported botocore/aiohttp version. In this case a failure in ``test_patches.py`` means you need to validate the section of code in aiohttp/botocore that no longer matches the hash in test_patches.py to see if any changes need to be reflected in aiobotocore which overloads, on depends on the code which triggered the hash mismatch.  This could there are new parameters we weren't expecting, parameters that are no longer passed to said overridden function(s), or an overridden function which calls a modified botocore method.  If this is a whole class collision the checks will be more extensive.
 2. You're implementing missing aiobotocore functionality, in which case you need to add entries for all the methods in botocore/aiohttp which you are overriding or depending on private functionality.  For special cases, like when private attributes are used, you may have to hash the whole class so you can catch any case where the private property is used/updated to ensure it matches our expectations.
 
-After you've validated the changes, you can update the hash in :file:`test_patches.py`.
+After you've validated the changes, you can update the hash in ``test_patches.py``.
 
 One would think we could just write enough unittests to catch all cases, however, this is impossible for two reasons:
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -84,16 +84,16 @@ botocore calls eventually called.
 
 The best way I've seen to upgrade botocore support is by performing the following:
 
-1. Download sources of the release of botocore you're trying to upgrade to, and the version of botocore that aiobotocore is currently locked to (see ``pyproject.toml``) and do a folder based file comparison of the botocore folders (tools like DiffMerge are nice).
+1. Download sources of the release of botocore you're trying to upgrade to, and the version of botocore that aiobotocore is currently locked to (see `pyproject.toml`_) and do a folder based file comparison of the botocore folders (tools like DiffMerge are nice).
 2. Manually apply the relevant changes to their aiobotocore equivalent(s). Note that sometimes new functions are added which will need to be overridden (like ``__enter__`` -> ``__aenter__``)
-3. Update the "project.optional-dependencies" in ``pyproject.toml`` to the versions which match the botocore version you are targeting.
+3. Update the "project.optional-dependencies" in `pyproject.toml`_ to the versions which match the botocore version you are targeting.
 4. Now do a directory diff between aiobotocore and your target version botocore directory to ensure the changes were propagated.
 
 See next section describing types of changes we must validate and support.
 
 Hashes of Botocore Code (important)
 -----------------------------------
-Because of the way aiobotocore is implemented (see Background section), it is very tightly coupled with botocore.  The validity of these couplings are enforced in ``test_patches.py``.  We also depend on some private properties in aiohttp, and because of this have entries in ``test_patches.py`` for this too.
+Because of the way aiobotocore is implemented (see Background section), it is very tightly coupled with botocore.  The validity of these couplings are enforced in `test_patches.py`_.  We also depend on some private properties in aiohttp, and because of this have entries in `test_patches.py`_ for this too.
 
 These patches are important to catch cases where botocore functionality was added/removed and needs to be reflected in our overridden methods.  Changes include:
 
@@ -101,14 +101,14 @@ These patches are important to catch cases where botocore functionality was adde
 * classes/methods being moved to new files
 * bodies of overridden methods updated
 
-To ensure we catch and reflect this changes in aiobotocore, the ``test_patches.py`` file has the hashes of the parts of botocore we need to manually validate changes in.
+To ensure we catch and reflect this changes in aiobotocore, the `test_patches.py`_ file has the hashes of the parts of botocore we need to manually validate changes in.
 
-``test_patches.py`` file needs to be updated in two scenarios:
+`test_patches.py`_ file needs to be updated in two scenarios:
 
-1. You're bumping the supported botocore/aiohttp version. In this case a failure in ``test_patches.py`` means you need to validate the section of code in aiohttp/botocore that no longer matches the hash in test_patches.py to see if any changes need to be reflected in aiobotocore which overloads, on depends on the code which triggered the hash mismatch.  This could there are new parameters we weren't expecting, parameters that are no longer passed to said overridden function(s), or an overridden function which calls a modified botocore method.  If this is a whole class collision the checks will be more extensive.
+1. You're bumping the supported botocore/aiohttp version. In this case a failure in `test_patches.py`_ means you need to validate the section of code in aiohttp/botocore that no longer matches the hash in test_patches.py to see if any changes need to be reflected in aiobotocore which overloads, on depends on the code which triggered the hash mismatch.  This could there are new parameters we weren't expecting, parameters that are no longer passed to said overridden function(s), or an overridden function which calls a modified botocore method.  If this is a whole class collision the checks will be more extensive.
 2. You're implementing missing aiobotocore functionality, in which case you need to add entries for all the methods in botocore/aiohttp which you are overriding or depending on private functionality.  For special cases, like when private attributes are used, you may have to hash the whole class so you can catch any case where the private property is used/updated to ensure it matches our expectations.
 
-After you've validated the changes, you can update the hash in ``test_patches.py``.
+After you've validated the changes, you can update the hash in `test_patches.py`_.
 
 One would think we could just write enough unittests to catch all cases, however, this is impossible for two reasons:
 
@@ -141,3 +141,6 @@ The Future
 The long term goal is that botocore will implement async functionality directly.
 See botocore issue: https://github.com/boto/botocore/issues/458  for details,
 tracked in aiobotocore here: https://github.com/aio-libs/aiobotocore/issues/36
+
+.. _pyproject.toml: https://github.com/aio-libs/aiobotocore/blob/main/pyproject.toml
+.. _test_patches.py: https://github.com/aio-libs/aiobotocore/blob/main/tests/test_patches.py

--- a/README.rst
+++ b/README.rst
@@ -199,7 +199,7 @@ For ``types-aiobotocore-lite`` package use explicit type annotations:
         # type checking and code completion is now enabled for client
 
 
-See the `types-aiobotocore documentation <https://youtype.github.io/types_aiobotocore_docs/>`_ for full reference.
+See the `types-aiobotocore <https://youtype.github.io/types_aiobotocore_docs/>`_ documentation for full reference.
 
 
 Requirements

--- a/README.rst
+++ b/README.rst
@@ -199,7 +199,7 @@ For ``types-aiobotocore-lite`` package use explicit type annotations:
         # type checking and code completion is now enabled for client
 
 
-Full documentation for ``types-aiobotocore`` can be found here: https://youtype.github.io/types_aiobotocore_docs/
+Full documentation for types-aiobotocore_ is available online.
 
 
 Requirements

--- a/README.rst
+++ b/README.rst
@@ -199,7 +199,7 @@ For ``types-aiobotocore-lite`` package use explicit type annotations:
         # type checking and code completion is now enabled for client
 
 
-See the `types-aiobotocore <https://youtype.github.io/types_aiobotocore_docs/>`_ documentation for full reference.
+See the `types-aiobotocore <https://youtype.github.io/types_aiobotocore_docs/>`__ documentation for full reference.
 
 
 Requirements

--- a/README.rst
+++ b/README.rst
@@ -199,7 +199,7 @@ For ``types-aiobotocore-lite`` package use explicit type annotations:
         # type checking and code completion is now enabled for client
 
 
-Full documentation for types-aiobotocore_ is available online.
+See the `types-aiobotocore documentation <https://youtype.github.io/types_aiobotocore_docs/>`_ for full reference.
 
 
 Requirements


### PR DESCRIPTION
### Description of Change

Small rendering fixes to the top-level RST files where links were broken or missing.

**README.rst — types-aiobotocore documentation link**

The sentence `Full documentation for ``types-aiobotocore`` can be found here: <naked URL>` read awkwardly on PyPI and GitHub — a bare URL trailing prose next to inline-code styling. Rewrote as a proper inline hyperlink where "types-aiobotocore" is the clickable link text and the URL is the target:

```rst
See the `types-aiobotocore <https://youtype.github.io/types_aiobotocore_docs/>`_ documentation for full reference.
```

**CONTRIBUTING.rst — make file references clickable**

Seven uses of Sphinx's `:file:` role were rendering literally as `:file:\`pyproject.toml\`` on GitHub (GitHub's RST renderer doesn't understand Sphinx-only roles). Beyond fixing the broken rendering, `:file:` was only semantic styling and never produced a link either on RTD. Replace with named RST hyperlink targets so these references actually navigate to the files in the repo on both GitHub and RTD:

```rst
.. _pyproject.toml: https://github.com/aio-libs/aiobotocore/blob/main/pyproject.toml
.. _test_patches.py: https://github.com/aio-libs/aiobotocore/blob/main/tests/test_patches.py
```

Used throughout the file as `` `pyproject.toml`_ `` (2 uses) and `` `test_patches.py`_ `` (5 uses).

### Assumptions

- No CHANGES.rst entry needed — docs-only, no runtime/API impact.
- Absolute `github.com/aio-libs/aiobotocore/blob/main/...` URLs are used so the links resolve both on GitHub (where CONTRIBUTING.rst is viewed directly) and on RTD (where `docs/contributing.rst` is just `.. include:: ../CONTRIBUTING.rst`). Relative paths wouldn't work from the RTD-rendered location.

### Checklist for All Submissions

* [ ] CHANGES.rst — N/A, no runtime/library changes.
* [x] Linked issue — N/A, reported directly.
* [ ] New feature — N/A.

### Checklist when updating botocore and/or aiohttp versions

N/A — no version changes.
