### PR TITLE
AI workflows: classifier accuracy, structured verdicts, port-tests skill

### DIFF
--- a/.github/botocore-sync-prompt.md
+++ b/.github/botocore-sync-prompt.md
@@ -284,6 +284,12 @@ feedback instead of guessing.
    is `CONTRIBUTING.rst` §"How to Upgrade Botocore" step 4.
 4. Run `/aiobotocore-bot:bump-version --mode=port --target=$LATEST_BOTOCORE`. The skill updates both
    `pyproject.toml` bounds, bumps MINOR version, writes the `CHANGES.rst` entry, and runs `uv lock`.
+5. Run `/aiobotocore-bot:port-tests --from=$LAST_SUPPORTED --to=$LATEST_BOTOCORE`. The skill identifies
+   new/changed tests in the botocore diff for files that have an aiobotocore mirror, applies the
+   sync→async conversion rules, validates each ported file with `pytest -x`, and commits on pass.
+   Files that fail validation are reverted and listed in the skill's report for human review.
+   Include the skill's report in the port PR's "What changed in aiobotocore" section so the
+   reviewer can see both successfully-ported tests and anything that needs manual attention.
 
 ### test_patches.py scenarios
 
@@ -387,6 +393,9 @@ Create or update the final PR via `/aiobotocore-bot:open-pr`:
 - `--mode=sync-no-port` or `--mode=sync-port`
 - `--botocore-diff-url=https://github.com/boto/botocore/compare/OLD...NEW`
 - `--async-need-summary="<the summary from /aiobotocore-bot:check-async-need>"` (no-port only)
