### PR TITLE
AI workflows: 2-job sync split + PR-body verbosity ceiling + bump-version fixes

### DIFF
--- a/.github/botocore-classify-prompt.md
+++ b/.github/botocore-classify-prompt.md
@@ -1,0 +1,56 @@
+You are the classifier stage of the botocore sync workflow. Your only job is to run the
+async-need classifier and write the result to a JSON file. The downstream `sync` job consumes
+your output to decide whether to use the cheap (Sonnet) no-port path or the expensive (Opus)
+port path.
+
+## Pre-computed values
+
+These are passed in by the workflow — use directly, do NOT re-derive:
+
+- Target botocore version: $LATEST_BOTOCORE
+- Last supported botocore version: $LAST_SUPPORTED
+- Dry-run flag: $DRY_RUN
+
+## Step 1: Run the classifier
+
+```text
+/aiobotocore-bot:check-async-need --from=$LAST_SUPPORTED --to=$LATEST_BOTOCORE
+```
+
+The skill emits a `CLASSIFICATION:` line plus a per-function rationale block. Capture both.
+
+## Step 2: Write classification to /tmp/classification.json
+
+Write a JSON object with exactly these fields:
+
+- `verdict`: one of `"no-port"`, `"port-required"`, `"ambiguous"`, `"error"`
+- `summary`: a single short sentence summarizing the classifier's decision (≤120 chars). For
+  `no-port`: name the dominant theme (e.g. "Model/schema-only updates for N services"). For
+  `port-required`: name the function or feature that triggered (e.g. "New
+  `auth_scheme_preference` threading through args + client requires async override").
+- `rationale`: a markdown table with columns `File | Function | Change | Verdict | Reason`,
+  one row per function the classifier inspected. The downstream `open-pr` skill renders this
+  table verbatim into the PR body — keep each Reason cell to ≤80 chars and don't pad the table
+  column separators. **Use the minimum-separator table convention: `|-|-|-|-|-|`**.
+
+If the classifier itself failed (returned `error: <reason>`), set `verdict` to `"error"` and
+put the error reason in `summary`. Leave `rationale` as the string `"(classifier failed)"`.
+
+If `$DRY_RUN` is `true`, also write a copy of the per-function rationale block to the GitHub
+step summary (`$GITHUB_STEP_SUMMARY`) so the human running the dispatch sees it without
+clicking through to JSON.
+
+## Restrictions
+
+- **Do NOT make any code changes.** No file edits outside `/tmp/`.
+- **Do NOT create branches, commits, PRs, or comments.** This stage is read-only.
+- **Do NOT do any porting work.** That belongs to the downstream `sync` job — running it here
+  would defeat the whole point of the model split.
+- If you find yourself reaching for `mcp__github_file_ops__commit_files`, `gh pr create`, or
+  similar — STOP and just write the JSON.
+
+## Honesty
+
+Never claim `no-port` without inspecting every changed function in an overridden file. If you
+could not run the classifier (network error, missing tag), set `verdict: "error"` and let the
+sync job escalate via the feedback-issue path. A false `no-port` is worse than `ambiguous`.

--- a/.github/botocore-sync-prompt.md
+++ b/.github/botocore-sync-prompt.md
@@ -10,6 +10,25 @@ pyproject.toml for version info:
 - Current supported range: $CURRENT_LOWER — $LAST_SUPPORTED
 - Exclusive upper bound: $CURRENT_UPPER
 
+The `classify` job (a separate Sonnet-driven stage that runs before this one) has already
+produced the async-need verdict — use it directly in Step 3, do NOT re-run the classifier:
+
+- Verdict: $CLASSIFIER_VERDICT
+- One-line summary: $CLASSIFIER_SUMMARY
+- Per-function rationale (markdown table): $CLASSIFIER_RATIONALE
+
+The classify job also pre-computed the list of aiobotocore source files whose botocore
+counterpart changed in the diff range — comma-separated, empty if none changed:
+
+- Affected aiobotocore files: $AFFECTED_AIOBOTOCORE_FILES
+
+Use this list as the starting point for Step 5 (port path) instead of re-running
+`git diff --name-only` and walking the mirror tree. The list excludes files without an
+existing aiobotocore mirror (those are out of scope per `port-tests` skill rules).
+
+If `$CLASSIFIER_VERDICT` is empty (rare — only when the classify job failed entirely),
+re-run the classifier yourself in Step 3 as a fallback.
+
 ## Configuration
 
 - ENABLE_BUMP: $ENABLE_BUMP (if false, bumps create a feedback issue instead of attempting code changes)
@@ -171,29 +190,37 @@ gh api repos/REPO/pulls/PR_NUM/reviews \
 
 **No PRs at all:** proceed to Step 3.
 
-## Step 3: Classify the botocore diff
+## Step 3: Use the pre-computed classifier verdict
 
 **The classifier is the authority, not the PR title.** Historical PRs have been
 mislabeled (e.g. a "Bump" title on what was actually a no-port update). If you are
 operating on an existing PR whose title contradicts the classifier's verdict, update the
 PR title to match — don't preserve a wrong inherited label.
 
-Run the classifier:
+The `classify` job has already run `/aiobotocore-bot:check-async-need` for the target
+range. Use `$CLASSIFIER_VERDICT` directly — do NOT re-invoke the classifier (that
+duplicates work the cheap Sonnet stage already did). The per-function rationale in
+`$CLASSIFIER_RATIONALE` is also pre-formatted as a markdown table — pass it verbatim to
+`/aiobotocore-bot:open-pr --classifier-verdicts=...` in Step 7.
+
+Branch on `$CLASSIFIER_VERDICT`:
+
+- `no-port` → Go to Step 4 (no-port path). Quote `$CLASSIFIER_SUMMARY` in the PR body as
+  the async-need justification. Do NOT justify a no-port verdict with "functions not
+  overridden" — that is the wrong test.
+- `port-required` → Go to Step 5 (port path).
+- `ambiguous` → Escalate via Step 9 with the ambiguous verdicts as feedback questions.
+- `error` → The classifier itself failed. Treat as `ambiguous`: escalate via Step 9 with
+  the error message (in `$CLASSIFIER_SUMMARY`) as context. Never silently assume no-port.
+
+**Fallback:** if `$CLASSIFIER_VERDICT` is empty (the classify job failed before producing
+output), re-run the classifier yourself:
 
 ```text
 /aiobotocore-bot:check-async-need --from=$LAST_SUPPORTED --to=$LATEST_BOTOCORE
 ```
 
-The skill diffs the two botocore versions, finds new/changed functions in overridden files, and returns one of:
-
-- `no-port` → no async-need signals found. Go to Step 4 (no-port path). Quote the skill's summary line in the
-  PR body as the async-need justification. Do NOT justify a no-port verdict with "functions not overridden" — that is the
-  wrong test.
-- `port-required` → at least one new/changed function has async-need signals. Go to Step 5 (port path).
-- `ambiguous` → the classifier could not rule out async-need for one or more functions. Escalate via Step 9 with
-  the ambiguous verdicts as feedback questions.
-- `error: <reason>` → the classifier itself failed (e.g. `/tmp/botocore` missing, tag not fetched). Treat as
-  `ambiguous`: escalate via Step 9 with the error message as context. Never silently assume no-port.
+This should be rare; the classify job uses Sonnet and has its own retry policy.
 
 ### Major bump detection
 

--- a/.github/claude-review-prompt.md
+++ b/.github/claude-review-prompt.md
@@ -229,6 +229,23 @@ Python, uv, and all dev dependencies are pre-installed.
 Never claim tests pass unless you ran them successfully. If you could not run tests, say so in the PR
 description. Do not use checkmarks for untested items.
 
+### No fake memory
+
+Each workflow run is **stateless** — there is no persistent agent memory across runs. Never claim to
+have "saved to memory", "saved as durable feedback / preference", "noted for future runs", or any
+similar phrasing that implies the next run will inherit your decision. Those claims are confabulated
+— the next run starts cold from the prompt + skill files in `.github/` and `plugins/`.
+
+If a reviewer requests a behavioral change for future runs, only one of these is honest:
+
+- Make the change in this PR by editing the relevant prompt or `SKILL.md` and include the diff in
+  your response.
+- Acknowledge the request and say a follow-up PR to the prompt/skill is needed; do NOT promise the
+  next run will behave differently absent that PR.
+- Stay silent on the meta-feedback if you can't act on it now.
+
+This rule applies to every reply you post — review summaries, inline replies, top-level comments.
+
 ## Reference
 
 Use the repository's CLAUDE.md for guidance on style and conventions. See docs/override-patterns.md for how

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -7,8 +7,9 @@ permissions: {}
 
 on:
   schedule:
-  # Every 3 days at 10:00 UTC
-  - cron: '0 10 */3 * *'
+  # Weekly, Monday at 10:00 UTC. Cost: each sync run costs $1-5 (more on
+  # port-required bumps); weekly balances "stay current" against budget.
+  - cron: '0 10 * * 1'
   workflow_dispatch:
     inputs:
       botocore_version:
@@ -163,9 +164,208 @@ jobs:
                     f"{sv if supported else nv} |\n")
         PYEOF
 
