### PR TITLE
botocore-sync: plugin-dir + open-pr de-duplication

### DIFF
--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -262,11 +262,22 @@ jobs:
         use_commit_signing: true
         display_report: true
         show_full_output: true
+        # Register the repo-local plugin so skills (check-async-need,
+        # bump-version, open-pr, port-tests, etc.) are discoverable by
+        # the Skill tool. See claude.yml for the companion comment on
+        # why --plugin-dir is also needed — without both, Skill-tool
+        # invocations return "Unknown skill: aiobotocore-bot:*" and the
+        # agent falls back to re-reading SKILL.md files (wastes ~2.5K
+        # tokens per invocation). Tracked upstream at
+        # anthropics/claude-code-action#1145.
+        plugin_marketplaces: ./.
+        plugins: aiobotocore-bot@aiobotocore
         prompt: ${{ steps.prompt.outputs.PROMPT }}
         claude_args: |
           --dangerously-skip-permissions
           --max-turns 100
           --model opus
+          --plugin-dir plugins/aiobotocore-bot
         # yamllint disable rule:line-length
         settings: |
           {

--- a/plugins/aiobotocore-bot/skills/open-pr/SKILL.md
+++ b/plugins/aiobotocore-bot/skills/open-pr/SKILL.md
@@ -84,11 +84,20 @@ Append:
 
 ```text
 ### What changed in botocore
-- Schema/model-only, or [summarize categorized diff].
-- Async-need check: <--async-need-summary verbatim>
+One or two sentences at the topic level — e.g. "Model/schema-only updates
+for N services" or "Adds `auth_scheme_preference` threading through args
++ client." DO NOT list per-function bullets here when
+`--classifier-verdicts` is provided; the table below already enumerates
+every changed function. Keep this section for the human's big picture.
+
+Async-need check: <--async-need-summary verbatim>
 
 ### What changed in aiobotocore
 <--changed-aiobotocore, default: Version bounds updated only, no code changes.>
+
+For port PRs, describe aiobotocore-side code (new Aio* classes,
+overridden methods, ported tests) — NOT a re-listing of the botocore
+changes the table already shows. One short sentence per file is plenty.
 
 <Classifier verdicts table — see below — when --classifier-verdicts is provided>
 
@@ -116,6 +125,23 @@ Same as `sync-no-port` but:
 - Reviewer checklist items change to: async patterns correct, hashes updated for new overrides,
   version bump is minor, tests ported from botocore where applicable.
 - Omit the async-need summary line (the bump itself is the answer).
+
+### Anti-duplication rule (both sync modes)
+
+The classifier verdicts table and the two "What changed" sections each have a
+distinct purpose:
+
+- **"What changed in botocore"**: topic-level what-and-why (one-to-two sentences
+  about the feature / theme of the upstream changes).
+- **Classifier verdicts table**: per-function accountability (every changed
+  symbol with its verdict + one-line reason).
+- **"What changed in aiobotocore"**: per-file aiobotocore-side code work (new
+  classes, method overrides, tests ported).
+
+If you find yourself writing "botocore/args.py: ClientArgsCreator.X changed"
+in a prose bullet AND in the table, drop it from the prose — the table is the
+authoritative per-function view. Prose sections should abstract up to themes,
+not mirror the table's row structure.
 
 ### Classifier verdicts table (both sync modes)
 


### PR DESCRIPTION
## Summary

Two follow-up fixes observed on run [24628931357](https://github.com/aio-libs/aiobotocore/actions/runs/24628931357)
and PR [#1571](https://github.com/aio-libs/aiobotocore/pull/1571):

**1. `botocore-sync.yml` missing plugin registration**

The sync workflow was missing what `claude.yml` already has (added in
#1570): `plugin_marketplaces`, `plugins`, and `--plugin-dir` in
claude_args. Every skill invocation (check-async-need, bump-version,
open-pr, port-tests) returned `Unknown skill: aiobotocore-bot:*` from
the Skill tool before falling back to reading SKILL.md directly.
Fallback works, but wastes ~2.5K tokens per skill call re-emitting
the skill body into context.

**2. `open-pr` PR body duplication**

PR #1571's body had overlap between "What changed in botocore"
(per-file bullets) and the new "Classifier verdicts" table (same
per-function data in tabular form). Both sections restated upstream
changes at different levels of detail.

Fix: assign each section a distinct purpose and add an explicit
anti-duplication rule:
- "What changed in botocore" → topic-level theme (1-2 sentences).
- Classifier verdicts table → per-function accountability (authoritative).
- "What changed in aiobotocore" → aiobotocore-side code work only.

## Test plan

- [x] Pre-commit passes
- [ ] Next botocore-sync run — confirm 0 Unknown skill errors
- [ ] Next port-required sync PR — confirm no per-function duplication
      between prose and classifier table

🤖 Generated with [Claude Code](https://claude.com/claude-code)