+- `--classifier-verdicts="<the per-function rationale block from /aiobotocore-bot:check-async-need>"`
+  (both modes — `open-pr` renders this as a markdown table so the human reviewer can spot-check
+  each function's verdict and reason without re-running the classifier)
 - `--changed-aiobotocore="<files/classes/tests for port, or 'Version bounds updated only, no code changes.' for no-port>"`
 - `--assumptions="<design decisions>"` (port only, if any)
 

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -254,6 +254,7 @@ jobs:
         claude_args: |
           --dangerously-skip-permissions
           --max-turns 100
+          --effort high
         # yamllint disable rule:line-length
         settings: |
           {

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -254,7 +254,7 @@ jobs:
         claude_args: |
           --dangerously-skip-permissions
           --max-turns 100
-          --effort high
+          --model opus
         # yamllint disable rule:line-length
         settings: |
           {

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -195,8 +195,20 @@ jobs:
         python-version: '3.12'
         enable-cache: auto
 
+    # Cache .venv directly — setup-uv covers the download cache
+    # (wheels) but `uv sync` still walks the lockfile and re-links the
+    # venv. Keyed on uv.lock + pyproject.toml so any dep change
+    # invalidates.
+    - name: Cache .venv
+      # yamllint disable-line rule:line-length
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
+      with:
+        path: .venv
+        # yamllint disable-line rule:line-length
+        key: venv-${{ runner.os }}-py3.12-${{ hashFiles('uv.lock', 'pyproject.toml') }}
+
     - name: Install dependencies
-      run: uv sync
+      run: uv sync --frozen
 
     - name: Cache botocore repo
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -121,8 +121,19 @@ jobs:
         python-version: '3.12'
         enable-cache: auto
 
+    # Cache .venv — setup-uv covers the download cache (wheels) but
+    # `uv sync` still walks the lockfile and re-links the venv. Keyed
+    # on uv.lock + pyproject.toml so any dep change invalidates.
+    - name: Cache .venv
+      # yamllint disable-line rule:line-length
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
+      with:
+        path: .venv
+        # yamllint disable-line rule:line-length
+        key: venv-${{ runner.os }}-py3.12-${{ hashFiles('uv.lock', 'pyproject.toml') }}
+
     - name: Install dependencies
-      run: uv sync
+      run: uv sync --frozen
 
     # Pre-install bun and hand its path to claude-code-action so the
     # action's bundled setup-bun step (which would otherwise resolve a

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -222,6 +222,7 @@ jobs:
         claude_args: |
           --dangerously-skip-permissions
           --plugin-dir plugins/aiobotocore-bot
+          --model opus
         # yamllint disable rule:line-length
         settings: |
           {

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -52,6 +52,11 @@ on:
         required: false
         default: ''
         type: string
+      debug_misclassifications:
+        description: On miss, ask the model which rule misled it (captured in JSON)
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   check-async-need:
@@ -68,6 +73,7 @@ jobs:
       EVAL_RUNS: ${{ inputs.runs || '3' }}
       EVAL_LIMIT: ${{ inputs.limit || '8' }}
       EVAL_CASES: ${{ inputs.cases || '' }}
+      EVAL_DEBUG_MISCLASSIFICATIONS: ${{ inputs.debug_misclassifications && '1' || '' }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
@@ -140,10 +146,15 @@ jobs:
           IFS=',' read -ra arr <<< "$EVAL_CASES"
           for n in "${arr[@]}"; do case_args+=(--case "${n// /}"); done
         fi
+        debug_arg=()
+        if [ -n "$EVAL_DEBUG_MISCLASSIFICATIONS" ]; then
+          debug_arg=(--debug-misclassifications)
+        fi
         uv run python plugins/aiobotocore-bot/evals/check_async_need.py \
           --runs "$EVAL_RUNS" \
           --limit "$EVAL_LIMIT" \
           "${case_args[@]}" \
+          "${debug_arg[@]}" \
           --json-out /tmp/async-need-results.json \
           | tee /tmp/async-need-stdout.txt
 

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -47,6 +47,11 @@ on:
         required: false
         default: '8'
         type: string
+      cases:
+        description: Comma-separated PR numbers to evaluate (empty = use limit)
+        required: false
+        default: ''
+        type: string
 
 jobs:
   check-async-need:
@@ -62,6 +67,7 @@ jobs:
     env:
       EVAL_RUNS: ${{ inputs.runs || '3' }}
       EVAL_LIMIT: ${{ inputs.limit || '8' }}
+      EVAL_CASES: ${{ inputs.cases || '' }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
@@ -112,9 +118,15 @@ jobs:
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         BOTOCORE_CLONE: /tmp/botocore
       run: |
+        case_args=()
+        if [ -n "$EVAL_CASES" ]; then
+          IFS=',' read -ra arr <<< "$EVAL_CASES"
+          for n in "${arr[@]}"; do case_args+=(--case "${n// /}"); done
+        fi
         uv run python plugins/aiobotocore-bot/evals/check_async_need.py \
           --runs "$EVAL_RUNS" \
           --limit "$EVAL_LIMIT" \
+          "${case_args[@]}" \
           --json-out /tmp/async-need-results.json \
           | tee /tmp/async-need-stdout.txt
 

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -110,8 +110,25 @@ jobs:
         python-version: '3.12'
         enable-cache: auto
 
+    # .venv caching: setup-uv caches uv's download cache (wheels), but
+    # `uv sync` still walks the lockfile and re-links the venv every
+    # run (~5-15s). Caching .venv directly short-circuits that on
+    # lockfile-unchanged runs. Invalidates on uv.lock or pyproject.toml
+    # changes.
+    - name: Cache .venv
+      # yamllint disable-line rule:line-length
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
+      with:
+        path: .venv
+        # yamllint disable-line rule:line-length
+        key: venv-${{ runner.os }}-py3.12-${{ hashFiles('uv.lock', 'pyproject.toml') }}
+
     - name: Install dependencies
-      run: uv sync
+      # --frozen is a guardrail: fail (not silently resolve) if uv.lock
+      # is somehow out of sync with pyproject.toml. On a warm .venv
+      # cache uv sync is near-instant; on a miss it re-links from the
+      # uv download cache.
+      run: uv sync --frozen
 
     - name: Run check_async_need eval
       env:
@@ -175,8 +192,25 @@ jobs:
         python-version: '3.12'
         enable-cache: auto
 
+    # .venv caching: setup-uv caches uv's download cache (wheels), but
+    # `uv sync` still walks the lockfile and re-links the venv every
+    # run (~5-15s). Caching .venv directly short-circuits that on
+    # lockfile-unchanged runs. Invalidates on uv.lock or pyproject.toml
+    # changes.
+    - name: Cache .venv
+      # yamllint disable-line rule:line-length
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
+      with:
+        path: .venv
+        # yamllint disable-line rule:line-length
+        key: venv-${{ runner.os }}-py3.12-${{ hashFiles('uv.lock', 'pyproject.toml') }}
+
     - name: Install dependencies
-      run: uv sync
+      # --frozen is a guardrail: fail (not silently resolve) if uv.lock
+      # is somehow out of sync with pyproject.toml. On a warm .venv
+      # cache uv sync is near-instant; on a miss it re-links from the
+      # uv download cache.
+      run: uv sync --frozen
 
     - name: Run check_override_drift eval
       env:

--- a/plugins/aiobotocore-bot/README.md
+++ b/plugins/aiobotocore-bot/README.md
@@ -41,6 +41,12 @@ design; this README only covers the plugin itself.
   mechanical updates: `pyproject.toml` bounds, `aiobotocore/__init__.py`
   version, `CHANGES.rst` entry (with correct `^` underline length),
   and `uv lock`.
+- `/aiobotocore-bot:port-tests [--from=<ver> --to=<ver>] [--backfill] [--paths=...]`
+  — convert botocore tests to aiobotocore-equivalent async form.
+  Two modes: port-PR (given a botocore version range, port new/changed
+  tests into the existing mirrored files) and backfill (port
+  not-yet-ported tests from the specified mirrored files). Validates
+  each file with `pytest -x`; commits on pass, reverts + advises on fail.
 - `/aiobotocore-bot:pyright-delta` — create a baseline worktree at
   origin/main, run pyright there, remove worktree, run pyright with
   current changes, report only new errors in files the changes touched.

--- a/plugins/aiobotocore-bot/evals/_common.py
+++ b/plugins/aiobotocore-bot/evals/_common.py
@@ -338,15 +338,14 @@ def new_client() -> anthropic.AsyncAnthropic:
     return anthropic.AsyncAnthropic()
 
 
-# Extended-thinking budget for Sonnet. The classifier has to walk
-# every changed function + consult three registries + apply the
-# Step-4 roll-up + sanity-check before committing to a verdict —
-# exactly the kind of work where thinking tokens pay off. 8K is
-# enough headroom for ~15 functions × several hundred reasoning
-# tokens each. Smaller Sonnet runs (4.6) charge for thinking tokens
-# but at the sync-only eval frequency (manual workflow_dispatch)
-# the absolute cost is negligible.
-THINKING_BUDGET_TOKENS = 8000
+# Adaptive thinking for the classifier. The work (walk every changed
+# function + consult three registries + apply roll-up + sanity-check
+# before committing) is exactly what thinking tokens pay for.
+# `adaptive` + `effort: high` is Anthropic's recommended shape for
+# Sonnet 4.6 (manual `budget_tokens` is deprecated). Mirrors the
+# `--effort high` setting on the claude-code-action-driven sync
+# workflow so eval and runtime share reasoning depth.
+THINKING_EFFORT = "high"
 
 
 async def invoke_and_parse(
@@ -361,22 +360,20 @@ async def invoke_and_parse(
     The verdict regex should capture the verdict string as group 1 (e.g.
     `^CLASSIFICATION:\\s*(\\S+)`).
 
-    Enables extended thinking so Sonnet can reason through each
-    changed function before committing to the top-line verdict —
+    Enables adaptive extended thinking so Sonnet can reason through
+    each changed function before committing to the top-line verdict —
     classification-style problems regress without it.
 
     The system prompt uses ephemeral cache_control so repeated calls
     within the same eval session (N runs × M cases ≈ 96 calls at
     defaults) hit the cache on the ~2K-token command body.
     """
-    # max_tokens must be > budget_tokens (thinking + response share
-    # the envelope). 16K leaves ~8K for the actual response.
     resp = await client.messages.create(
         model=model,
         max_tokens=16000,
         thinking={
-            "type": "enabled",
-            "budget_tokens": THINKING_BUDGET_TOKENS,
+            "type": "adaptive",
+            "effort": THINKING_EFFORT,
         },
         system=[
             {

--- a/plugins/aiobotocore-bot/evals/_common.py
+++ b/plugins/aiobotocore-bot/evals/_common.py
@@ -68,13 +68,18 @@ def overridden_symbols() -> set[str]:
     aiobotocore overrides.
 
     Each entry in the `test_patches` pytest.mark.parametrize body is
-    `(<symbol-reference>, {hashes})`. The symbol is either a bare name
-    (`_apply_request_trailer_checksum`) or an attribute chain
-    (`ClientArgsCreator.get_client_args`).
+    `(<symbol-reference>, {hashes})`. Three shapes are possible:
 
-    Returns a flat set containing both the full dotted name
-    (`ClientArgsCreator.get_client_args`) AND the tail component
-    (`get_client_args`) so name-only matches from diff hunks work too.
+    - Bare module-level function (`_apply_request_trailer_checksum`) —
+      returned as-is.
+    - Class method (`ClientArgsCreator.get_client_args`) — returned in
+      dotted form only. The bare tail is intentionally NOT added, so a
+      change to `SomeOtherClass.get_client_args` elsewhere doesn't
+      falsely match.
+    - Bare class name (`URLLib3Session`) — returned as-is, meaning the
+      class's whole source is tracked but NOT that every method is
+      mirrored. Callers must not generalize class-tracked to method-
+      tracked.
     """
     names: set[str] = set()
     tree = ast.parse(TEST_PATCHES_PATH.read_text())
@@ -90,7 +95,6 @@ def overridden_symbols() -> set[str]:
             parts.append(target.id)
             parts.reverse()
             names.add(".".join(parts))
-            names.add(parts[-1])
     return names
 
 

--- a/plugins/aiobotocore-bot/evals/_common.py
+++ b/plugins/aiobotocore-bot/evals/_common.py
@@ -34,6 +34,93 @@ DEFAULT_MODEL = "claude-opus-4-7"
 UPPER_RE = re.compile(r'"botocore\s*>=\s*[\d.]+\s*,\s*<\s*([\d.]+)"')
 LOWER_RE = re.compile(r'"botocore\s*>=\s*([\d.]+)\s*,')
 
+# Per-million-token pricing (USD) for models we actually run the evals
+# against. From https://platform.claude.com/docs/en/about-claude/pricing
+# as of 2026-04-19. Update when Anthropic publishes new rates.
+# `cache_write_5m` is the short-duration write price; `cache_read` is
+# any cache-hit read. Thinking tokens bill as `output`.
+MODEL_PRICING: dict[str, dict[str, float]] = {
+    "claude-opus-4-7": {
+        "input": 5.0,
+        "output": 25.0,
+        "cache_write_5m": 6.25,
+        "cache_read": 0.50,
+    },
+    "claude-sonnet-4-6": {
+        "input": 3.0,
+        "output": 15.0,
+        "cache_write_5m": 3.75,
+        "cache_read": 0.30,
+    },
+    "claude-haiku-4-5": {
+        "input": 1.0,
+        "output": 5.0,
+        "cache_write_5m": 1.25,
+        "cache_read": 0.10,
+    },
+}
+
+
+# Per-model usage accumulator updated by every invoke_and_* call in
+# this module. Single-event-loop asyncio so no lock needed.
+_USAGE: dict[str, dict[str, int]] = {}
+
+
+def _record_usage(model: str, usage: object) -> None:
+    """Accumulate token counts from a Messages API response into the
+    module-level tally. `usage` is the `resp.usage` attribute.
+    """
+    bucket = _USAGE.setdefault(
+        model,
+        {
+            "input": 0,
+            "output": 0,
+            "cache_write_5m": 0,
+            "cache_read": 0,
+            "calls": 0,
+        },
+    )
+    bucket["calls"] += 1
+    bucket["input"] += getattr(usage, "input_tokens", 0) or 0
+    bucket["output"] += getattr(usage, "output_tokens", 0) or 0
+    bucket["cache_write_5m"] += (
+        getattr(usage, "cache_creation_input_tokens", 0) or 0
+    )
+    bucket["cache_read"] += getattr(usage, "cache_read_input_tokens", 0) or 0
+
+
+def usage_summary() -> str:
+    """Render a human-readable token+cost breakdown of the eval session.
+
+    Returns empty string if no API calls were made. Lines are one per
+    model: call count, each token bucket, and estimated cost.
+    """
+    if not _USAGE:
+        return ""
+    lines = ["", "== Token usage / cost =="]
+    grand_total = 0.0
+    for model, u in sorted(_USAGE.items()):
+        p = MODEL_PRICING.get(model)
+        if p is None:
+            lines.append(f"  {model}: {u} (pricing unknown)")
+            continue
+        cost = (
+            u["input"] * p["input"]
+            + u["output"] * p["output"]
+            + u["cache_write_5m"] * p["cache_write_5m"]
+            + u["cache_read"] * p["cache_read"]
+        ) / 1_000_000
+        grand_total += cost
+        lines.append(
+            f"  {model}: {u['calls']} calls, "
+            f"in={u['input']:,}, out={u['output']:,}, "
+            f"cache_r={u['cache_read']:,}, cache_w={u['cache_write_5m']:,}"
+            f" → ${cost:.4f}"
+        )
+    if len(_USAGE) > 1:
+        lines.append(f"  Total: ${grand_total:.4f}")
+    return "\n".join(lines)
+
 
 def require_env(name: str) -> None:
     if name not in os.environ:
@@ -423,13 +510,20 @@ async def invoke_and_classify(
     `raw_text` captures any text blocks the model emitted alongside the
     tool call — useful for debugging and for the follow-up-on-miss flow.
 
+    16K max_tokens headroom: per-function verdict arrays for 10+ changed
+    functions plus reasoning text can exceed 4K. A truncated tool_use
+    block returns empty-dict input and a `parse-error` verdict —
+    previously this manifested as mysterious failures on large PRs.
+    Stop reason is surfaced in `raw_text` on truncation so debugging
+    rationales show the cause.
+
     The system prompt uses ephemeral cache_control so repeated calls
     within the same eval session (N runs × M cases ≈ 96 calls at
     defaults) hit the cache on the ~2K-token command body.
     """
     resp = await client.messages.create(
         model=model,
-        max_tokens=4096,
+        max_tokens=16000,
         tools=[tool],
         tool_choice={"type": "tool", "name": tool["name"]},
         system=[
@@ -441,11 +535,14 @@ async def invoke_and_classify(
         ],
         messages=[{"role": "user", "content": user}],
     )
+    _record_usage(model, resp.usage)
     raw = "".join(
         block.text
         for block in resp.content
         if getattr(block, "type", None) == "text"
     )
+    if resp.stop_reason and resp.stop_reason != "end_turn":
+        raw = f"[stop_reason={resp.stop_reason}]\n{raw}"
     for block in resp.content:
         if getattr(block, "type", None) == "tool_use":
             tool_input = block.input
@@ -495,6 +592,7 @@ async def followup_on_misclassification(
             {"role": "user", "content": followup_q},
         ],
     )
+    _record_usage(model, resp.usage)
     return "".join(
         block.text
         for block in resp.content

--- a/plugins/aiobotocore-bot/evals/_common.py
+++ b/plugins/aiobotocore-bot/evals/_common.py
@@ -387,6 +387,54 @@ async def invoke_and_parse(
     return ("parse-error", raw)
 
 
+async def followup_on_misclassification(
+    client: anthropic.AsyncAnthropic,
+    system: str,
+    user: str,
+    model: str,
+    assistant_reply: str,
+    expected: str,
+    got: str,
+) -> str:
+    """Ask the model, in a continuing conversation, what rule led it to the
+    wrong verdict. Used for prompt-iteration debugging — when eval expected
+    and got diverge, a targeted follow-up often surfaces which phrase in
+    the system prompt Opus/Sonnet anchored on.
+
+    Returns the follow-up assistant text.
+    """
+    followup_q = (
+        f"You classified this as `{got}` but the historical ground-truth "
+        f"label is `{expected}`. Walk through your reasoning step by step: "
+        "which exact phrase or rule in the system prompt led you to the "
+        "verdict you gave? Quote the text you relied on. Then identify "
+        "what would have needed to be different in the prompt for you to "
+        f"arrive at `{expected}` instead. Be specific about which rule "
+        "and which sentence misled (or failed to steer) you."
+    )
+    resp = await client.messages.create(
+        model=model,
+        max_tokens=2048,
+        system=[
+            {
+                "type": "text",
+                "text": system,
+                "cache_control": {"type": "ephemeral"},
+            },
+        ],
+        messages=[
+            {"role": "user", "content": user},
+            {"role": "assistant", "content": assistant_reply},
+            {"role": "user", "content": followup_q},
+        ],
+    )
+    return "".join(
+        block.text
+        for block in resp.content
+        if getattr(block, "type", None) == "text"
+    )
+
+
 async def run_cases_concurrent(
     cases: list,
     runs: int,

--- a/plugins/aiobotocore-bot/evals/_common.py
+++ b/plugins/aiobotocore-bot/evals/_common.py
@@ -430,25 +430,30 @@ def new_client() -> anthropic.AsyncAnthropic:
 def classify_tool_schema(
     tool_name: str,
     verdict_enum: list[str],
-    per_function_label: str,
+    per_function_label: str,  # noqa: ARG001 — kept for API stability
 ) -> dict:
-    """Build a tool schema that forces the model to emit its verdict
-    as structured data instead of regex-parseable text.
+    """Build a minimal tool schema for structured verdict extraction.
 
     `verdict_enum` constrains the top-line classification (e.g.
     `["no-port", "port-required", "ambiguous"]` for check-async-need,
     `["clean", "cosmetic-drift", "behavioral-drift"]` for
-    check-override-drift). `per_function_label` names what each row
-    represents (e.g. "function" or "line").
+    check-override-drift).
+
+    Intentionally schema-light: only `verdict` and `rationale` fields.
+    An earlier version included a rich `per_function_verdicts` array
+    of objects, but Opus 4.7 sometimes emitted an empty tool input
+    (`{}`) on larger PR diffs despite being forced via tool_choice,
+    even with 16K max_tokens and no truncation. The root cause was
+    likely the nested-array schema creating generation ambiguity.
+    `rationale` as a free-form string preserves the per-function
+    detail without the brittleness.
     """
     return {
         "name": tool_name,
         "description": (
             "Emit the final classification. Call this ONCE, at the end, "
-            "after you've reasoned through each changed function in your "
-            "text response. The top-line `verdict` must follow from the "
-            "per-function verdicts via the roll-up rule stated in the "
-            "system prompt."
+            "after you've reasoned through each changed function. "
+            "Include the per-function verdict breakdown in `rationale`."
         ),
         "input_schema": {
             "type": "object",
@@ -458,41 +463,16 @@ def classify_tool_schema(
                     "enum": verdict_enum,
                     "description": "Top-line roll-up classification.",
                 },
-                "summary": {
+                "rationale": {
                     "type": "string",
                     "description": (
-                        "One-line summary of the classification "
-                        "(counts, key drivers)."
+                        "Full reasoning: one paragraph per changed "
+                        "function with file, name, change-type, "
+                        "verdict, and reason. Rollup summary at the end."
                     ),
-                },
-                "per_function_verdicts": {
-                    "type": "array",
-                    "description": (
-                        f"One entry per changed/added/removed {per_function_label}."
-                    ),
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "file": {"type": "string"},
-                            "name": {"type": "string"},
-                            "change_type": {
-                                "type": "string",
-                                "enum": [
-                                    "added",
-                                    "changed",
-                                    "removed",
-                                    "renamed",
-                                    "refactored",
-                                ],
-                            },
-                            "verdict": {"type": "string"},
-                            "reason": {"type": "string"},
-                        },
-                        "required": ["file", "name", "verdict", "reason"],
-                    },
                 },
             },
-            "required": ["verdict", "summary"],
+            "required": ["verdict", "rationale"],
         },
     }
 
@@ -560,22 +540,37 @@ async def followup_on_misclassification(
     expected: str,
     got: str,
 ) -> str:
-    """Ask the model, in a continuing conversation, what rule led it to the
-    wrong verdict. Used for prompt-iteration debugging — when eval expected
-    and got diverge, a targeted follow-up often surfaces which phrase in
-    the system prompt Opus/Sonnet anchored on.
+    """Ask the model, in a continuing conversation, what led to the bad
+    output. Handles two failure modes:
+
+    - Wrong verdict: ask which prompt phrase it anchored on.
+    - Parse error (empty or malformed tool call): ask why it didn't
+      populate the tool input — that's a non-classification failure
+      we otherwise can't diagnose.
 
     Returns the follow-up assistant text.
     """
-    followup_q = (
-        f"You classified this as `{got}` but the historical ground-truth "
-        f"label is `{expected}`. Walk through your reasoning step by step: "
-        "which exact phrase or rule in the system prompt led you to the "
-        "verdict you gave? Quote the text you relied on. Then identify "
-        "what would have needed to be different in the prompt for you to "
-        f"arrive at `{expected}` instead. Be specific about which rule "
-        "and which sentence misled (or failed to steer) you."
-    )
+    if got == "parse-error":
+        followup_q = (
+            "Your response did not produce a usable classification — "
+            "the tool call came back with empty or missing input. Why "
+            "didn't you populate the tool's `verdict` and `rationale` "
+            "fields? Was the prompt unclear, the diff too long to "
+            "reason through, the tool schema confusing, or something "
+            "else? Be specific: what would you have needed to complete "
+            f"the classification (expected answer was `{expected}`)?"
+        )
+    else:
+        followup_q = (
+            f"You classified this as `{got}` but the historical "
+            f"ground-truth label is `{expected}`. Walk through your "
+            "reasoning step by step: which exact phrase or rule in the "
+            "system prompt led you to the verdict you gave? Quote the "
+            "text you relied on. Then identify what would have needed "
+            "to be different in the prompt for you to arrive at "
+            f"`{expected}` instead. Be specific about which rule and "
+            "which sentence misled (or failed to steer) you."
+        )
     resp = await client.messages.create(
         model=model,
         max_tokens=2048,

--- a/plugins/aiobotocore-bot/evals/_common.py
+++ b/plugins/aiobotocore-bot/evals/_common.py
@@ -22,12 +22,14 @@ import anthropic
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 AIOBOTOCORE_DIR = REPO_ROOT / "aiobotocore"
-# Sonnet (not Opus) for the same reason claude-code-action defaults to
-# Sonnet in the other workflows: structured classification with a clear
-# system prompt doesn't need Opus-level reasoning, and Sonnet is faster
-# + ~5× cheaper per call. First-run comparison on this branch showed
-# 8/8 on both eval suites at Opus; Sonnet is expected to match.
-DEFAULT_MODEL = "claude-sonnet-4-6"
+# Opus 4.7 at default effort. The recent Opus 4.5+ pricing drop
+# (to $5/$25 per M input/output, down from $15/$75) narrowed the gap
+# to Sonnet+thinking to ~25%, so the accuracy advantage makes Opus the
+# better cost/quality point. Baseline Opus eval was 8/8 without
+# thinking; Sonnet+thinking was 7/8. Default across eval, sync, and
+# reviewer workflows. Switch back to Sonnet if Opus ever underperforms
+# on the regression suite.
+DEFAULT_MODEL = "claude-opus-4-7"
 
 UPPER_RE = re.compile(r'"botocore\s*>=\s*[\d.]+\s*,\s*<\s*([\d.]+)"')
 LOWER_RE = re.compile(r'"botocore\s*>=\s*([\d.]+)\s*,')
@@ -338,21 +340,6 @@ def new_client() -> anthropic.AsyncAnthropic:
     return anthropic.AsyncAnthropic()
 
 
-# Extended-thinking budget for the classifier. The work (walk every
-# changed function + consult three registries + apply roll-up +
-# sanity-check before committing) is exactly what thinking tokens pay
-# for. `type: enabled, budget_tokens: N` is the stable shape — the
-# newer `type: adaptive, effort: X` is documented for Sonnet 4.6 but
-# the API currently rejects it ("Extra inputs are not permitted" on
-# `anthropic==0.96.0`, 2026-04-19). Switch once upstream ships it.
-#
-# 8K is enough headroom for ~15 functions × several hundred reasoning
-# tokens each. Mirrors the `--effort high` setting on the
-# claude-code-action-driven sync workflow so eval and runtime share
-# reasoning depth.
-THINKING_BUDGET_TOKENS = 8000
-
-
 async def invoke_and_parse(
     client: anthropic.AsyncAnthropic,
     system: str,
@@ -365,9 +352,11 @@ async def invoke_and_parse(
     The verdict regex should capture the verdict string as group 1 (e.g.
     `^CLASSIFICATION:\\s*(\\S+)`).
 
-    Enables adaptive extended thinking so Sonnet can reason through
-    each changed function before committing to the top-line verdict —
-    classification-style problems regress without it.
+    Opus 4.7 at default effort (no explicit extended thinking) is good
+    enough for classification after the #1567 registry-injection work —
+    baseline eval was 8/8 and Opus's default reasoning matches the
+    Sonnet+thinking result at a smaller price premium under the new
+    Opus pricing tier.
 
     The system prompt uses ephemeral cache_control so repeated calls
     within the same eval session (N runs × M cases ≈ 96 calls at
@@ -375,11 +364,7 @@ async def invoke_and_parse(
     """
     resp = await client.messages.create(
         model=model,
-        max_tokens=16000,
-        thinking={
-            "type": "enabled",
-            "budget_tokens": THINKING_BUDGET_TOKENS,
-        },
+        max_tokens=4096,
         system=[
             {
                 "type": "text",

--- a/plugins/aiobotocore-bot/evals/_common.py
+++ b/plugins/aiobotocore-bot/evals/_common.py
@@ -338,6 +338,17 @@ def new_client() -> anthropic.AsyncAnthropic:
     return anthropic.AsyncAnthropic()
 
 
+# Extended-thinking budget for Sonnet. The classifier has to walk
+# every changed function + consult three registries + apply the
+# Step-4 roll-up + sanity-check before committing to a verdict —
+# exactly the kind of work where thinking tokens pay off. 8K is
+# enough headroom for ~15 functions × several hundred reasoning
+# tokens each. Smaller Sonnet runs (4.6) charge for thinking tokens
+# but at the sync-only eval frequency (manual workflow_dispatch)
+# the absolute cost is negligible.
+THINKING_BUDGET_TOKENS = 8000
+
+
 async def invoke_and_parse(
     client: anthropic.AsyncAnthropic,
     system: str,
@@ -350,13 +361,23 @@ async def invoke_and_parse(
     The verdict regex should capture the verdict string as group 1 (e.g.
     `^CLASSIFICATION:\\s*(\\S+)`).
 
+    Enables extended thinking so Sonnet can reason through each
+    changed function before committing to the top-line verdict —
+    classification-style problems regress without it.
+
     The system prompt uses ephemeral cache_control so repeated calls
     within the same eval session (N runs × M cases ≈ 96 calls at
     defaults) hit the cache on the ~2K-token command body.
     """
+    # max_tokens must be > budget_tokens (thinking + response share
+    # the envelope). 16K leaves ~8K for the actual response.
     resp = await client.messages.create(
         model=model,
-        max_tokens=4096,
+        max_tokens=16000,
+        thinking={
+            "type": "enabled",
+            "budget_tokens": THINKING_BUDGET_TOKENS,
+        },
         system=[
             {
                 "type": "text",

--- a/plugins/aiobotocore-bot/evals/_common.py
+++ b/plugins/aiobotocore-bot/evals/_common.py
@@ -338,14 +338,19 @@ def new_client() -> anthropic.AsyncAnthropic:
     return anthropic.AsyncAnthropic()
 
 
-# Adaptive thinking for the classifier. The work (walk every changed
-# function + consult three registries + apply roll-up + sanity-check
-# before committing) is exactly what thinking tokens pay for.
-# `adaptive` + `effort: high` is Anthropic's recommended shape for
-# Sonnet 4.6 (manual `budget_tokens` is deprecated). Mirrors the
-# `--effort high` setting on the claude-code-action-driven sync
-# workflow so eval and runtime share reasoning depth.
-THINKING_EFFORT = "high"
+# Extended-thinking budget for the classifier. The work (walk every
+# changed function + consult three registries + apply roll-up +
+# sanity-check before committing) is exactly what thinking tokens pay
+# for. `type: enabled, budget_tokens: N` is the stable shape — the
+# newer `type: adaptive, effort: X` is documented for Sonnet 4.6 but
+# the API currently rejects it ("Extra inputs are not permitted" on
+# `anthropic==0.96.0`, 2026-04-19). Switch once upstream ships it.
+#
+# 8K is enough headroom for ~15 functions × several hundred reasoning
+# tokens each. Mirrors the `--effort high` setting on the
+# claude-code-action-driven sync workflow so eval and runtime share
+# reasoning depth.
+THINKING_BUDGET_TOKENS = 8000
 
 
 async def invoke_and_parse(
@@ -372,8 +377,8 @@ async def invoke_and_parse(
         model=model,
         max_tokens=16000,
         thinking={
-            "type": "adaptive",
-            "effort": THINKING_EFFORT,
+            "type": "enabled",
+            "budget_tokens": THINKING_BUDGET_TOKENS,
         },
         system=[
             {

--- a/plugins/aiobotocore-bot/evals/_common.py
+++ b/plugins/aiobotocore-bot/evals/_common.py
@@ -8,6 +8,7 @@ the pieces they share so behavior can only change in one place.
 
 from __future__ import annotations
 
+import ast
 import asyncio
 import json
 import os
@@ -57,6 +58,40 @@ def overridden_paths() -> set[str]:
         p.relative_to(AIOBOTOCORE_DIR).as_posix()
         for p in AIOBOTOCORE_DIR.rglob("*.py")
     }
+
+
+TEST_PATCHES_PATH = REPO_ROOT / "tests/test_patches.py"
+
+
+def overridden_symbols() -> set[str]:
+    """Parse tests/test_patches.py and return the set of botocore symbols
+    aiobotocore overrides.
+
+    Each entry in the `test_patches` pytest.mark.parametrize body is
+    `(<symbol-reference>, {hashes})`. The symbol is either a bare name
+    (`_apply_request_trailer_checksum`) or an attribute chain
+    (`ClientArgsCreator.get_client_args`).
+
+    Returns a flat set containing both the full dotted name
+    (`ClientArgsCreator.get_client_args`) AND the tail component
+    (`get_client_args`) so name-only matches from diff hunks work too.
+    """
+    names: set[str] = set()
+    tree = ast.parse(TEST_PATCHES_PATH.read_text())
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Tuple) or len(node.elts) != 2:
+            continue
+        target = node.elts[0]
+        parts: list[str] = []
+        while isinstance(target, ast.Attribute):
+            parts.append(target.attr)
+            target = target.value
+        if isinstance(target, ast.Name):
+            parts.append(target.id)
+            parts.reverse()
+            names.add(".".join(parts))
+            names.add(parts[-1])
+    return names
 
 
 def decrement_patch(ver: str) -> str:

--- a/plugins/aiobotocore-bot/evals/_common.py
+++ b/plugins/aiobotocore-bot/evals/_common.py
@@ -340,23 +340,88 @@ def new_client() -> anthropic.AsyncAnthropic:
     return anthropic.AsyncAnthropic()
 
 
-async def invoke_and_parse(
+def classify_tool_schema(
+    tool_name: str,
+    verdict_enum: list[str],
+    per_function_label: str,
+) -> dict:
+    """Build a tool schema that forces the model to emit its verdict
+    as structured data instead of regex-parseable text.
+
+    `verdict_enum` constrains the top-line classification (e.g.
+    `["no-port", "port-required", "ambiguous"]` for check-async-need,
+    `["clean", "cosmetic-drift", "behavioral-drift"]` for
+    check-override-drift). `per_function_label` names what each row
+    represents (e.g. "function" or "line").
+    """
+    return {
+        "name": tool_name,
+        "description": (
+            "Emit the final classification. Call this ONCE, at the end, "
+            "after you've reasoned through each changed function in your "
+            "text response. The top-line `verdict` must follow from the "
+            "per-function verdicts via the roll-up rule stated in the "
+            "system prompt."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "verdict": {
+                    "type": "string",
+                    "enum": verdict_enum,
+                    "description": "Top-line roll-up classification.",
+                },
+                "summary": {
+                    "type": "string",
+                    "description": (
+                        "One-line summary of the classification "
+                        "(counts, key drivers)."
+                    ),
+                },
+                "per_function_verdicts": {
+                    "type": "array",
+                    "description": (
+                        f"One entry per changed/added/removed {per_function_label}."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "file": {"type": "string"},
+                            "name": {"type": "string"},
+                            "change_type": {
+                                "type": "string",
+                                "enum": [
+                                    "added",
+                                    "changed",
+                                    "removed",
+                                    "renamed",
+                                    "refactored",
+                                ],
+                            },
+                            "verdict": {"type": "string"},
+                            "reason": {"type": "string"},
+                        },
+                        "required": ["file", "name", "verdict", "reason"],
+                    },
+                },
+            },
+            "required": ["verdict", "summary"],
+        },
+    }
+
+
+async def invoke_and_classify(
     client: anthropic.AsyncAnthropic,
     system: str,
     user: str,
     model: str,
-    verdict_re: re.Pattern[str],
-) -> tuple[str, str]:
-    """Call the Anthropic API and extract a verdict from the response.
+    tool: dict,
+) -> tuple[str, str, dict | None]:
+    """Call the Anthropic API forcing the model to emit its verdict via
+    the `tool` schema. Returns (verdict, raw_text, full_tool_input).
 
-    The verdict regex should capture the verdict string as group 1 (e.g.
-    `^CLASSIFICATION:\\s*(\\S+)`).
-
-    Opus 4.7 at default effort (no explicit extended thinking) is good
-    enough for classification after the #1567 registry-injection work —
-    baseline eval was 8/8 and Opus's default reasoning matches the
-    Sonnet+thinking result at a smaller price premium under the new
-    Opus pricing tier.
+    `raw_text` captures any text blocks the model emitted alongside the
+    tool call — useful for debugging and for the follow-up-on-miss flow.
 
     The system prompt uses ephemeral cache_control so repeated calls
     within the same eval session (N runs × M cases ≈ 96 calls at
@@ -365,6 +430,8 @@ async def invoke_and_parse(
     resp = await client.messages.create(
         model=model,
         max_tokens=4096,
+        tools=[tool],
+        tool_choice={"type": "tool", "name": tool["name"]},
         system=[
             {
                 "type": "text",
@@ -379,18 +446,12 @@ async def invoke_and_parse(
         for block in resp.content
         if getattr(block, "type", None) == "text"
     )
-    # Take the LAST match, not the first. The model sometimes emits an
-    # initial verdict, reasons further, self-corrects, and re-emits the
-    # final CLASSIFICATION line at the end (Opus debug follow-up on PR
-    # #1466 confirmed this). The last line is the model's final answer;
-    # the first is a superseded draft.
-    matches = verdict_re.findall(raw)
-    if matches:
-        # strip trailing `:` and `*` — models sometimes emit
-        # `**CLASSIFICATION: no-port**` (bold wrapping both label AND value),
-        # which leaves `no-port**` in the capture group.
-        return (matches[-1].strip().rstrip(":*").lower(), raw)
-    return ("parse-error", raw)
+    for block in resp.content:
+        if getattr(block, "type", None) == "tool_use":
+            tool_input = block.input
+            verdict = tool_input.get("verdict", "parse-error")
+            return (verdict.lower(), raw, tool_input)
+    return ("parse-error", raw, None)
 
 
 async def followup_on_misclassification(

--- a/plugins/aiobotocore-bot/evals/_common.py
+++ b/plugins/aiobotocore-bot/evals/_common.py
@@ -98,6 +98,55 @@ def overridden_symbols() -> set[str]:
     return names
 
 
+# Sync-signature methods that delegate to async internals in
+# aiobotocore. E.g. `HierarchicalEmitter.emit` stays sync but calls
+# `self._emit`, which aiobotocore overrides as `async def`. A caller in
+# a sync context hitting `.emit(...)` gets back a coroutine instead of
+# a result — so callers must be async-aware even though `emit` itself
+# isn't. `async_names()` can't auto-detect this from AST alone (we'd
+# need symbolic analysis of sync→async delegation), so it's an
+# explicit curated list. Grow as discovered.
+_SYNC_BUT_CONTAMINATED_NAMES: frozenset[str] = frozenset(
+    {
+        "emit",
+    }
+)
+
+
+def async_names() -> tuple[set[str], set[str]]:
+    """Scan aiobotocore/**/*.py for async surfaces.
+
+    Returns two sets:
+
+    - Async method / function names (bare): every `async def <name>`
+      defined anywhere under aiobotocore/, plus the curated
+      `_SYNC_BUT_CONTAMINATED_NAMES` entries. Used for duck-typed
+      contamination matching — e.g. if botocore adds new code that
+      calls `.read(...)` on any object, and `read` is in this set,
+      the new code is suspect because aiobotocore's version of that
+      method is async (or returns a coroutine).
+    - Aio* class names: every `class Aio<Name>(...)` definition. A
+      new botocore-side call that instantiates or references one of
+      these class's botocore parents (e.g. `ClientCreator(...)`) maps
+      to an async override in aiobotocore.
+    """
+    method_names: set[str] = set(_SYNC_BUT_CONTAMINATED_NAMES)
+    class_names: set[str] = set()
+    for path in AIOBOTOCORE_DIR.rglob("*.py"):
+        try:
+            tree = ast.parse(path.read_text())
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AsyncFunctionDef):
+                method_names.add(node.name)
+            elif isinstance(node, ast.ClassDef) and node.name.startswith(
+                "Aio"
+            ):
+                class_names.add(node.name)
+    return method_names, class_names
+
+
 def decrement_patch(ver: str) -> str:
     parts = list(map(int, ver.split(".")))
     parts[-1] = max(0, parts[-1] - 1)

--- a/plugins/aiobotocore-bot/evals/_common.py
+++ b/plugins/aiobotocore-bot/evals/_common.py
@@ -379,11 +379,17 @@ async def invoke_and_parse(
         for block in resp.content
         if getattr(block, "type", None) == "text"
     )
-    if m := verdict_re.search(raw):
+    # Take the LAST match, not the first. The model sometimes emits an
+    # initial verdict, reasons further, self-corrects, and re-emits the
+    # final CLASSIFICATION line at the end (Opus debug follow-up on PR
+    # #1466 confirmed this). The last line is the model's final answer;
+    # the first is a superseded draft.
+    matches = verdict_re.findall(raw)
+    if matches:
         # strip trailing `:` and `*` — models sometimes emit
         # `**CLASSIFICATION: no-port**` (bold wrapping both label AND value),
-        # which leaves `no-port**` in group 1.
-        return (m.group(1).strip().rstrip(":*").lower(), raw)
+        # which leaves `no-port**` in the capture group.
+        return (matches[-1].strip().rstrip(":*").lower(), raw)
     return ("parse-error", raw)
 
 

--- a/plugins/aiobotocore-bot/evals/check_async_need.py
+++ b/plugins/aiobotocore-bot/evals/check_async_need.py
@@ -246,19 +246,18 @@ async def main() -> int:
 
     runnable = [c for c in cases if c.pr in diffs]
 
-    async def invoke_one(case: Case) -> str:
+    async def invoke_one(case: Case) -> tuple[str, str]:
         diff = diffs[case.pr]
         if not diff.strip():
-            return "no-port"
+            return ("no-port", "")
         user = build_user_message(case, diff)
-        verdict, _raw = await invoke_and_parse(
+        return await invoke_and_parse(
             client,
             skill_body,
             user,
             args.model,
             VERDICT_RE,
         )
-        return verdict
 
     per_case_verdicts = await run_cases_concurrent(
         runnable, args.runs, invoke_one
@@ -269,7 +268,9 @@ async def main() -> int:
     # zip without strict= for Python 3.9 compat; lengths are equal by
     # construction (per_case_verdicts is gathered over runnable).
     assert len(runnable) == len(per_case_verdicts)
-    for case, verdicts in zip(runnable, per_case_verdicts):
+    for case, pairs in zip(runnable, per_case_verdicts):
+        verdicts = [v for v, _ in pairs]
+        rationales = [r for _, r in pairs]
         print(f"\n#{case.pr} [{case.expected}] {case.title}")
         print(
             f"  from={case.from_ver} to={case.to_ver} diff={diffs[case.pr].count(chr(10))} lines"
@@ -288,6 +289,7 @@ async def main() -> int:
             "to": case.to_ver,
             "expected": case.expected,
             "verdicts": verdicts,
+            "rationales": rationales,
             "majority": majority,
             "passed": passed,
         }

--- a/plugins/aiobotocore-bot/evals/check_async_need.py
+++ b/plugins/aiobotocore-bot/evals/check_async_need.py
@@ -46,6 +46,7 @@ from _common import (
     load_skill_body,
     new_client,
     overridden_paths,
+    overridden_symbols,
     parse_scenarios_yaml,
     require_env,
     run_cases_concurrent,
@@ -149,7 +150,8 @@ def compute_filtered_diff(case: Case, overridden: set[str]) -> str:
         ) from e
 
 
-def build_user_message(case: Case, diff: str) -> str:
+def build_user_message(case: Case, diff: str, overrides: set[str]) -> str:
+    overrides_block = "\n".join(f"- {s}" for s in sorted(overrides))
     return (
         textwrap.dedent(
             """
@@ -158,6 +160,18 @@ def build_user_message(case: Case, diff: str) -> str:
 
         The diff below is ALREADY FILTERED to changes in botocore files that have a
         mirror in aiobotocore/. Do NOT re-run git diff — use this content directly.
+
+        ## Authoritative aiobotocore override registry
+
+        These are the ONLY botocore symbols aiobotocore currently overrides
+        (from `tests/test_patches.py`, the source of truth). For a
+        changed function to drive a `port-required` verdict, its name or
+        dotted name MUST appear in this list. Do not assume overrides from
+        context — verify against this list.
+
+        {overrides_block}
+
+        ## Diff
 
         ```diff
         {diff}
@@ -172,7 +186,12 @@ def build_user_message(case: Case, diff: str) -> str:
            of your system prompt.
         """,
         )
-        .format(from_ver=case.from_ver, to_ver=case.to_ver, diff=diff)
+        .format(
+            from_ver=case.from_ver,
+            to_ver=case.to_ver,
+            diff=diff,
+            overrides_block=overrides_block,
+        )
         .strip()
     )
 
@@ -211,9 +230,11 @@ async def main() -> int:
 
     skill_body = load_skill_body(SKILL_PATH)
     overridden = overridden_paths()
+    override_symbols = overridden_symbols()
     print(
         f"Overridden files: {len(overridden)} ({', '.join(sorted(overridden)[:3])}, ...)"
     )
+    print(f"Override symbols from test_patches.py: {len(override_symbols)}")
 
     # Prefer the committed scenarios.yaml (faster, deterministic, has rationales).
     yaml_cases = load_scenarios_yaml(SCENARIOS_PATH)
@@ -250,7 +271,7 @@ async def main() -> int:
         diff = diffs[case.pr]
         if not diff.strip():
             return ("no-port", "")
-        user = build_user_message(case, diff)
+        user = build_user_message(case, diff, override_symbols)
         return await invoke_and_parse(
             client,
             skill_body,

--- a/plugins/aiobotocore-bot/evals/check_async_need.py
+++ b/plugins/aiobotocore-bot/evals/check_async_need.py
@@ -40,6 +40,7 @@ from _common import (
     DEFAULT_MODEL,
     REPO_ROOT,
     aiobotocore_port_happened,
+    async_names,
     derive_versions,
     invoke_and_parse,
     list_sync_prs,
@@ -150,8 +151,16 @@ def compute_filtered_diff(case: Case, overridden: set[str]) -> str:
         ) from e
 
 
-def build_user_message(case: Case, diff: str, overrides: set[str]) -> str:
+def build_user_message(
+    case: Case,
+    diff: str,
+    overrides: set[str],
+    async_methods: set[str],
+    aio_classes: set[str],
+) -> str:
     overrides_block = "\n".join(f"- {s}" for s in sorted(overrides))
+    async_methods_block = "\n".join(f"- {s}" for s in sorted(async_methods))
+    aio_classes_block = "\n".join(f"- {s}" for s in sorted(aio_classes))
     return (
         textwrap.dedent(
             """
@@ -161,46 +170,33 @@ def build_user_message(case: Case, diff: str, overrides: set[str]) -> str:
         The diff below is ALREADY FILTERED to changes in botocore files that have a
         mirror in aiobotocore/. Do NOT re-run git diff — use this content directly.
 
-        ## Authoritative aiobotocore override registry
+        ## Registries (your Step 1 inputs)
 
-        These are the botocore symbols aiobotocore currently overrides
-        (from `tests/test_patches.py`, the source of truth). Entry
-        shapes:
+        Three registries to consult during classification, per the
+        system prompt algorithm:
 
-        - `ClassName.method_name` — only that specific method is
-          mirrored.
-        - Bare function name (e.g. `_apply_request_trailer_checksum`) —
-          that specific module-level function is mirrored.
-        - Bare class name (e.g. `URLLib3Session`) — the class source is
-          hashed as a whole. This does NOT mean every method is
-          mirrored; only the specific dotted `ClassName.method` entries
-          are.
-
-        How to use the registry:
-
-        - **Existing code, changed**: if the function's dotted name is
-          NOT in the registry, a substantive body change alone does NOT
-          drive port-required — aiobotocore doesn't override it, so
-          aiobotocore's code path isn't affected. If it IS in the
-          registry and the change is substantive (signature, call
-          graph, control flow), flag port-required.
-        - **New code, added**: the registry doesn't cover new functions
-          yet — classify based on I/O signals per Step 3 of the system
-          prompt (`emit()`/`emit_first_non_none_response()` from an
-          aiobotocore-overridden hooks emitter, blocking primitives,
-          `resolve_awaitable`, etc.). A new function that calls a
-          function aiobotocore has already made async (e.g.
-          `self._emit(...)` where `HierarchicalEmitter.emit` is in the
-          registry) is needs-async.
-        - **Call-graph back-track**: if a new botocore function gets
-          classified needs-async, check the diff and registry for
-          callers: any caller already in the registry must be updated
-          to `await` this new call once aiobotocore mirrors it. Flag
-          those callers as port-required too, even if their body
-          changes look small.
-        - Do not infer overrides from file-mirror existence.
+        ### `overrides` — botocore symbols aiobotocore explicitly
+        overrides (from `tests/test_patches.py`). Entry shapes:
+        `ClassName.method` (specific method mirrored), bare function
+        name (module-level function mirrored), bare class name (class
+        source hashed as a whole; does NOT imply every method mirrored).
 
         {overrides_block}
+
+        ### `async_methods` — every `async def <name>` in aiobotocore,
+        plus curated sync-signature methods that delegate to async
+        internals (e.g. `emit` → `_emit`). A call `x.<name>(...)` where
+        `<name>` is in this set is suspect: if `x` is a known Aio*
+        instance or an aiobotocore self-attribute, it's async; on an
+        unknown receiver, emit `ambiguous`.
+
+        {async_methods_block}
+
+        ### `aio_classes` — every `class Aio<Name>(...)` in aiobotocore.
+        A new botocore call that instantiates or subclasses the non-Aio
+        parent needs to route through the Aio subclass.
+
+        {aio_classes_block}
 
         ## Diff
 
@@ -222,6 +218,8 @@ def build_user_message(case: Case, diff: str, overrides: set[str]) -> str:
             to_ver=case.to_ver,
             diff=diff,
             overrides_block=overrides_block,
+            async_methods_block=async_methods_block,
+            aio_classes_block=aio_classes_block,
         )
         .strip()
     )
@@ -262,10 +260,14 @@ async def main() -> int:
     skill_body = load_skill_body(SKILL_PATH)
     overridden = overridden_paths()
     override_symbols = overridden_symbols()
+    async_methods, aio_classes = async_names()
     print(
         f"Overridden files: {len(overridden)} ({', '.join(sorted(overridden)[:3])}, ...)"
     )
-    print(f"Override symbols from test_patches.py: {len(override_symbols)}")
+    print(
+        f"Registries: overrides={len(override_symbols)} "
+        f"async_methods={len(async_methods)} aio_classes={len(aio_classes)}"
+    )
 
     # Prefer the committed scenarios.yaml (faster, deterministic, has rationales).
     yaml_cases = load_scenarios_yaml(SCENARIOS_PATH)
@@ -302,7 +304,9 @@ async def main() -> int:
         diff = diffs[case.pr]
         if not diff.strip():
             return ("no-port", "")
-        user = build_user_message(case, diff, override_symbols)
+        user = build_user_message(
+            case, diff, override_symbols, async_methods, aio_classes
+        )
         return await invoke_and_parse(
             client,
             skill_body,

--- a/plugins/aiobotocore-bot/evals/check_async_need.py
+++ b/plugins/aiobotocore-bot/evals/check_async_need.py
@@ -205,21 +205,25 @@ def build_user_message(
         {diff}
         ```
 
-        Output format — strict. Follow the Step 4 protocol in your
-        system prompt exactly:
+        Output format — reason first, verdict last. Per Step 4 of
+        the system prompt:
 
-        1. Mentally classify each changed function per Step 3.
-        2. Apply the roll-up rule: any function `port-required` →
-           top-line `port-required`. Any `ambiguous` and none needs-
-           async → top-line `ambiguous`. Every function `pure-sync` →
-           top-line `no-port`.
-        3. Sanity check: does the top-line verdict match the per-
-           function verdicts? If your reasoning has any function as
-           port-required but you're about to write CLASSIFICATION:
-           no-port, STOP and correct the top-line.
-        4. THEN emit the response. The VERY FIRST line must be
-           `CLASSIFICATION: <verdict>`. No preamble, no markdown
-           formatting on this line. Reasoning goes after.
+        1. Write per-function verdicts FIRST. For each port-required
+           verdict you must quote the exact string from `overrides`
+           you matched (or the exact name from `async_methods` /
+           `aio_classes` you contacted).
+        2. Then the Summary block.
+        3. LAST, emit `CLASSIFICATION: <verdict>` on its own line.
+           The verdict follows from the per-function verdicts via the
+           roll-up rule: any port-required → top-line port-required;
+           any ambiguous and none port-required → ambiguous; every
+           function pure-sync → no-port.
+        4. Do NOT emit the CLASSIFICATION line early. Do not
+           re-emit it after corrections — write it once, at the end,
+           consistent with the final per-function verdicts.
+        5. Never justify port-required with "the test_patches.py hash
+           will break" — hash bumps are mechanical, NOT a port
+           signal.
         """,
         )
         .format(

--- a/plugins/aiobotocore-bot/evals/check_async_need.py
+++ b/plugins/aiobotocore-bot/evals/check_async_need.py
@@ -52,6 +52,7 @@ from _common import (
     parse_scenarios_yaml,
     require_env,
     run_cases_concurrent,
+    usage_summary,
 )
 
 SKILL_PATH = (
@@ -420,6 +421,9 @@ async def main() -> int:
     if args.json_out:
         args.json_out.write_text(json.dumps(results, indent=2))
         print(f"Wrote {args.json_out}")
+
+    if summary := usage_summary():
+        print(summary)
 
     return 0 if not failures else 1
 

--- a/plugins/aiobotocore-bot/evals/check_async_need.py
+++ b/plugins/aiobotocore-bot/evals/check_async_need.py
@@ -28,7 +28,6 @@ import argparse
 import asyncio
 import json
 import os
-import re
 import subprocess
 import sys
 import textwrap
@@ -41,9 +40,10 @@ from _common import (
     REPO_ROOT,
     aiobotocore_port_happened,
     async_names,
+    classify_tool_schema,
     derive_versions,
     followup_on_misclassification,
-    invoke_and_parse,
+    invoke_and_classify,
     list_sync_prs,
     load_skill_body,
     new_client,
@@ -60,14 +60,10 @@ SKILL_PATH = (
 SCENARIOS_PATH = REPO_ROOT / "plugins/aiobotocore-bot/evals/scenarios.yaml"
 BOTOCORE_CLONE = Path(os.environ.get("BOTOCORE_CLONE", "/tmp/botocore"))
 
-# Tolerate markdown-bold wrappers and leading whitespace — `**CLASSIFICATION**:`
-# and `CLASSIFICATION:` are both plausible model outputs; the previous
-# strict `^CLASSIFICATION:` would miss the bolded form and return
-# parse-error. Matches on any line start (MULTILINE) with optional
-# leading whitespace/asterisks around the label.
-VERDICT_RE = re.compile(
-    r"^\s*\**\s*CLASSIFICATION\s*\**\s*:\s*(\S+)",
-    re.MULTILINE,
+CLASSIFY_TOOL = classify_tool_schema(
+    tool_name="record_async_need_classification",
+    verdict_enum=["no-port", "port-required", "ambiguous"],
+    per_function_label="function",
 )
 
 
@@ -205,23 +201,18 @@ def build_user_message(
         {diff}
         ```
 
-        Output format — reason first, verdict last. Per Step 4 of
-        the system prompt:
+        Output protocol:
 
-        1. Write per-function verdicts FIRST. For each port-required
+        1. In your text response, reason through each changed function
+           per Step 3 of the system prompt. For any port-required
            verdict you must quote the exact string from `overrides`
            you matched (or the exact name from `async_methods` /
            `aio_classes` you contacted).
-        2. Then the Summary block.
-        3. LAST, emit `CLASSIFICATION: <verdict>` on its own line.
-           The verdict follows from the per-function verdicts via the
-           roll-up rule: any port-required → top-line port-required;
-           any ambiguous and none port-required → ambiguous; every
-           function pure-sync → no-port.
-        4. Do NOT emit the CLASSIFICATION line early. Do not
-           re-emit it after corrections — write it once, at the end,
-           consistent with the final per-function verdicts.
-        5. Never justify port-required with "the test_patches.py hash
+        2. Then call the `record_async_need_classification` tool
+           ONCE with your final verdict, summary, and per-function
+           verdicts. The tool call is the authoritative output — do
+           not emit a CLASSIFICATION label in text.
+        3. Never justify port-required with "the test_patches.py hash
            will break" — hash bumps are mechanical, NOT a port
            signal.
         """,
@@ -330,13 +321,21 @@ async def main() -> int:
         user = build_user_message(
             case, diff, override_symbols, async_methods, aio_classes
         )
-        return await invoke_and_parse(
+        verdict, raw, tool_input = await invoke_and_classify(
             client,
             skill_body,
             user,
             args.model,
-            VERDICT_RE,
+            CLASSIFY_TOOL,
         )
+        # Inline the structured tool input into the rationale so the
+        # JSON-out captures it alongside the narrative text.
+        rationale = raw
+        if tool_input is not None:
+            rationale += "\n\n---TOOL OUTPUT---\n" + json.dumps(
+                tool_input, indent=2
+            )
+        return (verdict, rationale)
 
     per_case_verdicts = await run_cases_concurrent(
         runnable, args.runs, invoke_one

--- a/plugins/aiobotocore-bot/evals/check_async_need.py
+++ b/plugins/aiobotocore-bot/evals/check_async_need.py
@@ -210,9 +210,11 @@ def build_user_message(
            you matched (or the exact name from `async_methods` /
            `aio_classes` you contacted).
         2. Then call the `record_async_need_classification` tool
-           ONCE with your final verdict, summary, and per-function
-           verdicts. The tool call is the authoritative output — do
-           not emit a CLASSIFICATION label in text.
+           ONCE with your final `verdict` and a `rationale` containing
+           the per-function breakdown (file, name, change-type,
+           verdict, reason) plus a roll-up summary. The tool call is
+           the authoritative output — do not emit a CLASSIFICATION
+           label in text.
         3. Never justify port-required with "the test_patches.py hash
            will break" — hash bumps are mechanical, NOT a port
            signal.

--- a/plugins/aiobotocore-bot/evals/check_async_need.py
+++ b/plugins/aiobotocore-bot/evals/check_async_need.py
@@ -42,6 +42,7 @@ from _common import (
     aiobotocore_port_happened,
     async_names,
     derive_versions,
+    followup_on_misclassification,
     invoke_and_parse,
     list_sync_prs,
     load_skill_body,
@@ -253,6 +254,16 @@ async def main() -> int:
     parser.add_argument(
         "--json-out", type=Path, help="Write full per-run results here"
     )
+    parser.add_argument(
+        "--debug-misclassifications",
+        action="store_true",
+        help=(
+            "After the eval, for each majority-vote failure, send a "
+            "follow-up turn asking the model what rule led to the wrong "
+            "verdict. Captured in --json-out as `debug_followup`. Useful "
+            "for prompt-iteration debugging."
+        ),
+    )
     args = parser.parse_args()
 
     if not BOTOCORE_CLONE.exists():
@@ -359,15 +370,40 @@ async def main() -> int:
         }
         results.append(result)
         if not passed:
-            failures.append(result)
+            failures.append((case, result, rationales))
 
     print(
         f"\n== Summary: {len(results) - len(failures)}/{len(results)} passed =="
     )
-    for f in failures:
+    for _, f, _ in failures:
         print(
             f"  FAIL #{f['pr']}: expected {f['expected']}, got {f['verdicts']}"
         )
+
+    # On --debug-misclassifications, ask the model (in a continuing
+    # conversation) what rule led it to the wrong verdict. Uses run 1's
+    # rationale as the assistant turn to continue from. Attaches to the
+    # result dict so JSON-out captures it.
+    if args.debug_misclassifications and failures:
+        print("\n== Debug follow-ups on misclassifications ==")
+        for case, result, rationales in failures:
+            diff = diffs[case.pr]
+            if not diff.strip() or not rationales or not rationales[0]:
+                continue
+            user = build_user_message(
+                case, diff, override_symbols, async_methods, aio_classes
+            )
+            followup = await followup_on_misclassification(
+                client,
+                skill_body,
+                user,
+                args.model,
+                rationales[0],
+                case.expected,
+                result["majority"],
+            )
+            result["debug_followup"] = followup
+            print(f"\n--- #{case.pr} follow-up ---\n{followup}\n")
 
     if args.json_out:
         args.json_out.write_text(json.dumps(results, indent=2))

--- a/plugins/aiobotocore-bot/evals/check_async_need.py
+++ b/plugins/aiobotocore-bot/evals/check_async_need.py
@@ -261,6 +261,15 @@ async def main() -> int:
     )
     args = parser.parse_args()
 
+    # Write an empty results file up front so `actions/upload-artifact`
+    # finds something even if the run aborts mid-way (e.g. Anthropic
+    # usage cap hit partway through). Real results overwrite at the end.
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(
+            json.dumps({"error": "not-started", "results": []}, indent=2)
+        )
+
     if not BOTOCORE_CLONE.exists():
         sys.stderr.write(
             f"Bare botocore clone not found at {BOTOCORE_CLONE}.\n"

--- a/plugins/aiobotocore-bot/evals/check_async_need.py
+++ b/plugins/aiobotocore-bot/evals/check_async_need.py
@@ -163,11 +163,42 @@ def build_user_message(case: Case, diff: str, overrides: set[str]) -> str:
 
         ## Authoritative aiobotocore override registry
 
-        These are the ONLY botocore symbols aiobotocore currently overrides
-        (from `tests/test_patches.py`, the source of truth). For a
-        changed function to drive a `port-required` verdict, its name or
-        dotted name MUST appear in this list. Do not assume overrides from
-        context — verify against this list.
+        These are the botocore symbols aiobotocore currently overrides
+        (from `tests/test_patches.py`, the source of truth). Entry
+        shapes:
+
+        - `ClassName.method_name` — only that specific method is
+          mirrored.
+        - Bare function name (e.g. `_apply_request_trailer_checksum`) —
+          that specific module-level function is mirrored.
+        - Bare class name (e.g. `URLLib3Session`) — the class source is
+          hashed as a whole. This does NOT mean every method is
+          mirrored; only the specific dotted `ClassName.method` entries
+          are.
+
+        How to use the registry:
+
+        - **Existing code, changed**: if the function's dotted name is
+          NOT in the registry, a substantive body change alone does NOT
+          drive port-required — aiobotocore doesn't override it, so
+          aiobotocore's code path isn't affected. If it IS in the
+          registry and the change is substantive (signature, call
+          graph, control flow), flag port-required.
+        - **New code, added**: the registry doesn't cover new functions
+          yet — classify based on I/O signals per Step 3 of the system
+          prompt (`emit()`/`emit_first_non_none_response()` from an
+          aiobotocore-overridden hooks emitter, blocking primitives,
+          `resolve_awaitable`, etc.). A new function that calls a
+          function aiobotocore has already made async (e.g.
+          `self._emit(...)` where `HierarchicalEmitter.emit` is in the
+          registry) is needs-async.
+        - **Call-graph back-track**: if a new botocore function gets
+          classified needs-async, check the diff and registry for
+          callers: any caller already in the registry must be updated
+          to `await` this new call once aiobotocore mirrors it. Flag
+          those callers as port-required too, even if their body
+          changes look small.
+        - Do not infer overrides from file-mirror existence.
 
         {overrides_block}
 

--- a/plugins/aiobotocore-bot/evals/check_async_need.py
+++ b/plugins/aiobotocore-bot/evals/check_async_need.py
@@ -204,13 +204,21 @@ def build_user_message(
         {diff}
         ```
 
-        Output format — strict:
+        Output format — strict. Follow the Step 4 protocol in your
+        system prompt exactly:
 
-        1. The VERY FIRST line of your response must be `CLASSIFICATION: <verdict>`
-           where <verdict> is one of `no-port`, `port-required`, or `ambiguous`.
-           No preamble, no explanation, no markdown formatting on this line.
-        2. Any supporting reasoning goes AFTER the classification line, per Step 4
-           of your system prompt.
+        1. Mentally classify each changed function per Step 3.
+        2. Apply the roll-up rule: any function `port-required` →
+           top-line `port-required`. Any `ambiguous` and none needs-
+           async → top-line `ambiguous`. Every function `pure-sync` →
+           top-line `no-port`.
+        3. Sanity check: does the top-line verdict match the per-
+           function verdicts? If your reasoning has any function as
+           port-required but you're about to write CLASSIFICATION:
+           no-port, STOP and correct the top-line.
+        4. THEN emit the response. The VERY FIRST line must be
+           `CLASSIFICATION: <verdict>`. No preamble, no markdown
+           formatting on this line. Reasoning goes after.
         """,
         )
         .format(

--- a/plugins/aiobotocore-bot/evals/check_override_drift.py
+++ b/plugins/aiobotocore-bot/evals/check_override_drift.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
-import re
 import subprocess
 import sys
 import textwrap
@@ -35,7 +34,8 @@ from pathlib import Path
 from _common import (
     DEFAULT_MODEL,
     REPO_ROOT,
-    invoke_and_parse,
+    classify_tool_schema,
+    invoke_and_classify,
     load_skill_body,
     new_client,
     overridden_symbols,
@@ -51,13 +51,12 @@ SCENARIOS_PATH = (
     REPO_ROOT / "plugins/aiobotocore-bot/evals/drift_scenarios.yaml"
 )
 
-# Matches `OVERRIDE_DRIFT:`, `**OVERRIDE_DRIFT**:`, or leading whitespace —
-# same tolerance as check_async_need.py's VERDICT_RE.
-VERDICT_RE = re.compile(
-    r"^\s*\**\s*OVERRIDE_DRIFT\s*\**\s*:\s*(\S+)",
-    re.MULTILINE,
-)
 VALID_VERDICTS = {"clean", "cosmetic-drift", "behavioral-drift"}
+CLASSIFY_TOOL = classify_tool_schema(
+    tool_name="record_override_drift_classification",
+    verdict_enum=sorted(VALID_VERDICTS),
+    per_function_label="function",
+)
 
 
 @dataclass
@@ -111,17 +110,18 @@ def build_user_message(case: Case, diff: str, overrides: set[str]) -> str:
 
         {overrides_block}
 
-        Output format — strict:
-
-        1. The VERY FIRST line of your response must be `OVERRIDE_DRIFT: <verdict>`
-           where <verdict> is one of `clean`, `cosmetic-drift`, or `behavioral-drift`.
-           No preamble, no explanation, no markdown formatting on this line.
-        2. Any supporting reasoning goes AFTER the classification line, per Step 4
-           of your system prompt.
-
         ```diff
         {diff}
         ```
+
+        Output protocol:
+
+        1. Reason through each changed function in your text response.
+        2. Then call the `record_override_drift_classification` tool
+           ONCE with your final verdict (one of `clean`,
+           `cosmetic-drift`, `behavioral-drift`), summary, and per-
+           function verdicts. The tool call is the authoritative
+           output — do not emit an OVERRIDE_DRIFT label in text.
         """,
         )
         .format(
@@ -184,12 +184,12 @@ async def main() -> int:
     async def invoke_one(case: Case) -> str:
         diff = diffs[case.pr]
         user = build_user_message(case, diff, override_symbols)
-        verdict, _raw = await invoke_and_parse(
+        verdict, _raw, _tool = await invoke_and_classify(
             client,
             skill_body,
             user,
             args.model,
-            VERDICT_RE,
+            CLASSIFY_TOOL,
         )
         if verdict not in VALID_VERDICTS and verdict != "parse-error":
             verdict = f"unknown:{verdict}"

--- a/plugins/aiobotocore-bot/evals/check_override_drift.py
+++ b/plugins/aiobotocore-bot/evals/check_override_drift.py
@@ -119,10 +119,11 @@ def build_user_message(case: Case, diff: str, overrides: set[str]) -> str:
 
         1. Reason through each changed function in your text response.
         2. Then call the `record_override_drift_classification` tool
-           ONCE with your final verdict (one of `clean`,
-           `cosmetic-drift`, `behavioral-drift`), summary, and per-
-           function verdicts. The tool call is the authoritative
-           output — do not emit an OVERRIDE_DRIFT label in text.
+           ONCE with your final `verdict` (one of `clean`,
+           `cosmetic-drift`, `behavioral-drift`) and a `rationale`
+           containing the per-function breakdown plus a roll-up
+           summary. The tool call is the authoritative output — do
+           not emit an OVERRIDE_DRIFT label in text.
         """,
         )
         .format(

--- a/plugins/aiobotocore-bot/evals/check_override_drift.py
+++ b/plugins/aiobotocore-bot/evals/check_override_drift.py
@@ -153,6 +153,15 @@ async def main() -> int:
     )
     args = parser.parse_args()
 
+    # Write an empty results file up front so `actions/upload-artifact`
+    # finds something even if the run aborts mid-way (e.g. Anthropic
+    # usage cap hit partway through). Real results overwrite at the end.
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(
+            json.dumps({"error": "not-started", "results": []}, indent=2)
+        )
+
     require_env("ANTHROPIC_API_KEY")
 
     skill_body = load_skill_body(SKILL_PATH)

--- a/plugins/aiobotocore-bot/evals/check_override_drift.py
+++ b/plugins/aiobotocore-bot/evals/check_override_drift.py
@@ -38,6 +38,7 @@ from _common import (
     invoke_and_parse,
     load_skill_body,
     new_client,
+    overridden_symbols,
     parse_scenarios_yaml,
     require_env,
     run_cases_concurrent,
@@ -86,7 +87,8 @@ def fetch_pr_diff(pr: int) -> str:
     )
 
 
-def build_user_message(case: Case, diff: str) -> str:
+def build_user_message(case: Case, diff: str, overrides: set[str]) -> str:
+    overrides_block = "\n".join(f"- {s}" for s in sorted(overrides))
     return (
         textwrap.dedent(
             """
@@ -99,6 +101,15 @@ def build_user_message(case: Case, diff: str) -> str:
         currently-pinned version; you can assume botocore is approximately at its
         latest stable release). For `aiobotocore/` files without a botocore mirror
         (e.g. httpxsession.py), mark the file as out-of-scope and skip.
+
+        ## Authoritative aiobotocore override registry
+
+        These are the botocore symbols aiobotocore overrides (from
+        `tests/test_patches.py`). Use this to distinguish a tracked
+        override that must mirror botocore from new aiobotocore-only
+        code that isn't under drift-check scope.
+
+        {overrides_block}
 
         Output format — strict:
 
@@ -113,7 +124,12 @@ def build_user_message(case: Case, diff: str) -> str:
         ```
         """,
         )
-        .format(pr=case.pr, title=case.title, diff=diff)
+        .format(
+            pr=case.pr,
+            title=case.title,
+            diff=diff,
+            overrides_block=overrides_block,
+        )
         .strip()
     )
 
@@ -140,6 +156,8 @@ async def main() -> int:
     require_env("ANTHROPIC_API_KEY")
 
     skill_body = load_skill_body(SKILL_PATH)
+    override_symbols = overridden_symbols()
+    print(f"Override symbols from test_patches.py: {len(override_symbols)}")
     cases = load_scenarios(SCENARIOS_PATH)
     if args.case:
         wanted = set(args.case)
@@ -165,7 +183,7 @@ async def main() -> int:
 
     async def invoke_one(case: Case) -> str:
         diff = diffs[case.pr]
-        user = build_user_message(case, diff)
+        user = build_user_message(case, diff, override_symbols)
         verdict, _raw = await invoke_and_parse(
             client,
             skill_body,

--- a/plugins/aiobotocore-bot/evals/check_override_drift.py
+++ b/plugins/aiobotocore-bot/evals/check_override_drift.py
@@ -42,6 +42,7 @@ from _common import (
     parse_scenarios_yaml,
     require_env,
     run_cases_concurrent,
+    usage_summary,
 )
 
 SKILL_PATH = (
@@ -246,6 +247,9 @@ async def main() -> int:
     if args.json_out:
         args.json_out.write_text(json.dumps(results, indent=2))
         print(f"Wrote {args.json_out}")
+
+    if summary := usage_summary():
+        print(summary)
 
     return 0 if not failures else 1
 

--- a/plugins/aiobotocore-bot/scripts/registries.py
+++ b/plugins/aiobotocore-bot/scripts/registries.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Emit the aiobotocore override/async registries as JSON.
+
+One entry point used by BOTH the `check-async-need` skill at runtime (via
+a Bash step) and the eval harness (via direct import) so both paths see
+the exact same data. The registry schema:
+
+    {
+      "overrides": [ "ClientArgsCreator.get_client_args", ... ],
+      "async_methods": [ "read", "send", "emit", "_emit", ... ],
+      "aio_classes": [ "AioAWSResponse", "AioBaseClient", ... ]
+    }
+
+Run from repo root:
+
+    uv run python plugins/aiobotocore-bot/scripts/registries.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "plugins/aiobotocore-bot/evals"))
+
+from _common import async_names, overridden_symbols  # noqa: E402
+
+
+def main() -> int:
+    method_names, class_names = async_names()
+    payload = {
+        "overrides": sorted(overridden_symbols()),
+        "async_methods": sorted(method_names),
+        "aio_classes": sorted(class_names),
+    }
+    json.dump(payload, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/aiobotocore-bot/skills/check-async-need/SKILL.md
+++ b/plugins/aiobotocore-bot/skills/check-async-need/SKILL.md
@@ -1,7 +1,7 @@
 ---
 description: Use when classifying a botocore version bump as no-port, port-required, or ambiguous. Diffs `$FROM..$TO` in a bare botocore clone, inspects every added/changed function in overridden files, and emits `CLASSIFICATION:` plus per-function reasons. Shared by the sync bot (to pick no-port vs port path) and the PR reviewer (to sanity-check sync-bot PRs).
 argument-hint: "--from=<version> --to=<version> [--aiobotocore-root=<path>] [--botocore-clone=<path>]"
-allowed-tools: Bash(git -C /tmp/botocore:*) Bash(find:*) Bash(sed:*) Bash(cat:*) Bash(test:*)
+allowed-tools: Bash(git -C /tmp/botocore:*) Bash(find:*) Bash(sed:*) Bash(cat:*) Bash(test:*) Bash(grep:*)
 ---
 
 <!--
@@ -29,15 +29,31 @@ historical override status.
 Assume the clone already exists and has both tags fetched. If it does not, return `error: botocore clone
 missing or tag unavailable` and stop — the caller is responsible for provisioning it.
 
-## Step 1: Enumerate overridden files
+## Step 1: Enumerate overridden files and symbols
 
-Use the filename-mirror convention: `botocore/<relpath>` is overridden iff
-`aiobotocore/<relpath>` exists. Must recurse into subdirectories — `aiobotocore/retries/*.py`
-mirrors `botocore/retries/*.py`, and those paths do get modified on syncs.
+Two registries matter:
 
-```text
-find "$AIOBOTOCORE_ROOT" -name '*.py' | sed "s|^$AIOBOTOCORE_ROOT/||"
-```
+1. **File mirror**: `botocore/<relpath>` is a candidate for override iff
+   `aiobotocore/<relpath>` exists. Must recurse into subdirectories —
+   `aiobotocore/retries/*.py` mirrors `botocore/retries/*.py`, and those
+   paths do get modified on syncs.
+
+   ```text
+   find "$AIOBOTOCORE_ROOT" -name '*.py' | sed "s|^$AIOBOTOCORE_ROOT/||"
+   ```
+
+2. **Symbol registry** (authoritative): `tests/test_patches.py` is the
+   source of truth for every botocore class/method/function aiobotocore
+   overrides. Each `pytest.mark.parametrize` entry pairs a symbol
+   reference (e.g. `ClientArgsCreator.get_client_args` or
+   `_apply_request_trailer_checksum`) with its SHA-1 hash. A function's
+   presence or absence in this file is the deterministic answer to "is
+   this overridden in aiobotocore?" — **do not infer override status
+   from file mirror alone**; a file may contain many functions and only
+   some are actually overridden.
+
+   Read `tests/test_patches.py` up front and keep the symbol set in
+   working memory for Step 3's check.
 
 Call this set `OVERRIDDEN`. Entries are relative paths like `client.py` or
 `retries/adaptive.py` — NOT basenames. Any changed botocore file whose
@@ -97,8 +113,13 @@ For each added/changed function, inspect the **new code** for these signals:
   not require a code port. They DO bust the hash in `tests/test_patches.py`, which needs a bump,
   but that's mechanical — not a classifier signal.
 
-  Check: for each changed function, (1) grep `aiobotocore/<mirror>.py` for `async def <same-name>`
-  or `def <same-name>`; (2) if found, determine whether the change is cosmetic or substantive. If
+  Check (authoritative): look up the function's dotted name
+  (`ClassName.method` or bare `function_name`) in the Step 1 symbol
+  registry from `tests/test_patches.py`. If absent, the function is NOT
+  overridden in aiobotocore — classify as `pure-sync` regardless of
+  I/O content in the botocore diff. A change to non-overridden code
+  does not require a port. Only if the symbol IS in the registry, then
+  determine whether the change is cosmetic or substantive; if
   substantive, flag as needs-async regardless of body purity.
 
   Three examples:

--- a/plugins/aiobotocore-bot/skills/check-async-need/SKILL.md
+++ b/plugins/aiobotocore-bot/skills/check-async-need/SKILL.md
@@ -166,39 +166,56 @@ function in aiobotocore's world), check the diff for callers:
   Only flag callers where the new call appears as a concrete added line
   inside a registered-override body.
 
-## Step 4: Output format — strict
+## Step 4: Output format — reason first, verdict last
 
 **Output protocol — follow in this order:**
 
-1. First, mentally work through each changed function and determine its
-   verdict per Step 3. Do not write anything yet.
-2. Apply the roll-up rule: if ANY per-function verdict is
-   `needs-async` / `port-required`, the top-line MUST be
-   `port-required`. If any is `ambiguous` and none are needs-async,
-   the top-line is `ambiguous`. Only if EVERY verdict is `pure-sync`
-   is the top-line `no-port`.
-3. **Sanity check**: before you write the CLASSIFICATION line, confirm
-   that the verdict on it is consistent with the per-function verdicts
-   you're about to emit. If your detailed reasoning below arrives at
-   `port-required` for any function but you're writing
-   `CLASSIFICATION: no-port`, STOP — the top-line is wrong. Rewrite.
-4. Now emit the response. The FIRST LINE must be
-   `CLASSIFICATION: <verdict>` where `<verdict>` is one of `no-port`,
-   `port-required`, or `ambiguous`. No preamble.
+1. Write per-function detail FIRST. For each changed function, run
+   through Step 3's rules in order and record the verdict. For any
+   port-required verdict, you MUST be able to quote the exact string
+   from the `overrides` list that the function's name matched (or the
+   exact async-method / aio-class name it contacted). If you can't
+   produce a specific quoted match, the verdict is not port-required
+   — try the remaining Step-C rules or fall to pure-sync.
+2. After all per-function detail, write the Summary block.
+3. LAST, emit `CLASSIFICATION: <verdict>` on its own line where
+   `<verdict>` is `no-port`, `port-required`, or `ambiguous`, chosen
+   by the roll-up rule: any function port-required → top-line
+   port-required; any ambiguous and none port-required → ambiguous;
+   every function pure-sync → no-port.
+4. If while writing the Summary or CLASSIFICATION line you realize an
+   earlier per-function verdict was wrong, DO NOT just flip the
+   top-line. Go back and correct the specific per-function entry,
+   THEN re-run the roll-up for CLASSIFICATION. The top-line must
+   follow from the per-function verdicts as written.
 
-After the classification line, emit per-function detail:
+Response shape:
 
 ```text
-CLASSIFICATION: no-port | port-required | ambiguous
-
-Summary: <N> functions inspected across <M> overridden files. <P> pure-sync, <Q> needs-async, <R> ambiguous.
-
 ## Per-function verdicts
 
 ### botocore/<file> → aiobotocore/<file>
 - `<name>` (added|changed|removed|renamed): <verdict>
   Reason: <one-line justification naming the specific signal or absence thereof>
+
+Summary: <N> functions inspected across <M> overridden files. <P> pure-sync, <Q> needs-async, <R> ambiguous.
+
+CLASSIFICATION: no-port | port-required | ambiguous
 ```
+
+### HASH-BUMP IS NOT A PORT CONCERN
+
+A recurring trap: when an upstream change will cause a
+`tests/test_patches.py` hash to change, the temptation is to flag
+port-required because "the hash will fail." That is WRONG.
+
+`tests/test_patches.py` hashes get bumped mechanically as part of every
+sync (port or no-port). A hash change is a build consequence, not a
+classification signal. If the only reason you can articulate for
+`port-required` is "the hash will break" or "the test will fail", the
+correct verdict is NOT port-required — it's whatever the async-need
+rules say (typically `pure-sync`, with a hash bump done by the caller
+mechanically during sync).
 
 Roll-up rules:
 

--- a/plugins/aiobotocore-bot/skills/check-async-need/SKILL.md
+++ b/plugins/aiobotocore-bot/skills/check-async-need/SKILL.md
@@ -166,30 +166,18 @@ function in aiobotocore's world), check the diff for callers:
   Only flag callers where the new call appears as a concrete added line
   inside a registered-override body.
 
-## Step 4: Output format — reason first, verdict last
+## Step 4: Output format
 
-**Output protocol — follow in this order:**
+**When invoked via the eval harness**: the caller forces a structured
+tool call (`record_async_need_classification`). Reason through each
+changed function in text (quote the exact `overrides` / `async_methods`
+/ `aio_classes` match for every port-required verdict), then call the
+tool ONCE with `verdict`, `summary`, and `per_function_verdicts`. The
+tool call is the authoritative output.
 
-1. Write per-function detail FIRST. For each changed function, run
-   through Step 3's rules in order and record the verdict. For any
-   port-required verdict, you MUST be able to quote the exact string
-   from the `overrides` list that the function's name matched (or the
-   exact async-method / aio-class name it contacted). If you can't
-   produce a specific quoted match, the verdict is not port-required
-   — try the remaining Step-C rules or fall to pure-sync.
-2. After all per-function detail, write the Summary block.
-3. LAST, emit `CLASSIFICATION: <verdict>` on its own line where
-   `<verdict>` is `no-port`, `port-required`, or `ambiguous`, chosen
-   by the roll-up rule: any function port-required → top-line
-   port-required; any ambiguous and none port-required → ambiguous;
-   every function pure-sync → no-port.
-4. If while writing the Summary or CLASSIFICATION line you realize an
-   earlier per-function verdict was wrong, DO NOT just flip the
-   top-line. Go back and correct the specific per-function entry,
-   THEN re-run the roll-up for CLASSIFICATION. The top-line must
-   follow from the per-function verdicts as written.
-
-Response shape:
+**When invoked directly (human via slash command or agent without tool
+schema)**: emit the following plain text at the END of your response,
+after reasoning:
 
 ```text
 ## Per-function verdicts
@@ -202,6 +190,10 @@ Summary: <N> functions inspected across <M> overridden files. <P> pure-sync, <Q>
 
 CLASSIFICATION: no-port | port-required | ambiguous
 ```
+
+Either way, the roll-up rule: any function port-required → top-line
+port-required; any ambiguous and none port-required → ambiguous; every
+function pure-sync → no-port.
 
 ### HASH-BUMP IS NOT A PORT CONCERN
 

--- a/plugins/aiobotocore-bot/skills/check-async-need/SKILL.md
+++ b/plugins/aiobotocore-bot/skills/check-async-need/SKILL.md
@@ -1,23 +1,18 @@
 ---
 description: Use when classifying a botocore version bump as no-port, port-required, or ambiguous. Diffs `$FROM..$TO` in a bare botocore clone, inspects every added/changed function in overridden files, and emits `CLASSIFICATION:` plus per-function reasons. Shared by the sync bot (to pick no-port vs port path) and the PR reviewer (to sanity-check sync-bot PRs).
 argument-hint: "--from=<version> --to=<version> [--aiobotocore-root=<path>] [--botocore-clone=<path>]"
-allowed-tools: Bash(git -C /tmp/botocore:*) Bash(find:*) Bash(sed:*) Bash(cat:*) Bash(test:*) Bash(grep:*)
+allowed-tools: Bash(git -C /tmp/botocore:*) Bash(find:*) Bash(sed:*) Bash(cat:*) Bash(test:*) Bash(grep:*) Bash(uv run python:*)
 ---
 
-<!--
-Tool note: Step 3's async-def lookup inside `aiobotocore/<file>.py` uses the Read tool, not
-Bash, so no Bash(cat aiobotocore/*) entry is needed in allowed-tools above. Only the botocore
-clone and filesystem-mirror checks go through Bash.
--->
+Classify a botocore version bump for aiobotocore. Given a botocore tag
+range, decide whether aiobotocore needs code changes (port-required),
+just a version-bounds update (no-port), or the diff is non-trivial enough
+to escalate (ambiguous).
 
-Given a botocore version range, inspect every new or changed function in botocore files that have a mirror in
-`aiobotocore/` and return a structured verdict for each. This is the shared async-need classifier used by both
-the sync bot (to decide no-port vs port-required and justify it) and the PR reviewer (to independently sanity-check a
-sync-bot PR).
-
-The classifier answers: **"would aiobotocore need to override this function going forward?"** It does NOT
-answer "did we already override it". The relevant distinction is async-worthiness of the new code, not the
-historical override status.
+The classifier answers: **"do aiobotocore overrides need to change to
+stay correct?"** — where "correct" means aiobotocore's async flow
+continues to work without runtime errors and without silently diverging
+from botocore's behavior.
 
 ## Arguments
 
@@ -29,168 +24,113 @@ historical override status.
 Assume the clone already exists and has both tags fetched. If it does not, return `error: botocore clone
 missing or tag unavailable` and stop — the caller is responsible for provisioning it.
 
-## Step 1: Enumerate overridden files and symbols
+## Step 1: Load the authoritative registries
 
-Two registries matter:
-
-1. **File mirror**: `botocore/<relpath>` is a candidate for override iff
-   `aiobotocore/<relpath>` exists. Must recurse into subdirectories —
-   `aiobotocore/retries/*.py` mirrors `botocore/retries/*.py`, and those
-   paths do get modified on syncs.
-
-   ```text
-   find "$AIOBOTOCORE_ROOT" -name '*.py' | sed "s|^$AIOBOTOCORE_ROOT/||"
-   ```
-
-2. **Symbol registry** (authoritative): `tests/test_patches.py` is the
-   source of truth for every botocore class/method/function aiobotocore
-   overrides. Each `pytest.mark.parametrize` entry pairs a symbol
-   reference (e.g. `ClientArgsCreator.get_client_args` or
-   `_apply_request_trailer_checksum`) with its SHA-1 hash. A function's
-   presence or absence in this file is the deterministic answer to "is
-   this overridden in aiobotocore?" — **do not infer override status
-   from file mirror alone**; a file may contain many functions and only
-   some are actually overridden.
-
-   Read `tests/test_patches.py` up front and keep the symbol set in
-   working memory for Step 3's check.
-
-Call this set `OVERRIDDEN`. Entries are relative paths like `client.py` or
-`retries/adaptive.py` — NOT basenames. Any changed botocore file whose
-`botocore/`-stripped path isn't in this set is out of scope; skip it.
-
-Do not use `ls *.py | xargs basename`: that misses nested files AND
-strips the directory, so the pathspec in Step 2 would become
-`botocore/adaptive.py` instead of `botocore/retries/adaptive.py` — a
-non-existent path that silently returns an empty diff.
-
-## Step 2: Enumerate changed functions in overridden files
-
-For each file `f` in `OVERRIDDEN` that appears in the diff (recall: `f` is a
-relative path, possibly including a subdirectory):
+Run the shared registry-emit script and parse its JSON output:
 
 ```text
-git -C $BOTOCORE_CLONE diff $FROM..$TO -- botocore/$f
+uv run python plugins/aiobotocore-bot/scripts/registries.py
 ```
 
-Identify every function (top-level `def` / `async def` and class methods) that was:
+The payload has three fields:
 
-- **added** (new `def` that did not exist at `$FROM`)
-- **changed** (body differs, not just whitespace/comments/docstrings)
+- `overrides` — every botocore symbol aiobotocore has explicitly
+  overridden (from `tests/test_patches.py`). Entries are either
+  `ClassName.method_name` or bare function names or bare class names.
+  Authoritative for "did we already override this exact symbol?".
+- `async_methods` — every method name that `aiobotocore/**/*.py`
+  defines as `async def`, plus a small curated set of sync-signature
+  methods that delegate to async internals (e.g. `emit` delegating to
+  `_emit`). Use for **duck-typed contamination**: a call `x.<name>(...)`
+  on an unknown `x` is suspect if `<name>` is in this set.
+- `aio_classes` — every `class AioX(...)` defined in aiobotocore. A new
+  botocore call that instantiates or subclasses the non-Aio parent
+  (e.g. `ClientCreator(...)` when `AioClientCreator` exists) needs to
+  be routed through the Aio subclass.
 
-For a changed function, compare the new body against the old body — the relevant unit is the **delta**, not
-the whole function. If a new branch adds `requests.get(...)` to an otherwise-pure function, that's a
-needs-async verdict even if the rest of the function was fine.
+Keep all three in working memory for Steps 3–4.
 
-Pure-docstring, pure-type-annotation, pure-whitespace/formatting, and pure-import-reorder changes are
-not interesting — classify as `pure-sync` with reason `cosmetic`. They bust the SHA1 hashes in
-`tests/test_patches.py` (which hashes bytes, not semantics) but that's a mechanical one-line update,
-not a port. Don't let a hash mismatch alone drive a port-required verdict.
+## Step 2: Enumerate the botocore diff
 
-## Step 3: Classify each function
+For each file in `$FROM..$TO` under `botocore/` that also has a mirror
+in `aiobotocore/`:
 
-For each added/changed function, inspect the **new code** for these signals:
+```text
+git -C $BOTOCORE_CLONE diff $FROM..$TO -- botocore/<path>
+```
 
-**needs-async** — any of:
+Scan each file's diff for changed/added/removed functions. For every
+function identified, collect: name, change type (added / removed /
+changed / renamed), and the relevant body lines.
 
-- Calls that perform network or disk I/O: `requests.*`, `urllib.*`, `http.client.*`, `socket.*`,
-  `open(...)` for real files, `subprocess.*`, anything that hits the filesystem or network
-- Calls to functions that aiobotocore already makes async — check `aiobotocore/$f` for an `async def`
-  version (match by method name within the subclassed class)
-- Instantiation or use of a botocore class that aiobotocore subclasses (search `aiobotocore/` for
-  `class Aio<Name>(<Name>)` — if `<Name>` is instantiated in the new code, the override chain must
-  extend to this new caller)
-- **Substantive changes to functions aiobotocore overrides.** If botocore modifies a function in
-  a way that affects behavior — signature (params added/removed/renamed/reordered) OR body
-  (new internal call, removed internal call, changed control flow, guard added/removed, return
-  value shape change) — AND aiobotocore has an `async def` override of that same function, the
-  override must mirror the change. This holds even when the new code is pure-sync
-  dict/arithmetic: the override has to stay in lockstep with botocore's behavior or callers
-  silently diverge.
+`botocore/data/**/*.json` and non-Python files are out of scope —
+schema/endpoint data is never ported.
 
-  **Cosmetic-only changes are not port-driving** (Step 2's cosmetic carve-out applies): docstring
-  edits, pure whitespace/formatting changes, pure type-hint additions, and import reordering do
-  not require a code port. They DO bust the hash in `tests/test_patches.py`, which needs a bump,
-  but that's mechanical — not a classifier signal.
+## Step 3: Classify each function (apply the algorithm)
 
-  Check (authoritative for existing code): look up the function's
-  dotted name (`ClassName.method` or bare `function_name`) in the Step
-  1 symbol registry from `tests/test_patches.py`. If absent, the
-  function is NOT an existing tracked override — a change to it does
-  not force port-required on its own. Only if the symbol IS in the
-  registry AND the change is substantive (signature, call graph,
-  control flow), flag as needs-async.
+For each function `F`, execute:
 
-  Registry entry shapes — be strict:
+### A. File scope
 
-  - `ClassName.method_name` — only that specific method is mirrored.
-  - Bare function name — that module-level function is mirrored.
-  - Bare class name (e.g. `URLLib3Session` alone) — the class source
-    is hashed, but it does NOT mean every method is mirrored. A change
-    to a method like `URLLib3Session._get_pool_manager_kwargs` is
-    port-required ONLY if that specific dotted form is listed.
+If `botocore/<F's file>` has no `aiobotocore/<same path>` mirror → skip
+(inherited as-is by virtue of not being subclassed).
 
-  Do not generalize class-level presence to method-level. Do not infer
-  overrides from file-mirror existence.
+### B. Classify the change
 
-  **New functions** (not in registry): the registry lags behind — a
-  newly added botocore function won't be listed yet. Classify on I/O
-  signals in the new body: blocking primitives, calls to something
-  aiobotocore already overrides (e.g. `self._emit(...)` where
-  `HierarchicalEmitter.emit` is registered — aiobotocore's override is
-  async, so the new caller must be awaited-in-async too), instantiation
-  of a registered class where the constructor is async, etc. A new
-  function can be needs-async even though it isn't in the registry.
+- **Deleted** (removed from botocore, no replacement in diff): check
+  whether aiobotocore still calls `F` anywhere. If yes → `port-required`
+  (caller has to retarget). If no → `pure-sync` with reason
+  "botocore deletion; aiobotocore does not reference".
+- **Renamed** (paired `-def X` + `+def Y` with matching signature/body):
+  `port-required` — any aiobotocore caller of `X` must update to `Y`.
+- **Refactored** (body moved across functions): analyze each side's
+  body for async contamination per Step C.
+- **New** or **Changed**: go to Step C.
 
-  **Call-graph back-track**: if any function in the diff is classified
-  needs-async, scan the diff and the existing registry for callers.
-  Any caller that's already a registered override must be flagged as
-  port-required too — once aiobotocore mirrors the callee as `async
-  def`, callers need to `await` it, which is a signature change on the
-  caller's side.
+### C. Async-contamination check on F's body
 
-  Three examples:
-  - **needs-async**: `get_client_args` gains a `s3_disable_express_session_auth` parameter in
-    botocore → `AioClientArgsCreator.get_client_args` must mirror the signature.
-  - **needs-async**: `_apply_request_trailer_checksum` body stops calling
-    `_register_checksum_algorithm_feature_id` internally (registration moved to a new helper) →
-    aiobotocore's override must drop the inner call too, or behavior silently diverges.
-  - **pure-sync / cosmetic**: `_make_api_call` gains a new docstring describing existing behavior
-    → hash update only; aiobotocore's override doesn't need to mirror the docstring to stay
-    behaviorally aligned.
-- Blocking primitives: `time.sleep`, `threading.*`, `queue.Queue.get` without timeout, `concurrent.*`
-- New event-hook handler registrations that may be fed awaitables downstream (handlers registered for
-  events that aiobotocore resolves via `resolve_awaitable`)
+Inspect the NEW body (for added/changed) or OLD body (for deleted):
 
-**pure-sync** — none of the above; the new code is dict/list/str manipulation, attribute access, regex,
-arithmetic, or calls to other pure-sync botocore utilities.
+1. **Network I/O**: does the body call network I/O primitives —
+   `requests.*`, `urllib.*`, `http.client.*`, `socket.*`, anything
+   that hits a remote endpoint? → contaminated. Note: file I/O
+   (`open`, `os.fsync`, `tempfile`) is NOT a contamination signal —
+   aiobotocore doesn't do async file I/O.
+2. **Registry contamination**: does the body call a name in
+   `async_methods`, or instantiate a class whose Aio-prefixed version
+   is in `aio_classes`? → contaminated. Be strict about the match:
+   `x.read(...)` on an unknown receiver is `ambiguous`; `self._emit(...)`
+   or `self._client_creator(...)` where `_client_creator` is a known
+   async factory is `port-required`.
+3. **Registered override, substantive change**: if `F`'s dotted name
+   is in `overrides` and the body change is substantive — added/removed
+   internal call, changed control flow, signature added/removed/renamed
+   param — flag `port-required` regardless of explicit contamination.
+   The override must mirror upstream behavior.
+4. **Cosmetic only**: docstring edits, pure whitespace/formatting, pure
+   type-hint additions, import reorder — `pure-sync` with reason
+   `cosmetic`. These bust hashes in `tests/test_patches.py` (mechanical
+   bump only) but don't require a code port.
+5. **Nothing else matches**: `pure-sync`.
 
-**ambiguous** — calls an unfamiliar helper whose body you cannot inspect within this skill run, OR the
-call graph is deep enough that you can't rule out I/O without tracing. Prefer `ambiguous` over a wrong
-confident verdict; the caller will escalate.
+### D. Propagate up (call-graph back-track)
 
-### Common false-positive signal patterns (do NOT flag as needs-async)
+If `F` in Step C newly becomes `port-required` (i.e. it's now an async
+function in aiobotocore's world), check the diff for callers:
 
-Not every `await` / `asyncio` / `threading` token in the diff is a real async-need signal:
+- Any caller currently in `overrides` that now contains a new call to
+  `F` (visible as an added line in the caller's body) → that caller is
+  also `port-required` (needs to `await F` or the equivalent).
+- Do NOT recursively invent back-track chains from class membership.
+  Only flag callers where the new call appears as a concrete added line
+  inside a registered-override body.
 
-- **String literals and docstrings.** A log message, error text, or docstring that mentions
-  "await" or "threading" is not code. Ignore.
-- **Comments.** `# async version of X` is not executable.
-- **Test fixtures or test-only helpers.** Code under `botocore/tests/` or `botocore/stubbing.py`
-  is test scaffolding; aiobotocore doesn't override tests.
-- **Unreached paths.** A new sync-only helper defined in an overridden file but never called
-  from an aiobotocore-overridden code path isn't something we need to port. If you can verify
-  nothing in aiobotocore (including via the override chain) calls the new helper, it's
-  pure-sync regardless of what the helper itself does.
-- **`botocore/data/`** — schema and model JSON files are never code we override. They're
-  excluded by the filename-mirror filter in Step 1; if any leak through, ignore.
+## Step 4: Output format — strict
 
-When in doubt between `pure-sync` and `ambiguous`, choose `ambiguous`. A false `pure-sync` on
-a real need-to-override is worse than a false alarm.
+The FIRST LINE must be `CLASSIFICATION: <verdict>` where `<verdict>` is
+one of `no-port`, `port-required`, or `ambiguous`. No preamble.
 
-## Step 4: Output
-
-Emit a structured report. Two sections: a summary line the caller can grep, followed by per-function detail.
+After the classification line, emit per-function detail:
 
 ```text
 CLASSIFICATION: no-port | port-required | ambiguous
@@ -199,38 +139,46 @@ Summary: <N> functions inspected across <M> overridden files. <P> pure-sync, <Q>
 
 ## Per-function verdicts
 
-### botocore/handlers.py  →  aiobotocore/handlers.py
-- `_set_sigv4a_signing_context` (added): pure-sync
-  Reason: only dict manipulation and a call to `_resolve_sigv4a_region`, itself pure (attribute access and
-  dict lookups).
-- `_set_auth_scheme_preference_signer` (changed): pure-sync
-  Reason: new call to `_set_sigv4a_signing_context`; the called helper is pure-sync (see above).
-
-### botocore/<otherfile>.py  →  aiobotocore/<otherfile>.py
-- `<function>` (added|changed): <verdict>
-  Reason: <one-line justification, naming the specific signal or absence thereof>
+### botocore/<file> → aiobotocore/<file>
+- `<name>` (added|changed|removed|renamed): <verdict>
+  Reason: <one-line justification naming the specific signal or absence thereof>
 ```
 
-The top-level `CLASSIFICATION` is:
+Roll-up rules:
 
-- `no-port` if and only if every verdict is `pure-sync`
-- `port-required` if any verdict is `needs-async`
-- `ambiguous` if there are no `needs-async` verdicts but at least one `ambiguous` (caller must resolve
-  before concluding no-port)
-
-## Consumption
-
-**Sync bot** (`botocore-sync-prompt.md`): runs this in Step 3. If `CLASSIFICATION: no-port`, proceed to
-Step 4 (no-port path) and quote the summary in the PR body as the async-need justification. If `port-required`,
-go to Step 5 (bump path). If `ambiguous`, go to Step 9 (feedback issue) with the ambiguous verdicts as the
-questions.
-
-**Reviewer** (`review-pr` skill): runs this in Step 3d for sync-bot-authored PRs, extracting `$FROM` / `$TO`
-from the botocore diff URL in the PR body. If the PR claims no-port but this skill returns `port-required`
-or `ambiguous`, flag the mismatch as a high-confidence review issue.
+- `no-port` iff every per-function verdict is `pure-sync`.
+- `port-required` iff any verdict is `needs-async` (or `port-required`
+  by any other path through the algorithm).
+- `ambiguous` iff no `needs-async` but at least one `ambiguous` — the
+  caller must resolve before treating as `no-port`.
 
 ## Honesty
 
-Never classify as `pure-sync` without having read the new code. If you could not read a file (diff command
-failed, file missing), return `error: <reason>` instead of guessing. A false `pure-sync` verdict on a
-function with I/O would let a bad no-port verdict ship.
+Never claim `pure-sync` without inspecting the new body. If you could
+not read a file (diff command failed, file missing), return
+`error: <reason>` instead of guessing. Prefer `ambiguous` over a wrong
+confident verdict — a false `pure-sync` on a function with async
+contamination is how missed ports (#1126 class) slip through.
+
+## Human-review territory
+
+These patterns are hard for a static classifier to catch; emit
+`ambiguous` and flag for human review when encountered:
+
+- Context propagation through decorator chains (e.g. `with_current_context`).
+- Callback identity bound at object construction time (e.g.
+  `EPRBuiltins.ACCOUNT_ID = credentials.get_account_id` pattern).
+- Async lifecycle semantics (session/client teardown, `__aenter__` /
+  `__aexit__` contracts).
+
+## Consumption
+
+**Sync bot** (`botocore-sync-prompt.md`): runs this as the Step 3
+classifier. If `no-port`, proceed to Step 4 (no-port path) and quote the
+summary in the PR body. If `port-required`, go to Step 5 (bump path).
+If `ambiguous`, escalate via Step 9 (feedback issue).
+
+**Reviewer** (`review-pr` skill): runs this in Step 3d on sync-bot PRs,
+extracting `$FROM` / `$TO` from the PR body. If the PR claims no-port
+but this skill returns `port-required` or `ambiguous`, flag the
+mismatch as high-confidence.

--- a/plugins/aiobotocore-bot/skills/check-async-need/SKILL.md
+++ b/plugins/aiobotocore-bot/skills/check-async-need/SKILL.md
@@ -102,39 +102,49 @@ Inspect the NEW body (for added/changed) or OLD body (for deleted):
    `x.read(...)` on an unknown receiver is `ambiguous`; `self._emit(...)`
    or `self._client_creator(...)` where `_client_creator` is a known
    async factory is `port-required`.
-3. **Registered override, substantive change**: if `F`'s EXACT dotted
-   name (e.g. `ClientArgsCreator.get_client_args`) or bare function
-   name (e.g. `_apply_request_trailer_checksum`) appears in the
-   `overrides` list, AND the body change is anything other than
-   pure-cosmetic (see #4 below) — **including a line removal, a call
-   swap, a rename, a control-flow tweak, or a new guard** — flag
-   `port-required`. The aiobotocore override MUST mirror the upstream
-   body. The goal here is byte-level alignment with botocore, not
-   whether the change affects async correctness: a registration-side-
-   effect line removed upstream still has to be removed in the
-   override to keep the sync diff minimal. "Cosmetic/minor refactor"
-   is NOT a pass — if a code line was removed, added, or substituted,
-   it's substantive.
+3. **Registered override, substantive change**: this rule has a hard
+   prerequisite — apply it ONLY after the following gate passes:
 
-   **CRITICAL — do not extrapolate from class to method.** If a bare
-   class name appears in `overrides` (e.g. `URLLib3Session` with no
-   dot), that means the ENTIRE class source is hashed in
-   `test_patches.py` for byte-level change detection. It does NOT
-   mean any particular method of that class is mirrored by
-   aiobotocore. A change to `URLLib3Session._get_pool_manager_kwargs`
-   is `port-required` ONLY if `URLLib3Session._get_pool_manager_kwargs`
-   itself appears in the `overrides` list. If only the bare class
-   `URLLib3Session` appears (and not the method), a body change to a
-   method of that class requires a hash bump in `test_patches.py` but
-   is NOT port-required — aiobotocore inherits the method unchanged.
+   **GATE — is `F` an aiobotocore-tracked override?**
 
-   Concretely: before flagging port-required via rule #3, verify you
-   can point to the EXACT string in the `overrides` list (either the
-   full `ClassName.method` form or a bare name). If you find yourself
-   writing "ClassName is in overrides and method_name is a method of
-   ClassName, therefore method_name is mirrored" — STOP. That's the
-   extrapolation failure. You must find the exact dotted form
-   `ClassName.method_name` or don't apply rule #3.
+   Scan the `overrides` list for an exact string match of:
+   - `F`'s full dotted name (e.g. `ClientArgsCreator.get_client_args`), OR
+   - `F`'s bare name when `F` is a module-level function (e.g.
+     `_apply_request_trailer_checksum`).
+
+   A bare class name in `overrides` (e.g. `URLLib3Session` with no
+   dot) does NOT match any of that class's methods. Class-level
+   tracking in `test_patches.py` only means the class's full source
+   is hashed for detecting upstream edits; it says NOTHING about
+   whether aiobotocore overrides any specific method. The only
+   thing that makes `URLLib3Session._get_pool_manager_kwargs` a
+   tracked override is `URLLib3Session._get_pool_manager_kwargs`
+   appearing verbatim in `overrides`.
+
+   If the gate fails — i.e. you cannot point to the exact string in
+   `overrides` — rule #3 does NOT apply. Do not substitute reasoning
+   about "parity", "divergence", "silent behavior drift", or "keeping
+   in sync". Those concerns are about the broader project philosophy,
+   not about this verdict. Proceed to the other Step-C rules; the
+   function may still be flagged via rule #1 (network I/O) or rule #2
+   (calls something in `async_methods` / `aio_classes`). Absent any
+   of those, it's `pure-sync` — aiobotocore inherits it unchanged.
+
+   If the gate PASSES, then: the body change is `port-required` if
+   it's anything other than pure-cosmetic (see #4) — including a line
+   removal, a call swap, a rename, a control-flow tweak, or a new
+   guard. aiobotocore's override file has to be updated to match the
+   new upstream body. "Cosmetic/minor refactor" is NOT a pass here —
+   if a code line was removed, added, or substituted inside a tracked
+   override, it's substantive.
+
+   **STOP-RULE**: if your draft rationale contains phrases like
+   "ClassName is in overrides, method is a method of ClassName,
+   therefore..." or "even though the method isn't overridden, we
+   should flag for parity/divergence" — ABORT that reasoning. Return
+   to the gate. If the exact name isn't in `overrides`, rule #3 is
+   not applicable regardless of how philosophically appealing a
+   port-required verdict feels.
 4. **Cosmetic only**: docstring edits, pure whitespace/formatting, pure
    type-hint additions, import reorder — `pure-sync` with reason
    `cosmetic`. These bust hashes in `tests/test_patches.py` (mechanical

--- a/plugins/aiobotocore-bot/skills/check-async-need/SKILL.md
+++ b/plugins/aiobotocore-bot/skills/check-async-need/SKILL.md
@@ -103,14 +103,23 @@ Inspect the NEW body (for added/changed) or OLD body (for deleted):
    or `self._client_creator(...)` where `_client_creator` is a known
    async factory is `port-required`.
 3. **Registered override, substantive change**: if `F`'s dotted name
-   is in `overrides` and the body change is substantive — added/removed
-   internal call, changed control flow, signature added/removed/renamed
-   param — flag `port-required` regardless of explicit contamination.
-   The override must mirror upstream behavior.
+   is in `overrides` and the body change is anything other than
+   pure-cosmetic (see #4 below) — **including a line removal, a call
+   swap, a rename, a control-flow tweak, or a new guard** — flag
+   `port-required`. The aiobotocore override MUST mirror the upstream
+   body. The goal here is byte-level alignment with botocore, not
+   whether the change affects async correctness: a registration-side-
+   effect line removed upstream still has to be removed in the
+   override to keep the sync diff minimal. "Cosmetic/minor refactor"
+   is NOT a pass — if a code line was removed, added, or substituted,
+   it's substantive.
 4. **Cosmetic only**: docstring edits, pure whitespace/formatting, pure
    type-hint additions, import reorder — `pure-sync` with reason
    `cosmetic`. These bust hashes in `tests/test_patches.py` (mechanical
-   bump only) but don't require a code port.
+   bump only) but don't require a code port. If you're writing
+   "removed a line / added a line but it's just cosmetic" that's a
+   contradiction — removed/added code lines are substantive, not
+   cosmetic.
 5. **Nothing else matches**: `pure-sync`.
 
 ### D. Propagate up (call-graph back-track)
@@ -127,8 +136,23 @@ function in aiobotocore's world), check the diff for callers:
 
 ## Step 4: Output format — strict
 
-The FIRST LINE must be `CLASSIFICATION: <verdict>` where `<verdict>` is
-one of `no-port`, `port-required`, or `ambiguous`. No preamble.
+**Output protocol — follow in this order:**
+
+1. First, mentally work through each changed function and determine its
+   verdict per Step 3. Do not write anything yet.
+2. Apply the roll-up rule: if ANY per-function verdict is
+   `needs-async` / `port-required`, the top-line MUST be
+   `port-required`. If any is `ambiguous` and none are needs-async,
+   the top-line is `ambiguous`. Only if EVERY verdict is `pure-sync`
+   is the top-line `no-port`.
+3. **Sanity check**: before you write the CLASSIFICATION line, confirm
+   that the verdict on it is consistent with the per-function verdicts
+   you're about to emit. If your detailed reasoning below arrives at
+   `port-required` for any function but you're writing
+   `CLASSIFICATION: no-port`, STOP — the top-line is wrong. Rewrite.
+4. Now emit the response. The FIRST LINE must be
+   `CLASSIFICATION: <verdict>` where `<verdict>` is one of `no-port`,
+   `port-required`, or `ambiguous`. No preamble.
 
 After the classification line, emit per-function detail:
 

--- a/plugins/aiobotocore-bot/skills/check-async-need/SKILL.md
+++ b/plugins/aiobotocore-bot/skills/check-async-need/SKILL.md
@@ -172,8 +172,9 @@ function in aiobotocore's world), check the diff for callers:
 tool call (`record_async_need_classification`). Reason through each
 changed function in text (quote the exact `overrides` / `async_methods`
 / `aio_classes` match for every port-required verdict), then call the
-tool ONCE with `verdict`, `summary`, and `per_function_verdicts`. The
-tool call is the authoritative output.
+tool ONCE with `verdict` and a `rationale` that contains the per-function
+breakdown + a roll-up summary. The tool call is the authoritative
+output.
 
 **When invoked directly (human via slash command or agent without tool
 schema)**: emit the following plain text at the END of your response,

--- a/plugins/aiobotocore-bot/skills/check-async-need/SKILL.md
+++ b/plugins/aiobotocore-bot/skills/check-async-need/SKILL.md
@@ -113,14 +113,41 @@ For each added/changed function, inspect the **new code** for these signals:
   not require a code port. They DO bust the hash in `tests/test_patches.py`, which needs a bump,
   but that's mechanical — not a classifier signal.
 
-  Check (authoritative): look up the function's dotted name
-  (`ClassName.method` or bare `function_name`) in the Step 1 symbol
-  registry from `tests/test_patches.py`. If absent, the function is NOT
-  overridden in aiobotocore — classify as `pure-sync` regardless of
-  I/O content in the botocore diff. A change to non-overridden code
-  does not require a port. Only if the symbol IS in the registry, then
-  determine whether the change is cosmetic or substantive; if
-  substantive, flag as needs-async regardless of body purity.
+  Check (authoritative for existing code): look up the function's
+  dotted name (`ClassName.method` or bare `function_name`) in the Step
+  1 symbol registry from `tests/test_patches.py`. If absent, the
+  function is NOT an existing tracked override — a change to it does
+  not force port-required on its own. Only if the symbol IS in the
+  registry AND the change is substantive (signature, call graph,
+  control flow), flag as needs-async.
+
+  Registry entry shapes — be strict:
+
+  - `ClassName.method_name` — only that specific method is mirrored.
+  - Bare function name — that module-level function is mirrored.
+  - Bare class name (e.g. `URLLib3Session` alone) — the class source
+    is hashed, but it does NOT mean every method is mirrored. A change
+    to a method like `URLLib3Session._get_pool_manager_kwargs` is
+    port-required ONLY if that specific dotted form is listed.
+
+  Do not generalize class-level presence to method-level. Do not infer
+  overrides from file-mirror existence.
+
+  **New functions** (not in registry): the registry lags behind — a
+  newly added botocore function won't be listed yet. Classify on I/O
+  signals in the new body: blocking primitives, calls to something
+  aiobotocore already overrides (e.g. `self._emit(...)` where
+  `HierarchicalEmitter.emit` is registered — aiobotocore's override is
+  async, so the new caller must be awaited-in-async too), instantiation
+  of a registered class where the constructor is async, etc. A new
+  function can be needs-async even though it isn't in the registry.
+
+  **Call-graph back-track**: if any function in the diff is classified
+  needs-async, scan the diff and the existing registry for callers.
+  Any caller that's already a registered override must be flagged as
+  port-required too — once aiobotocore mirrors the callee as `async
+  def`, callers need to `await` it, which is a signature change on the
+  caller's side.
 
   Three examples:
   - **needs-async**: `get_client_args` gains a `s3_disable_express_session_auth` parameter in

--- a/plugins/aiobotocore-bot/skills/check-async-need/SKILL.md
+++ b/plugins/aiobotocore-bot/skills/check-async-need/SKILL.md
@@ -102,8 +102,10 @@ Inspect the NEW body (for added/changed) or OLD body (for deleted):
    `x.read(...)` on an unknown receiver is `ambiguous`; `self._emit(...)`
    or `self._client_creator(...)` where `_client_creator` is a known
    async factory is `port-required`.
-3. **Registered override, substantive change**: if `F`'s dotted name
-   is in `overrides` and the body change is anything other than
+3. **Registered override, substantive change**: if `F`'s EXACT dotted
+   name (e.g. `ClientArgsCreator.get_client_args`) or bare function
+   name (e.g. `_apply_request_trailer_checksum`) appears in the
+   `overrides` list, AND the body change is anything other than
    pure-cosmetic (see #4 below) — **including a line removal, a call
    swap, a rename, a control-flow tweak, or a new guard** — flag
    `port-required`. The aiobotocore override MUST mirror the upstream
@@ -113,6 +115,26 @@ Inspect the NEW body (for added/changed) or OLD body (for deleted):
    override to keep the sync diff minimal. "Cosmetic/minor refactor"
    is NOT a pass — if a code line was removed, added, or substituted,
    it's substantive.
+
+   **CRITICAL — do not extrapolate from class to method.** If a bare
+   class name appears in `overrides` (e.g. `URLLib3Session` with no
+   dot), that means the ENTIRE class source is hashed in
+   `test_patches.py` for byte-level change detection. It does NOT
+   mean any particular method of that class is mirrored by
+   aiobotocore. A change to `URLLib3Session._get_pool_manager_kwargs`
+   is `port-required` ONLY if `URLLib3Session._get_pool_manager_kwargs`
+   itself appears in the `overrides` list. If only the bare class
+   `URLLib3Session` appears (and not the method), a body change to a
+   method of that class requires a hash bump in `test_patches.py` but
+   is NOT port-required — aiobotocore inherits the method unchanged.
+
+   Concretely: before flagging port-required via rule #3, verify you
+   can point to the EXACT string in the `overrides` list (either the
+   full `ClassName.method` form or a bare name). If you find yourself
+   writing "ClassName is in overrides and method_name is a method of
+   ClassName, therefore method_name is mirrored" — STOP. That's the
+   extrapolation failure. You must find the exact dotted form
+   `ClassName.method_name` or don't apply rule #3.
 4. **Cosmetic only**: docstring edits, pure whitespace/formatting, pure
    type-hint additions, import reorder — `pure-sync` with reason
    `cosmetic`. These bust hashes in `tests/test_patches.py` (mechanical

--- a/plugins/aiobotocore-bot/skills/check-override-drift/SKILL.md
+++ b/plugins/aiobotocore-bot/skills/check-override-drift/SKILL.md
@@ -1,7 +1,7 @@
 ---
 description: Use when reviewing an aiobotocore PR that touches `aiobotocore/*.py` files with a botocore mirror. Compares each added line against the matching botocore function and emits `OVERRIDE_DRIFT:` (`clean` | `cosmetic-drift` | `behavioral-drift`) plus per-function detail. Distinguishes legitimate async gaps from unmatched additions that widen the sync diff.
 argument-hint: "(--pr=<number> | --diff=<path>) [--botocore-path=<path>]"
-allowed-tools: Bash(gh pr diff:*) Bash(gh pr view:*) Bash(python3 -c:*) Bash(ls:*)
+allowed-tools: Bash(gh pr diff:*) Bash(gh pr view:*) Bash(python3 -c:*) Bash(ls:*) Bash(grep:*) Bash(cat:*)
 ---
 
 aiobotocore exists to mirror botocore as closely as possible, with `async` sprinkled on
@@ -64,6 +64,14 @@ botocore mirror exists at `$BOTOCORE_PATH/<same-name>.py`. Files without a mirro
 Identify the function name (by scanning the hunk for enclosing `def`/`async def`).
 Read the matching function in botocore. If the function does not exist in botocore —
 skip it (new aiobotocore-only helper; unusual but not in scope for drift checking).
+
+**Authoritative override registry**: `tests/test_patches.py` enumerates every
+botocore symbol aiobotocore overrides. If the changed function's dotted name
+(`ClassName.method`) or bare name is NOT in that file, it is not a tracked
+override — either it's new code aiobotocore is adding without a counterpart
+(which should be flagged separately in Step 3) or it's a passthrough not under
+drift-check scope. Use the registry to distinguish "tracked override we expect
+to mirror botocore" from "something else".
 
 ## Step 3: Categorize each added/changed line
 

--- a/plugins/aiobotocore-bot/skills/open-pr/SKILL.md
+++ b/plugins/aiobotocore-bot/skills/open-pr/SKILL.md
@@ -20,6 +20,10 @@ so template changes flow through automatically and checklist-verification stays 
   `https://github.com/boto/botocore/compare/1.42.84...1.42.89`.
 - `--async-need-summary=<text>` (required for `sync-no-port`): the summary line from the
   `check-async-need` skill that justifies the no-port verdict. Do not paraphrase — quote it.
+- `--classifier-verdicts=<text>` (optional, sync modes): the per-function verdict block from the
+  `check-async-need` skill's `rationale` field. When provided, rendered as a markdown table in
+  the PR body so a human reviewer can spot-check each classification without re-running the
+  classifier. See "Classifier verdicts table" below for expected shape.
 - `--assumptions=<text>` (optional): design decisions for the "Assumptions" slot (bumps only).
 - `--changed-aiobotocore=<text>` (optional): summary of aiobotocore changes — files modified,
   classes added, tests ported. For no-port: pass `"Version bounds updated only, no code changes."`.
@@ -86,6 +90,8 @@ Append:
 ### What changed in aiobotocore
 <--changed-aiobotocore, default: Version bounds updated only, no code changes.>
 
+<Classifier verdicts table — see below — when --classifier-verdicts is provided>
+
 ### Reviewer checklist
 - [ ] Botocore diff reviewed — confirms no-port vs port-required
 - [ ] `test_patches.py` hashes current
@@ -110,6 +116,23 @@ Same as `sync-no-port` but:
 - Reviewer checklist items change to: async patterns correct, hashes updated for new overrides,
   version bump is minor, tests ported from botocore where applicable.
 - Omit the async-need summary line (the bump itself is the answer).
+
+### Classifier verdicts table (both sync modes)
+
+When `--classifier-verdicts` is provided, append a `### Classifier verdicts` section with a
+markdown table extracted from the classifier's per-function `rationale`. Each row is one
+changed/added/removed function the classifier inspected. Columns:
+
+| File | Function | Change | Verdict | Reason |
+|-|-|-|-|-|
+| botocore/args.py | `ClientArgsCreator.get_client_args` | changed | needs-async | Added call to async `self._emit`; override must mirror |
+| botocore/httpchecksum.py | `Sha512Checksum` | added | pure-sync | New class, no I/O, not in overrides |
+| botocore/utils.py | `has_checksum_header` | changed | pure-sync | Refactor delegates to new pure-sync helper |
+
+This table is the primary signal the human reviewer uses to validate the classifier's work —
+one row per function gives them the per-entry accountability the raw verdict hides. Parse the
+rationale into rows verbatim; if the rationale doesn't have per-function detail, omit the
+table (do not synthesize rows). Keep reason text to one short sentence — reviewers skim this.
 
 ## Step 5: Open or update
 

--- a/plugins/aiobotocore-bot/skills/port-tests/SKILL.md
+++ b/plugins/aiobotocore-bot/skills/port-tests/SKILL.md
@@ -110,10 +110,26 @@ Inside each ported test body:
 - Any call to a method or function in the `async_methods` registry gets awaited:
   `session.create_client(...)` → `await session.create_client(...)`.
 - Context managers that are now async become `async with`: `with session.create_client(...)` →
-  `async with session.create_client(...)`.
+  `async with session.create_client(...)`. For `ExitStack` / `contextlib.ExitStack`, use
+  `contextlib.AsyncExitStack` and `enter_async_context`.
 - `for chunk in stream` → `async for chunk in stream` when `stream` is a response body.
 - `stream.read()` → `await stream.read()` (read is in async_methods).
+- `client.get_paginator(...).paginate(...)` returns an async iterator — use
+  `async for page in paginator.paginate(...)`, not `.build_full_result()` which isn't
+  directly available. See `aiobotocore/paginate.py::AioPageIterator` for what's supported.
 - `mock.Mock(return_value=...)` on a coroutine target → `mock.AsyncMock(return_value=...)`.
+- `patch.object(obj, 'method', return_value=X)` when `method` is in `async_methods`: use
+  `AsyncMock(return_value=X)` or `new_callable=mock.AsyncMock`.
+- `side_effect=[a, b, c]` on async mocks: AsyncMock handles this natively; no change needed.
+- `side_effect=ExceptionClass` on async mocks: AsyncMock also handles this natively.
+- Fixtures that yield a client / session: keep the `yield` pattern, convert to
+  `async def` + add `async with` for the resource. Pytest-asyncio handles await on yields.
+- Event loop: DO NOT create new loops in fixtures. `asyncio_mode = "auto"` is set in
+  `pyproject.toml` — rely on it. Any `loop = asyncio.new_event_loop()` / `loop.run_until_complete`
+  patterns must be rewritten: the test becomes `async def`, the inner awaitables just get `await`.
+- `time.sleep(X)` in a test: replace with `await asyncio.sleep(X)` ONLY if the purpose is to
+  trigger time-sensitive behavior (e.g. credential refresh). For pure wait-until-state,
+  prefer polling with `asyncio.wait_for`.
 
 ### 3d. Stubber replacement
 
@@ -121,10 +137,37 @@ Inside each ported test body:
 aiobotocore clients. Replace with the helpers already exported by `tests.botocore_tests`:
 
 - `ClientHTTPStubber` → `from tests.botocore_tests import ClientHTTPStubber` (aiobotocore's
-  version, already async-aware)
-- `SessionHTTPStubber` → same import path
-- `botocore.stub.Stubber` for low-level API stubbing: no direct equivalent; flag the test as
-  requiring manual review in the advisory output.
+  version, already async-aware). Usage is identical: `async with ClientHTTPStubber(client) as s:`.
+- `SessionHTTPStubber` → same import path.
+- `botocore.stub.Stubber` for low-level API-level stubbing (not HTTP-level): no direct
+  equivalent. Flag the test in the advisory output with the note
+  "API-level Stubber — port manually; consider rewriting as ClientHTTPStubber with canned
+  HTTP responses, or move the test to the aiobotocore-specific test dir."
+
+### 3e. HTTP mock libraries
+
+`botocore` tests sometimes use `responses` (for `requests`-based mocking) or raw `mock.patch`
+on HTTP internals. aiobotocore uses aiohttp and httpx — neither is compatible with `responses`.
+
+- `responses.add(...)` / `@responses.activate` → replace with `ClientHTTPStubber` (above) OR
+  if the test needs specific HTTP-layer behavior not expressible via Stubber, use
+  `aioresponses` (for aiohttp) / `pytest-httpx` (for httpx). Flag for human review if
+  unclear which backend the test needs.
+- `mock.patch('botocore.httpsession.URLLib3Session.send')` → no direct equivalent in
+  aiobotocore (the async equivalent is `AioHTTPSession.send`). Usually the right move is to
+  use `ClientHTTPStubber` instead of patching the session class.
+
+### 3f. Patterns that need manual review (flag, don't auto-port)
+
+- Tests using `threading` / `multiprocessing` for parallelism — async equivalents use
+  `asyncio.gather` / `asyncio.create_task`. Human judgment needed on whether the test
+  exercises something aiobotocore actually does differently.
+- Tests that assert on private internals whose names/types differ between botocore
+  and aiobotocore (e.g. `_endpoint`, `_auth`). Don't blindly substitute.
+- Tests with `@pytest.mark.parametrize` over sync/async variants — usually port just the
+  async variant; human picks if the sync case has value.
+- Tests using `botocore.tests.BaseSessionTest` or similar class hierarchies. Convert the
+  TestCase → top-level async functions pattern; the fixture conversion requires judgment.
 
 ## Step 4: Write, validate, commit
 

--- a/plugins/aiobotocore-bot/skills/port-tests/SKILL.md
+++ b/plugins/aiobotocore-bot/skills/port-tests/SKILL.md
@@ -1,7 +1,7 @@
 ---
 description: Use when porting botocore tests to aiobotocore (during a port-required sync, or when backfilling historical test coverage). Converts sync test files under `botocore/tests/...` to their async counterparts under `tests/botocore_tests/...`, validates each port with `pytest -x`, commits on pass, reverts on fail. Handles both new/changed tests from a botocore diff AND backfill of relevant-but-not-yet-ported tests.
 argument-hint: "[--from=<version>] [--to=<version>] [--backfill] [--paths=<file1,file2,...>] [--dry-run]"
-allowed-tools: Bash(git -C /tmp/botocore:*) Bash(uv run pytest:*) Bash(uv run python:*) Bash(ls:*) Bash(find:*) Bash(cat:*) Bash(diff:*) Bash(cp:*) mcp__github_file_ops__commit_files
+allowed-tools: Bash(git -C /tmp/botocore:*) Bash(git checkout:*) Bash(uv run pytest:*) Bash(uv run python:*) Bash(ls:*) Bash(find:*) Bash(cat:*) Bash(diff:*) Bash(cp:*) mcp__github_file_ops__commit_files
 ---
 
 Port botocore tests to aiobotocore. Two driving scenarios:
@@ -180,9 +180,11 @@ For each successfully converted file:
    first failure; `-v` surfaces the failing test name; `-s` shows prints for debugging.
 3. **If pytest passes**: the file is ready to commit via `mcp__github_file_ops__commit_files`
    (the caller handles the actual commit batching).
-4. **If pytest fails**: revert the file to its pre-port state (`git checkout -- <path>` or
-   delete if it was a new file), emit an advisory block describing which test(s) failed and
-   which conversion rules were applied. The human reviewer can pick up from there.
+4. **If pytest fails**: revert the file to its pre-port state with
+   `git checkout -- <path>`. (Step 1 restricts us to files with an existing aiobotocore
+   mirror, so the target file always exists on disk — no new-file case to handle.) Emit
+   an advisory block describing which test(s) failed and which conversion rules were
+   applied; the human reviewer can pick up from there.
 
 ## Step 5: Output report
 

--- a/plugins/aiobotocore-bot/skills/port-tests/SKILL.md
+++ b/plugins/aiobotocore-bot/skills/port-tests/SKILL.md
@@ -1,0 +1,181 @@
+---
+description: Use when porting botocore tests to aiobotocore (during a port-required sync, or when backfilling historical test coverage). Converts sync test files under `botocore/tests/...` to their async counterparts under `tests/botocore_tests/...`, validates each port with `pytest -x`, commits on pass, reverts on fail. Handles both new/changed tests from a botocore diff AND backfill of relevant-but-not-yet-ported tests.
+argument-hint: "[--from=<version>] [--to=<version>] [--backfill] [--paths=<file1,file2,...>] [--dry-run]"
+allowed-tools: Bash(git -C /tmp/botocore:*) Bash(uv run pytest:*) Bash(uv run python:*) Bash(ls:*) Bash(find:*) Bash(cat:*) Bash(diff:*) Bash(cp:*) mcp__github_file_ops__commit_files
+---
+
+Port botocore tests to aiobotocore. Two driving scenarios:
+
+1. **Port PR workflow** (`--from=X --to=Y`): called from `botocore-sync-prompt.md` Step 5
+   (port path). For each test file under `botocore/tests/` that has new or changed tests in the
+   `X..Y` range AND has a mirror in `tests/botocore_tests/`, apply the sync→async conversion
+   to the new/changed tests and write them into the mirror.
+2. **Backfill mode** (`--backfill`): human-invoked when maintainers want to narrow the coverage
+   gap. Walk every `botocore/tests/<unit|functional>/test_*.py` that has a partial aiobotocore
+   mirror (same filename in `tests/botocore_tests/<unit|functional>/`) and port any test function
+   missing from the mirror. Scoped so it doesn't silently port hundreds of tests at once — run
+   with `--paths=` to limit to specific files.
+
+Conversion rules are identical in both modes. The skill writes files, validates each with
+`pytest -x`, and only commits what passes. Failures are preserved as advisory output so the
+human reviewer can finish by hand.
+
+## Arguments
+
+- `--from=<version>`, `--to=<version>` (port-PR mode): botocore tag range. Used to diff for
+  added/changed tests.
+- `--backfill` (backfill mode): port every not-yet-ported test function from existing mirrored
+  files, not just those changed in a version range.
+- `--paths=<file1,file2,...>` (optional): restrict to specific test file basenames (e.g.
+  `test_credentials.py,test_signers.py`). Required in `--backfill` mode to avoid wall-of-
+  churn PRs. In `--from/--to` mode, defaults to "every file that appears in the diff".
+- `--dry-run` (optional): emit the converted diffs to stdout; do not write files. Useful for
+  review before letting the skill commit changes.
+
+The modes are mutually exclusive: pass `--from/--to` OR `--backfill`, not both.
+
+## Step 1: Enumerate candidate test files
+
+**Port-PR mode (`--from/--to`):**
+
+```text
+git -C $BOTOCORE_CLONE diff --name-only $FROM..$TO -- 'botocore/tests/**/test_*.py'
+```
+
+Filter to files with an aiobotocore mirror — `tests/botocore_tests/<unit|functional>/<same-name>`
+must exist. Files without a mirror are out of scope (we haven't ported that file at all; adding
+a new mirror is a separate decision).
+
+**Backfill mode:**
+
+```text
+find tests/botocore_tests -name 'test_*.py' -type f
+```
+
+For each aiobotocore test file, identify its botocore counterpart. Use that file pair as the
+scope.
+
+## Step 2: Extract candidate test functions
+
+For each candidate file:
+
+1. Parse the botocore file (via `uv run python -c "import ast; ..."`) to extract every
+   top-level `def test_*` and every `class Test*/def test_*` method.
+2. Parse the aiobotocore mirror similarly.
+3. The port candidates are:
+   - **Port-PR mode**: tests added/changed in the botocore diff AND not yet in the mirror.
+   - **Backfill mode**: every botocore test whose name is not in the mirror.
+
+Skip these categories regardless of mode:
+
+- Tests that assert botocore-internal behavior aiobotocore doesn't override (e.g. synchronous
+  urllib3 behavior when aiobotocore uses aiohttp). Use the `overrides` registry from
+  `scripts/registries.py` to identify which tests exercise overridden code.
+- Tests named `test_*_sync_*` or that import from `botocore.httpsession` directly — the sync
+  HTTP path doesn't exist in aiobotocore.
+
+## Step 3: Apply conversion rules
+
+For each test function to port, apply these transformations in order:
+
+### 3a. Decorators and signatures
+
+- `def test_X(...)` → `async def test_X(...)`
+- `class TestX` staying as a class is fine; convert its `def test_*` methods to `async def`.
+- `@pytest.fixture` on a fixture that returns something created via `async def` → fixture itself
+  becomes `async def` (pytest-asyncio with `asyncio_mode = "auto"` handles the await).
+- `@mock.patch(...)` decorators: update string targets per §3b.
+- Remove `unittest.TestCase` inheritance when porting — project uses top-level async test
+  functions, not test classes.
+
+### 3b. Imports and mock targets
+
+Replace in both `import` statements AND `mock.patch("...")` / `mocker.patch("...")` strings:
+
+| botocore symbol | aiobotocore equivalent |
+|-|-|
+| `from botocore.session import Session` | `from aiobotocore.session import AioSession` |
+| `from botocore.credentials import CredentialResolver` | `from aiobotocore.credentials import AioCredentialResolver` |
+| `from botocore.args import ClientArgsCreator` | `from aiobotocore.args import AioClientArgsCreator` |
+| `from botocore.client import ClientCreator` | `from aiobotocore.client import AioClientCreator` |
+| `from botocore.signers import ...` | `from aiobotocore.signers import ...` (no Aio prefix for module-level functions) |
+
+Rule: look up the botocore class name in the `aio_classes` registry from `registries.py`. If
+`AioX` exists, replace `X` with `AioX` in both imports and patch strings.
+
+### 3c. Async-awareness in bodies
+
+Inside each ported test body:
+
+- Any call to a method or function in the `async_methods` registry gets awaited:
+  `session.create_client(...)` → `await session.create_client(...)`.
+- Context managers that are now async become `async with`: `with session.create_client(...)` →
+  `async with session.create_client(...)`.
+- `for chunk in stream` → `async for chunk in stream` when `stream` is a response body.
+- `stream.read()` → `await stream.read()` (read is in async_methods).
+- `mock.Mock(return_value=...)` on a coroutine target → `mock.AsyncMock(return_value=...)`.
+
+### 3d. Stubber replacement
+
+`botocore.stub.Stubber` and `botocore.client.ClientHTTPStubber` aren't directly compatible with
+aiobotocore clients. Replace with the helpers already exported by `tests.botocore_tests`:
+
+- `ClientHTTPStubber` → `from tests.botocore_tests import ClientHTTPStubber` (aiobotocore's
+  version, already async-aware)
+- `SessionHTTPStubber` → same import path
+- `botocore.stub.Stubber` for low-level API stubbing: no direct equivalent; flag the test as
+  requiring manual review in the advisory output.
+
+## Step 4: Write, validate, commit
+
+For each successfully converted file:
+
+1. Write the new content to `tests/botocore_tests/<unit|functional>/<same-name>`. If the mirror
+   file already has ported tests, APPEND the new tests at a sensible location (typically end of
+   file) rather than overwriting — preserve existing work.
+2. Run `uv run pytest -xvs tests/botocore_tests/<path>` on just that file. `-x` stops at the
+   first failure; `-v` surfaces the failing test name; `-s` shows prints for debugging.
+3. **If pytest passes**: the file is ready to commit via `mcp__github_file_ops__commit_files`
+   (the caller handles the actual commit batching).
+4. **If pytest fails**: revert the file to its pre-port state (`git checkout -- <path>` or
+   delete if it was a new file), emit an advisory block describing which test(s) failed and
+   which conversion rules were applied. The human reviewer can pick up from there.
+
+## Step 5: Output report
+
+Emit a structured report:
+
+```text
+## Port-tests report (mode: <port-pr|backfill>)
+
+### Successfully ported
+- tests/botocore_tests/unit/test_credentials.py
+  - test_assume_role_refresh (new in 1.42.89)
+  - test_sso_token_fetch (new in 1.42.89)
+  - pytest: PASSED (2 new, 14 existing)
+
+### Skipped (out of scope)
+- botocore/tests/unit/test_awsrequest.py
+  - Reason: no aiobotocore mirror at tests/botocore_tests/unit/test_awsrequest.py
+
+### Failed — needs human review
+- tests/botocore_tests/unit/test_signers.py
+  - test_presigned_url_with_sigv4a: AssertionError on URL comparison
+  - Conversion notes: converted `client.generate_presigned_url` to `await`; patched
+    `aiobotocore.signers.generate_presigned_url`. Reverted write.
+```
+
+## Honesty
+
+Never claim a test passes without actually running pytest on the ported file. If the botocore
+clone isn't available or a tag is missing, return `error: <reason>` instead of attempting the
+port. A falsely green port creates technical debt that's worse than not porting at all.
+
+## Consumption
+
+**Sync bot** (`botocore-sync-prompt.md` Step 5, port path): after `bump-version` lands the
+version changes, invoke `/aiobotocore-bot:port-tests --from=$FROM --to=$TO`. Include the
+resulting report in the port PR's "What changed in aiobotocore" section.
+
+**Humans**: run `/aiobotocore-bot:port-tests --backfill --paths=test_foo.py,test_bar.py` to
+narrow a coverage gap on specific files. The `--dry-run` flag is recommended first.

--- a/plugins/aiobotocore-bot/skills/review-pr/SKILL.md
+++ b/plugins/aiobotocore-bot/skills/review-pr/SKILL.md
@@ -100,22 +100,21 @@ e) **Port-vs-no-port sanity check** (only for sync-bot-authored PRs — `claude[
    three-way disagreement between classifier / body / pyproject.toml is worth flagging.
 
 f) **Coverage-driven test-porting suggestions** (any PR that adds or modifies `aiobotocore/*.py`
-   code): check whether the added/changed lines have test coverage. Pull the codecov report
-   for the PR via their comment (codecov[bot] leaves one automatically within ~2 minutes of
-   push) or via the GitHub check run. For any added/changed aiobotocore function whose lines
-   show red (uncovered) AND whose botocore counterpart exists, look for a corresponding
-   `botocore/tests/unit/test_<file>.py::test_<name>*` pattern. If botocore has tests for that
-   code but aiobotocore's mirror doesn't, post a soft top-level suggestion:
+   code): if codecov[bot] has already posted a coverage comment on the PR, read it via the
+   same `gh api graphql` pattern used in Step 1 (include `body` in the comment nodes).
+   codecov renders a per-file coverage delta; any file with uncovered new lines is a
+   candidate. For a candidate file whose botocore counterpart exists (e.g.
+   `aiobotocore/httpchecksum.py` ↔ `botocore/tests/unit/test_httpchecksum.py`), post at
+   most ONE soft top-level suggestion per PR — listing every gap is noise:
 
-   > Coverage gap: `aiobotocore/<file>.py::<function>` has no test. botocore tests at
-   > `botocore/tests/<path>.py` cover this functionality — consider running
-   > `/aiobotocore-bot:port-tests --backfill --paths=test_<file>.py` to port them.
+   > Coverage gap: `aiobotocore/<file>.py` has uncovered new lines per codecov. botocore
+   > tests at `botocore/tests/<path>.py` may cover this — consider running
+   > `/aiobotocore-bot:port-tests --backfill --paths=test_<file>.py`.
 
-   This is NOT a blocking finding (coverage below the patch threshold may already be caught
-   by codecov's own comment). It's a hint to the author and the future reviewer that the
-   port-tests skill has a concrete target. Emit at most ONE such suggestion per PR —
-   listing every gap turns into noise. Pick the highest-confidence match: the file with the
-   most uncovered lines that have a clear botocore test counterpart.
+   Skip entirely if codecov hasn't posted yet (don't block the review waiting for it) or
+   if every file's coverage is already ≥ the codecov patch threshold. Not a blocking
+   finding. Pick the file with the most uncovered lines that has a clear botocore test
+   counterpart.
 
 **CRITICAL: Only flag HIGH SIGNAL issues.**
 

--- a/plugins/aiobotocore-bot/skills/review-pr/SKILL.md
+++ b/plugins/aiobotocore-bot/skills/review-pr/SKILL.md
@@ -99,6 +99,24 @@ e) **Port-vs-no-port sanity check** (only for sync-bot-authored PRs — `claude[
    the `pyproject.toml` diff: lower-bound change = port-required, upper-only = no-port. Any
    three-way disagreement between classifier / body / pyproject.toml is worth flagging.
 
+f) **Coverage-driven test-porting suggestions** (any PR that adds or modifies `aiobotocore/*.py`
+   code): check whether the added/changed lines have test coverage. Pull the codecov report
+   for the PR via their comment (codecov[bot] leaves one automatically within ~2 minutes of
+   push) or via the GitHub check run. For any added/changed aiobotocore function whose lines
+   show red (uncovered) AND whose botocore counterpart exists, look for a corresponding
+   `botocore/tests/unit/test_<file>.py::test_<name>*` pattern. If botocore has tests for that
+   code but aiobotocore's mirror doesn't, post a soft top-level suggestion:
+
+   > Coverage gap: `aiobotocore/<file>.py::<function>` has no test. botocore tests at
+   > `botocore/tests/<path>.py` cover this functionality — consider running
+   > `/aiobotocore-bot:port-tests --backfill --paths=test_<file>.py` to port them.
+
+   This is NOT a blocking finding (coverage below the patch threshold may already be caught
+   by codecov's own comment). It's a hint to the author and the future reviewer that the
+   port-tests skill has a concrete target. Emit at most ONE such suggestion per PR —
+   listing every gap turns into noise. Pick the highest-confidence match: the file with the
+   most uncovered lines that have a clear botocore test counterpart.
+
 **CRITICAL: Only flag HIGH SIGNAL issues.**
 
 Flag issues where:

--- a/tests/evals/test_common.py
+++ b/tests/evals/test_common.py
@@ -8,7 +8,6 @@ are tested via mocked check_output so tests don't hit git or the gh API.
 from __future__ import annotations
 
 import json
-import re
 from pathlib import Path
 from unittest.mock import patch
 
@@ -242,7 +241,11 @@ def test_classify_tool_schema_shape() -> None:
     )
     assert schema["name"] == "test_tool"
     props = schema["input_schema"]["properties"]
-    assert props["verdict"]["enum"] == ["no-port", "port-required", "ambiguous"]
+    assert props["verdict"]["enum"] == [
+        "no-port",
+        "port-required",
+        "ambiguous",
+    ]
     assert "summary" in props
     assert "per_function_verdicts" in props
     assert set(schema["input_schema"]["required"]) == {"verdict", "summary"}

--- a/tests/evals/test_common.py
+++ b/tests/evals/test_common.py
@@ -246,6 +246,5 @@ def test_classify_tool_schema_shape() -> None:
         "port-required",
         "ambiguous",
     ]
-    assert "summary" in props
-    assert "per_function_verdicts" in props
-    assert set(schema["input_schema"]["required"]) == {"verdict", "summary"}
+    assert "rationale" in props
+    assert set(schema["input_schema"]["required"]) == {"verdict", "rationale"}

--- a/tests/evals/test_common.py
+++ b/tests/evals/test_common.py
@@ -231,23 +231,18 @@ def test_committed_scenarios_yaml_parses() -> None:
     assert all(r["expected"] in {"no-port", "port-required"} for r in rows)
 
 
-def test_invoke_and_parse_verdict_regex_shape() -> None:
-    """The regex contract: group(1) captures the verdict token."""
-    verdict_re = re.compile(
-        r"^\s*\**\s*CLASSIFICATION\s*\**\s*:\s*(\S+)",
-        re.MULTILINE,
+def test_classify_tool_schema_shape() -> None:
+    """The tool schema used for structured verdict extraction constrains
+    `verdict` to the provided enum and requires a summary.
+    """
+    schema = _common.classify_tool_schema(
+        tool_name="test_tool",
+        verdict_enum=["no-port", "port-required", "ambiguous"],
+        per_function_label="function",
     )
-    # Plain form
-    m = verdict_re.search("Some preamble\nCLASSIFICATION: no-port\nMore text")
-    assert m is not None and m.group(1) == "no-port"
-    # Markdown-bold form (model likes to format headings this way)
-    m = verdict_re.search("**CLASSIFICATION**: port-required\nRationale...")
-    assert m is not None and m.group(1) == "port-required"
-    # Leading whitespace
-    m = verdict_re.search("  CLASSIFICATION: ambiguous\n")
-    assert m is not None and m.group(1) == "ambiguous"
-    # Bold wrapping BOTH label and value — group 1 keeps the trailing `**`;
-    # the rstrip(":*") in invoke_and_parse strips them.
-    m = verdict_re.search("**CLASSIFICATION: no-port**\n")
-    assert m is not None
-    assert m.group(1).rstrip(":*") == "no-port"
+    assert schema["name"] == "test_tool"
+    props = schema["input_schema"]["properties"]
+    assert props["verdict"]["enum"] == ["no-port", "port-required", "ambiguous"]
+    assert "summary" in props
+    assert "per_function_verdicts" in props
+    assert set(schema["input_schema"]["required"]) == {"verdict", "summary"}


### PR DESCRIPTION
## Summary

Follow-up to #1567 addressing classifier accuracy, verdict structure, and human-reviewer
visibility. Three axes of work:

**1. Classifier accuracy (8/8 on the regression suite)**

- **Registry injection**: `tests/test_patches.py` is now the authoritative override registry —
  parsed to structured symbols via a new `plugins/aiobotocore-bot/scripts/registries.py` and
  passed to every classification. Also scans `aiobotocore/**/*.py` for `async def` + `Aio*`
  classes so duck-typed contamination matching works (`x.emit(...)`, `self._client_creator`,
  etc.).
- **Prompt restructure**: `check-async-need` SKILL.md rewritten to an explicit
  A/B/C/D algorithm (file-scope → change-type classify → async-contamination → call-graph
  back-track). Gate-first rule 3 with STOP-RULEs prevents the class-to-method extrapolation
  pattern Opus was anchored on (\"`ClassName` tracked ⇒ all methods mirrored\").
- **Opus 4.7 default** across eval + sync + reviewer. Recent pricing drop (\$5/\$25 per M)
  narrows the cost gap vs Sonnet+thinking to ~25% while recovering accuracy.

**2. Structured verdict output**

- Switched from \`re.search\` on \`CLASSIFICATION: ...\` text to Anthropic tool-use. The model
  is forced to call \`record_async_need_classification\` / \`record_override_drift_classification\`
  with a schema-validated \`verdict\` enum + \`rationale\` string. Eliminates first-vs-last-line
  parsing bets, bold-wrapper tolerance, and malformed-verdict failure modes entirely.
- Cost + token summary at the end of every eval run (per-model breakdown, dollars).
- \`--debug-misclassifications\` CLI flag + workflow input: on a miss, send a continuing-
  conversation turn asking the model which prompt phrase misled it. Branch on got-verdict so
  parse-error cases ask \"why didn't you populate the tool?\" instead of \"why did you pick X?\".

**3. Human-reviewer visibility + new port-tests skill**

- \`open-pr\` skill gains \`--classifier-verdicts=<rationale>\` arg; sync-mode PR bodies render
  per-function verdicts as a markdown table so the reviewer can spot-check each classification
  without re-running the classifier.
- New \`port-tests\` skill converts botocore tests to aiobotocore async form. Two modes:
  port-PR (given \`--from/--to\` botocore tags, port new/changed tests in mirrored files) and
  backfill (port not-yet-ported tests from \`--paths=\`). Validates each file with \`pytest -x\`;
  commits on pass, reverts + advises on fail. Wired into \`botocore-sync-prompt.md\` Step 5.
- \`review-pr\` skill picks up codecov report: uncovered lines in added/changed aiobotocore code
  + matching \`botocore/tests/\` file → soft suggestion to run \`port-tests --backfill\`.

## Misc

- \`.venv\` cache added to botocore-sync + claude + evals workflows (keyed on uv.lock +
  pyproject.toml hash) — ~10-15s saved per run on unchanged lockfiles.
- Seed \`json_out\` placeholder before first API call so artifacts upload even if the run
  aborts mid-way (usage cap hit, transient 500).
- Filed [#1569](https://github.com/aio-libs/aiobotocore/issues/1569) to track optional
  enhancement: extend \`test_patches.py\` entries with aiobotocore-side symbol pointers so
  the override/async-name registries can collapse into one.

## Eval results

| Suite | Before | After |
|-|-|-|
| check-async-need (8 cases × 3 runs) | 4/8 (main) | **8/8** |
| check-override-drift (2 cases × 3 runs) | 2/2 | **2/2** |

## Test plan

- [x] \`uv run pytest tests/evals/test_common.py\` — 20 passed
- [x] Full eval regression on branch — \`check-async-need: 8/8\`, \`check-override-drift: 2/2\`
- [x] \`uv run pre-commit run --all --show-diff-on-failure\` — all green
- [ ] Smoke: real PR review run once merged (tool-use path end-to-end)
- [ ] Smoke: real botocore sync run once merged (port-tests skill on first port PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)