-  sync:
+  # Classify the diff with Sonnet before deciding which model to use for the
+  # actual sync. The classifier is mechanical (diff-walking + registry lookups)
+  # — Sonnet handles it for ~$0.10 per run versus ~$1+ if we ran the same step
+  # inside the Opus sync. Outputs `verdict` so `sync` below can pick the model:
+  # no-port → Sonnet (cheap), anything else → Opus (full reasoning).
+  classify:
     needs: detect
     if: needs.detect.outputs.needs_update == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: claude
+    permissions:
+      contents: read
+      id-token: write
+      actions: read
+    outputs:
+      verdict: ${{ steps.parse.outputs.verdict }}
+      summary: ${{ steps.parse.outputs.summary }}
+      rationale: ${{ steps.parse.outputs.rationale }}
+      affected_files: ${{ steps.affected.outputs.files }}
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        persist-credentials: false
+
+    - name: Set up uv + Python
+      # yamllint disable-line rule:line-length
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+      with:
+        version: '0.11.7'
+        python-version: '3.12'
+        enable-cache: auto
+
+    - name: Cache .venv
+      # yamllint disable-line rule:line-length
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
+      with:
+        path: .venv
+        # yamllint disable-line rule:line-length
+        key: venv-${{ runner.os }}-py3.12-${{ hashFiles('uv.lock', 'pyproject.toml') }}
+
+    - name: Install dependencies
+      run: uv sync --frozen
+
+    - name: Cache botocore repo
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
+      with:
+        path: /tmp/botocore
+        key: botocore-repo
+
+    - name: Clone or update botocore
+      run: |
+        if [ -f /tmp/botocore/HEAD ]; then
+          git -C /tmp/botocore fetch --tags --prune
+        else
+          git clone --bare \
+            https://github.com/boto/botocore.git \
+            /tmp/botocore
+        fi
+
+    # Pre-compute the list of aiobotocore source files that mirror botocore
+    # files changed in the diff range. Pure bash — no Claude needed. Passes
+    # downstream so the sync job's prompt can reference it instead of
+    # re-running the same `git diff` + mirror-glob.
+    - name: List affected aiobotocore files
+      id: affected
+      env:
+        FROM: ${{ needs.detect.outputs.last_supported }}
+        TO: ${{ needs.detect.outputs.latest_botocore }}
+      run: |
+        files=$(git -C /tmp/botocore diff --name-only \
+          "$FROM..$TO" -- 'botocore/**/*.py' 2>/dev/null \
+          | sed -E 's|^botocore/|aiobotocore/|' \
+          | while read -r f; do [ -f "$f" ] && echo "$f"; done \
+          | sort -u | paste -sd ',' -)
+        echo "files=$files" >> "$GITHUB_OUTPUT"
+        if [ -n "$files" ]; then
+          echo "Affected aiobotocore mirrors: $files" \
+            >> "$GITHUB_STEP_SUMMARY"
+        fi
+
+    - name: Read classify prompt
+      id: prompt
+      env:
+        LATEST_BOTOCORE: >-
+          ${{ needs.detect.outputs.latest_botocore }}
+        LAST_SUPPORTED: >-
+          ${{ needs.detect.outputs.last_supported }}
+        DRY_RUN: >-
+          ${{ inputs.dry_run || 'false' }}
+      run: |
+        VARS='$LATEST_BOTOCORE $LAST_SUPPORTED $DRY_RUN'
+        prompt=$(envsubst "$VARS" < .github/botocore-classify-prompt.md)
+        {
+          echo 'PROMPT<<PROMPT_EOF'
+          echo "$prompt"
+          echo 'PROMPT_EOF'
+        } >> "$GITHUB_OUTPUT"
+
+    # yamllint disable-line rule:line-length
+    - uses: anthropics/claude-code-action@38ec876110f9fbf8b950c79f534430740c3ac009  # v1.0.101
+      id: claude
+      with:
+        anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+        # No commits in classify — it's a read-only stage.
+        use_commit_signing: false
+        display_report: true
+        show_full_output: true
+        plugin_marketplaces: ./.
+        plugins: aiobotocore-bot@aiobotocore
+        prompt: ${{ steps.prompt.outputs.PROMPT }}
+        # Sonnet for the classifier. The check-async-need skill is largely
+        # mechanical (diff-walk + registry lookup); Sonnet matches Opus on
+        # this task at ~5× lower output cost.
+        claude_args: |
+          --dangerously-skip-permissions
+          --max-turns 30
+          --model sonnet
+          --plugin-dir plugins/aiobotocore-bot
+        # yamllint disable rule:line-length
+        settings: |
+          {
+            "hooks": {
+              "PreToolUse": [{
+                "matcher": "Bash",
+                "command": "if echo \"$TOOL_INPUT\" | grep -qE '\\b(git commit|git push|gh pr (create|edit|comment|merge|close)|gh issue create)\\b'; then echo 'BLOCKED: classify stage is read-only — no commits, pushes, PRs, or issues. Just write /tmp/classification.json.' >&2; exit 2; fi"
+              }]
+            }
+          }
+        # yamllint enable rule:line-length
+
+    - name: Hash test sanity check
+      # Only run for dry-run dispatches — for real sync runs the downstream
+      # `sync` job runs the same hash tests as part of its prompt. Running
+      # them here too would just double the wallclock for no extra signal.
+      if: inputs.dry_run == true
+      continue-on-error: true
+      env:
+        TARGET: ${{ needs.detect.outputs.latest_botocore }}
+      run: |
+        uv pip install "botocore==$TARGET"
+        if uv run pytest tests/test_patches.py -x 2>&1 \
+            | tee /tmp/hash_tests.log; then
+          echo "✅ Hash tests pass against $TARGET" \
+            >> "$GITHUB_STEP_SUMMARY"
+        else
+          {
+            echo "❌ Hash tests FAIL against $TARGET — sanity-check the verdict"
+            echo ''
+            echo '```'
+            tail -50 /tmp/hash_tests.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+        fi
+
+    - name: Parse classification
+      id: parse
+      run: |
+        if [ ! -f /tmp/classification.json ]; then
+          msg="classify did not write /tmp/classification.json"
+          echo "::warning::$msg — defaulting to ambiguous"
+          {
+            echo "verdict=ambiguous"
+            echo "summary=Classifier output missing — see classify-job logs"
+            echo 'rationale<<RATIONALE_EOF'
+            echo "(classifier did not produce output)"
+            echo 'RATIONALE_EOF'
+          } >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        verdict=$(jq -r '.verdict // "ambiguous"' /tmp/classification.json)
+        summary=$(jq -r '.summary // ""' /tmp/classification.json)
+        echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+        echo "summary=$summary" >> "$GITHUB_OUTPUT"
+        {
+          echo 'rationale<<RATIONALE_EOF'
+          jq -r '.rationale // "(none)"' /tmp/classification.json
+          echo 'RATIONALE_EOF'
+        } >> "$GITHUB_OUTPUT"
+        {
+          echo "## Classification: $verdict"
+          echo ""
+          echo "$summary"
+          echo ""
+          echo "<details><summary>Per-function rationale</summary>"
+          echo ""
+          jq -r '.rationale // "(none)"' /tmp/classification.json
+          echo ""
+          echo "</details>"
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Usage summary
+      if: always()
+      continue-on-error: true
+      env:
+        EXEC_FILE: >-
+          ${{ steps.claude.outputs.execution_file }}
+      run: python3 .github/usage-summary.py
+
+  sync:
+    needs: [detect, classify]
+    if: needs.detect.outputs.needs_update == 'true' && inputs.dry_run != true
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment: claude
@@ -241,10 +441,26 @@ jobs:
           ${{ inputs.enable_bump || 'false' }}
         DRY_RUN: >-
           ${{ inputs.dry_run || 'false' }}
+        # Pre-computed by the classify job. Sync's prompt Step 3 short-
+        # circuits the classifier when these are non-empty — saves the
+        # cost of re-classifying on the Opus side.
+        CLASSIFIER_VERDICT: >-
+          ${{ needs.classify.outputs.verdict }}
+        CLASSIFIER_SUMMARY: >-
+          ${{ needs.classify.outputs.summary }}
+        CLASSIFIER_RATIONALE: >-
+          ${{ needs.classify.outputs.rationale }}
+        # Pre-computed by classify (pure bash). Comma-separated list of
+        # aiobotocore source files that have a botocore counterpart that
+        # changed in the diff range. Empty if no Python source changed.
+        AFFECTED_AIOBOTOCORE_FILES: >-
+          ${{ needs.classify.outputs.affected_files }}
       # yamllint disable-line rule:line-length
       run: |
         VARS='$LATEST_BOTOCORE $CURRENT_UPPER $CURRENT_LOWER'
         VARS="$VARS"' $LAST_SUPPORTED $ENABLE_BUMP $DRY_RUN'
+        VARS="$VARS"' $CLASSIFIER_VERDICT $CLASSIFIER_SUMMARY $CLASSIFIER_RATIONALE'
+        VARS="$VARS"' $AFFECTED_AIOBOTOCORE_FILES'
         prompt=$(envsubst "$VARS" < .github/botocore-sync-prompt.md)
         {
           echo 'PROMPT<<PROMPT_EOF'
@@ -273,10 +489,15 @@ jobs:
         plugin_marketplaces: ./.
         plugins: aiobotocore-bot@aiobotocore
         prompt: ${{ steps.prompt.outputs.PROMPT }}
+        # Model is conditional on the classify job's verdict:
+        # - no-port → Sonnet (mechanical bump+PR; ~5× cheaper output)
+        # - everything else → Opus (real porting work, ambiguity, escalation)
+        # When `verdict` is empty (classify failed/skipped) the fallback is
+        # Opus, matching the prior single-job behavior.
         claude_args: |
           --dangerously-skip-permissions
           --max-turns 100
-          --model opus
+          --model ${{ needs.classify.outputs.verdict == 'no-port' && 'sonnet' || 'opus' }}
           --plugin-dir plugins/aiobotocore-bot
         # yamllint disable rule:line-length
         settings: |

--- a/plugins/aiobotocore-bot/skills/bump-version/SKILL.md
+++ b/plugins/aiobotocore-bot/skills/bump-version/SKILL.md
@@ -1,7 +1,7 @@
 ---
 description: Use when applying the mechanical version + CHANGES.rst + pyproject.toml + uv.lock updates for a botocore sync (no-port = patch bump; port = minor bump, lower bound moves). Handles the Sphinx `^`-underline exact-length rule and drives `uv lock`. Caller commits the result.
-argument-hint: "--mode=no-port|port --target=<version> [--changelog=<text>] [--extra-changelog=<text>]"
-allowed-tools: Bash(uv lock:*) Bash(date:*) Bash(cat:*) Bash(grep:*) Bash(sed:*) Bash(printf:*) Bash(wc:*) Bash(seq:*) Bash(tr:*) mcp__github_file_ops__commit_files
+argument-hint: "--mode=no-port|port --target=<version> [--lower-bound=<version>] [--changelog=<text>] [--extra-changelog=<text>]"
+allowed-tools: Bash(uv lock:*) Bash(uv pip:*) Bash(curl:*) Bash(date:*) Bash(cat:*) Bash(grep:*) Bash(sed:*) Bash(printf:*) Bash(wc:*) Bash(seq:*) Bash(tr:*) Bash(python3:*) mcp__github_file_ops__commit_files
 ---
 
 Apply the mechanical version+changelog+pyproject changes for a botocore sync. Use this instead of
@@ -11,6 +11,12 @@ hand-editing each file — the `^` underline length rule and `uv lock` step are 
 
 - `--mode=no-port|port` (required)
 - `--target=<version>` (required): the target botocore version, e.g. `1.42.89`
+- `--lower-bound=<version>` (optional, port mode only): the EARLIEST botocore version that
+  shipped the breaking change requiring this port. Defaults to `--target` if omitted, but
+  the caller should set this explicitly when the classifier identified the change as
+  shipping in an earlier version of the `$FROM..$TO` range. Example: classifier finds the
+  new `auth_scheme_preference` arrived in 1.42.90 and the target is 1.42.91 — pass
+  `--lower-bound=1.42.90` so users on 1.42.90 still satisfy the spec.
 - `--changelog=<text>` (optional): custom CHANGES.rst bullet. Default for either mode is
   `bump botocore dependency specification to support "botocore >= <lower>, < <upper>"`.
   Single wording matches the unified "Bump ..." PR-title convention; the no-port vs
@@ -29,7 +35,9 @@ Read `aiobotocore/__init__.py` to get the current `__version__`. Compute the new
 - Locate the botocore dependency line (e.g. `botocore >= 1.42.79, < 1.42.90`).
 - New upper bound is always one patch above `--target`: if target is `1.42.89`, upper is `< 1.42.90`.
 - `--mode=no-port`: keep the lower bound unchanged, update the upper bound.
-- `--mode=port`: set lower bound to `--target`, set upper bound as above.
+- `--mode=port`: set lower bound to `--lower-bound` (or `--target` if not provided), set upper
+  bound as above. **Lifting the lower bound past the version that introduced the breaking change
+  is wrong** — it locks out users on the in-between version that already has the new feature.
 - Do the same for the `boto3` dependency line if it's pinned (same range).
 
 ## Step 3: Update aiobotocore/**init**.py
@@ -38,8 +46,33 @@ Replace `__version__ = "<old>"` with `__version__ = "<new>"`.
 
 ## Step 4: Update CHANGES.rst
 
-Insert a new entry at the top with today's date (`date +%Y-%m-%d`). **The `^` underline MUST match
-the header length exactly** — miscounts break Sphinx rendering.
+### Step 4a: Detect existing unreleased entry
+
+A previous PR may have added an entry that hasn't shipped yet. Stacking a NEW entry on top in
+that case clutters the changelog (#1571 review feedback). Detect:
+
+```text
+# Latest released aiobotocore version on PyPI
+released=$(curl -s https://pypi.org/pypi/aiobotocore/json \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['info']['version'])")
+# Top entry's version in CHANGES.rst (first line that looks like "X.Y.Z (YYYY-MM-DD)")
+top_entry=$(grep -m1 -E '^[0-9]+\.[0-9]+\.[0-9]+ \(' CHANGES.rst | sed -E 's/ .*//')
+```
+
+If `Version(top_entry) > Version(released)`, the top entry is **unreleased**. **Merge the new
+bump into it** rather than inserting a new section above:
+
+- Replace the existing version with the new computed version (recompute the `^` underline length).
+- Append the new bullet (the default or `--changelog`) under the same header.
+- Preserve any existing bullets — the merged entry covers both the prior unreleased work and
+  this bump in a single release.
+
+If `Version(top_entry) == Version(released)` (top entry is already shipped), proceed to Step 4b
+and insert a fresh section.
+
+### Step 4b: Write the entry
+
+**The `^` underline MUST match the header length exactly** — miscounts break Sphinx rendering.
 
 Build the header and underline mechanically — do not eyeball the length:
 
@@ -49,7 +82,7 @@ LEN=$(printf '%s' "$HEADER" | wc -c | tr -d ' ')
 UNDERLINE=$(printf '^%.0s' $(seq 1 "$LEN"))
 ```
 
-Then write:
+Then write (or, in the merge case, replace the existing header and append bullets):
 
 ```text
 $HEADER
@@ -63,10 +96,12 @@ Verify before writing: `[ "${#HEADER}" -eq "${#UNDERLINE}" ]` — if not equal, 
 ## Step 5: Run uv lock
 
 ```text
-uv lock
+uv lock --upgrade-package boto3 --upgrade-package botocore
 ```
 
-This updates `uv.lock` to reflect the new constraints.
+The dual `--upgrade-package` is intentional: `boto3` and `botocore` are tightly version-coupled
+upstream and a stale `boto3` against a freshly-bumped `botocore` produces confusing test failures
+(#1571 review feedback). Always upgrade both together so the lockfile reflects a coherent pair.
 
 ## Step 6: Output
 

--- a/plugins/aiobotocore-bot/skills/open-pr/SKILL.md
+++ b/plugins/aiobotocore-bot/skills/open-pr/SKILL.md
@@ -53,6 +53,29 @@ Treat the template as the foundation for the body. Apply these rules:
 4. If the template has new sections or checklist items compared to your memory, include them
    anyway — treat the file as authoritative on each run.
 
+### Do NOT hard-wrap PR bodies or comments
+
+GitHub renders Markdown with natural word-wrap; hard-wrapped lines display as awkwardly short
+paragraphs and bloat cached input on every follow-up turn. Write each paragraph as ONE long
+logical line. The same applies to inline review comments and top-level PR comments produced by
+sibling skills (`review-pr`, `complete-run`, `analyze-pr-feedback`).
+
+Hard-wrap is for source files only (yamllint compliance); rendered Markdown does not need it.
+
+### Verbosity ceiling
+
+Reviewers skim. Length costs cache on every follow-up @claude run. Defaults:
+
+- **"Description of Change"**: at most 2 sentences. Say what version range and what theme of
+  change (e.g. "Bump botocore to 1.42.91. New `auth_scheme_preference` threading needs async
+  porting"). Per-symbol detail belongs in the classifier table, not here.
+- **"Assumptions"**: include only if a non-obvious decision was made that the reviewer should
+  validate. Inheriting from a base class without an override is NOT a non-obvious decision —
+  it's the default. Omit the section if the only "assumptions" are restatements of the diff.
+- **"What changed in aiobotocore"**: at most one short line per file. No prose paragraphs. Do
+  NOT restate per-symbol botocore changes — the table covers those.
+- **Reviewer checklist**: keep to ≤6 items. Don't pad with items that overlap.
+
 Tick a checklist box only for work the current branch actually did. For items you didn't do,
 either omit with a brief note or leave the box unchecked with a one-line reason, e.g.
 `[ ] Detailed description of issue — N/A, no linked issue`. **Unchecked with a reason is always
@@ -80,24 +103,19 @@ No extra sections unless the caller passes `--extra-sections=<text>`.
 
 ### mode=sync-no-port
 
-Append:
+Append (conditional sections marked with `[only if ...]`):
 
 ```text
+[only if --classifier-verdicts NOT provided]
 ### What changed in botocore
 One or two sentences at the topic level — e.g. "Model/schema-only updates
 for N services" or "Adds `auth_scheme_preference` threading through args
-+ client." DO NOT list per-function bullets here when
-`--classifier-verdicts` is provided; the table below already enumerates
-every changed function. Keep this section for the human's big picture.
++ client."
 
 Async-need check: <--async-need-summary verbatim>
 
 ### What changed in aiobotocore
 <--changed-aiobotocore, default: Version bounds updated only, no code changes.>
-
-For port PRs, describe aiobotocore-side code (new Aio* classes,
-overridden methods, ported tests) — NOT a re-listing of the botocore
-changes the table already shows. One short sentence per file is plenty.
 
 <Classifier verdicts table — see below — when --classifier-verdicts is provided>
 
@@ -110,38 +128,49 @@ changes the table already shows. One short sentence per file is plenty.
 
 ### How to help
 - Review the botocore diff: <--botocore-diff-url>
-- If something looks wrong, leave a review comment — the bot will attempt to fix straightforward
-  issues automatically.
-- Use `@claude` to ask questions or request modifications.
+- `@claude <ask>` to request modifications. Reviewer comments → automatic fix attempt.
 ```
+
+When `--classifier-verdicts` is provided, omit the "What changed in botocore" section entirely
+— the table is the authoritative per-function view (see Anti-duplication rule below). Keep the
+async-need summary line; it's a one-line top-line verdict the table doesn't repeat.
 
 ### mode=sync-port
 
 Same as `sync-no-port` but:
 
-- Description-of-change mentions it's a bump and why (new functionality requires async override).
-- Include `--assumptions` under a dedicated "Assumptions" section if provided.
-- "What changed in aiobotocore" should list files modified, classes added, tests ported.
+- Description-of-change is one sentence: `Bump botocore to X.Y.Z. <one-clause summary of the
+  feature requiring the port>`. Per-symbol detail belongs in the classifier table.
+- Include `--assumptions` under an "Assumptions" section ONLY if provided AND non-tautological
+  (see Anti-duplication rule).
+- "What changed in aiobotocore": ≤1 line per file. List new `Aio*` classes, overridden methods,
+  ported tests. Never restate the botocore-side change.
 - Reviewer checklist items change to: async patterns correct, hashes updated for new overrides,
   version bump is minor, tests ported from botocore where applicable.
 - Omit the async-need summary line (the bump itself is the answer).
 
 ### Anti-duplication rule (both sync modes)
 
-The classifier verdicts table and the two "What changed" sections each have a
-distinct purpose:
+When `--classifier-verdicts` is provided, the classifier verdicts table is the
+authoritative per-function view. To prevent the description from saying the
+same thing five times (description ¶1, assumptions, what-changed-in-botocore,
+what-changed-in-aiobotocore, classifier table), apply these mechanical rules:
 
-- **"What changed in botocore"**: topic-level what-and-why (one-to-two sentences
-  about the feature / theme of the upstream changes).
-- **Classifier verdicts table**: per-function accountability (every changed
-  symbol with its verdict + one-line reason).
-- **"What changed in aiobotocore"**: per-file aiobotocore-side code work (new
-  classes, method overrides, tests ported).
+- **Drop the "What changed in botocore" section entirely** when
+  `--classifier-verdicts` is provided. The table replaces it. Do not write
+  prose bullets summarizing what the table already enumerates per-row.
+- **Description of Change**: 2 sentences max — see "Verbosity ceiling" above.
+  Never restate per-file or per-symbol changes; that's the table's job.
+- **What changed in aiobotocore**: per-file aiobotocore-side work only — new
+  classes, overridden methods, ported tests. ≤1 line per file. Never restate
+  the botocore-side change for that file (the table already shows it).
+- **Assumptions**: omit when "assumption" is a tautology of inheritance
+  (e.g. "regions.py needs no changes because the subclass inherits"). Keep
+  only assumptions a reviewer would actually want to validate.
 
-If you find yourself writing "botocore/args.py: ClientArgsCreator.X changed"
-in a prose bullet AND in the table, drop it from the prose — the table is the
-authoritative per-function view. Prose sections should abstract up to themes,
-not mirror the table's row structure.
+If you find yourself writing the same fact in two sections, delete it from
+the less-authoritative one. The hierarchy from most-to-least authoritative:
+classifier table > what-changed-aiobotocore > description > assumptions.
 
 ### Classifier verdicts table (both sync modes)
 


### PR DESCRIPTION
## Summary

Cost-driven cleanup after analyzing the first port-required sync (PR #1571 cost ~\$14 across 6 runs). Three independent threads:

1. **Workflow split** — new `classify` job runs the async-need classifier with Sonnet (~\$0.10) and emits the verdict + per-function rationale + affected aiobotocore files as outputs. The downstream `sync` job picks Sonnet on `no-port` (~5× cheaper output) and Opus otherwise. Sync's prompt Step 3 short-circuits when `\$CLASSIFIER_VERDICT` is set, so Opus doesn't redo the classifier's work.
2. **PR-body verbosity** — open-pr SKILL gains a hard verbosity ceiling, a no-hard-wrap rule, and a tightened anti-duplication rule (drop \"What changed in botocore\" entirely when the classifier-verdicts table is provided). All driven by jakob-keller's #1571 feedback.
3. **bump-version fixes** — three concrete defects from #1571's review:
   - `--lower-bound` argument so port bumps don't lift the lower bound past the version that introduced the breaking change.
   - Detect an existing unreleased CHANGES.rst entry and merge into it instead of stacking a duplicate.
   - `uv lock --upgrade-package boto3 --upgrade-package botocore` so boto3 stays in lockstep.

Plus: cron `*/3 days` → weekly Monday, and a \"no fake memory\" rule in claude-review-prompt.md (the bot confabulated \"saved to memory as durable feedback\" on #1571 — the runtime has no persistent memory across runs).

## Architecture

\`\`\`
detect (existing — emits version info)
  ↓
classify (NEW — Sonnet, ~\$0.10, runs check-async-need only)
  ↓ verdict + rationale + affected_files
sync (existing — model = sonnet if no-port else opus)
\`\`\`

Estimated savings per run:
- no-port sync: ~\$4.50 → ~\$1.50 (Sonnet output is ~5× cheaper)
- port-required sync: ~\$4.50 → ~\$4.30 (skips Step 3 reasoning)
- dry-run: skips sync entirely; classify-only with hash sanity check in step summary

Annualized at ~weekly cadence with ~70% no-port: ~\$110/yr saved before counting reduced @claude follow-up cost (smaller PR bodies = smaller cached prefix).

## Test plan

- [ ] `uv run pre-commit run --all-files` passes locally (verified — yamllint + rumdl + GHA workflow validator all green)
- [ ] Dry-run via workflow_dispatch on this branch with a known no-port range — confirm classify emits `no-port` and sync doesn't run
- [ ] Dry-run with a known port-required range — confirm classify emits `port-required` and the conditional model resolves to `opus`
- [ ] Real schedule run — verify model selection works end-to-end

## Out of scope

- PR #1573 (port-tests new-mirror exception) is not touched here. A follow-up comment with a registry-detection enhancement suggestion will be posted on that PR separately.
- Bigger architectural option (have classify produce a structured port plan that sync just executes) is deferred to a separate design discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)