### PR TITLE
ci(claude): skip dependabot and fork PRs in pull_request trigger

### DIFF
--- a/.github/claude-review-prompt.md
+++ b/.github/claude-review-prompt.md
@@ -195,19 +195,33 @@ IMPORTANT: Never merge or close pull requests. Never close issues. These actions
 End-of-run cleanup via `/aiobotocore-bot:complete-run`. The skill posts the summary reply to the right target
 (inline thread vs top-level PR comment vs issue comment, based on `--event`) and swaps the 👀 reaction for 👍.
 
+`claude.yml` enables `use_sticky_comment: true` + `track_progress: true`, so claude-code-action automatically
+posts a top-level PR comment containing your final assistant message. For events whose natural reply target
+*is* a top-level PR comment, that sticky comment already serves as the reply — passing `--skip-reply` to
+`complete-run` avoids duplicate top-level comments. For inline-thread replies (`pull_request_review_comment`)
+and issue threads (`issues`), the sticky comment is on a different surface, so `complete-run` still needs to
+post.
+
 Invocations by event:
 
-- `pull_request_review_comment` or `issue_comment`:
-  `/aiobotocore-bot:complete-run --event=$EVENT_NAME --number=$NUMBER --comment-id=$COMMENT_ID --summary="<body>"`
-- `pull_request_review`:
-  `/aiobotocore-bot:complete-run --event=pull_request_review --number=$NUMBER --summary="<body>"`
-- `issues`:
-  `/aiobotocore-bot:complete-run --event=issues --number=$NUMBER --summary="<body>"`
+- `pull_request_review_comment`:
+  `/aiobotocore-bot:complete-run --event=pull_request_review_comment --number=$NUMBER --comment-id=$COMMENT_ID --summary="<body>"`
+  — inline-thread reply, distinct surface from the sticky comment.
+- `issue_comment`: `/aiobotocore-bot:complete-run --event=issue_comment --number=$NUMBER --comment-id=$COMMENT_ID --skip-reply`
+  — sticky comment already posted your reply at the top level; just swap the reaction.
+- `pull_request_review`: `/aiobotocore-bot:complete-run --event=pull_request_review --number=$NUMBER --skip-reply`
+  — same as above; sticky comment is the reply.
+- `issues`: `/aiobotocore-bot:complete-run --event=issues --number=$NUMBER --summary="<body>"`
+  — issue thread is the only surface; sticky comment is PR-only.
 - `pull_request` (review path): `/aiobotocore-bot:complete-run --event=pull_request --number=$NUMBER --skip-reply`
   — `review-pr` already posted its own review comment; we only need the reaction swap.
 
-The summary body should say what you changed (with commit SHAs or file paths), what you decided NOT to do (and
-why), and any follow-up asks for the reviewer.
+When `--skip-reply` is set, your assistant-message output IS the user-visible reply (it lands in the sticky
+comment), so write it as the actual response to the reviewer — not as an internal status update.
+
+The reply body (whether posted by `complete-run` or surfaced via the sticky comment) should say what you
+changed (with commit SHAs or file paths), what you decided NOT to do (and why), and any follow-up asks for
+the reviewer.
 
 ## Environment
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -56,12 +56,22 @@ on:
 jobs:
   claude:
     # Only trusted authors can trigger @claude interactions.
-    # Auto-review on pull_request events is unrestricted — except on drafts,
-    # which should not burn CI time. Explicit @claude mentions on a draft still
-    # fire via issue_comment / review_comment / review and are allowed.
+    # Auto-review on pull_request events is unrestricted — except on:
+    #   - drafts (should not burn CI time)
+    #   - dependabot PRs (claude-code-action's allowed_bots gate hard-fails
+    #     on dependabot[bot]; nothing useful to review on dep bumps anyway)
+    #   - fork PRs (GitHub downgrades id-token: write to read-only on fork
+    #     pull_request events, so the action can't mint an OIDC token and
+    #     the run errors out; maintainers can still trigger review on a
+    #     fork PR via @claude in an issue_comment, which runs in the base
+    #     repo's context with full permissions)
+    # Explicit @claude mentions on a draft still fire via
+    # issue_comment / review_comment / review and are allowed.
     if: >-
       (github.event_name == 'pull_request' &&
-       github.event.pull_request.draft != true) ||
+       github.event.pull_request.draft != true &&
+       github.event.pull_request.user.login != 'dependabot[bot]' &&
+       github.event.pull_request.head.repo.fork != true) ||
       (github.event_name == 'issue_comment' &&
        contains(github.event.comment.body, '@claude') &&
        contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'),

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -4,15 +4,16 @@ name: Claude Code
 run-name: >-
   Claude:
   ${{
-    github.event_name == 'pull_request'
+    github.event_name == 'pull_request_target'
+      && github.event.pull_request.head.repo.fork
+      && format('Notify fork PR #{0}',
+         github.event.pull_request.number)
+    || github.event_name == 'pull_request_target'
       && format('Review PR #{0}',
          github.event.pull_request.number)
     || github.event_name == 'issues'
       && format('Issue #{0}',
          github.event.issue.number)
-    || github.event_name == 'pull_request_target'
-      && format('Notify fork PR #{0}',
-         github.event.pull_request.number)
     || format('PR #{0} comment',
        github.event.issue.number
        || github.event.pull_request.number)
@@ -35,10 +36,23 @@ permissions: {}
 concurrency:
   # yamllint disable-line rule:line-length
   group: claude-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
 
 on:
-  pull_request:
+  # Use pull_request_target instead of pull_request so the action runs
+  # against main's version of THIS workflow file. claude-code-action's
+  # anti-tampering validator hard-fails any run where the calling
+  # workflow file diverges from the default branch — i.e. every PR
+  # that touches claude.yml itself (dependabot bumps, maintainer
+  # tweaks). pull_request_target runs in the base repo's context, so
+  # the workflow file used IS main's and the validator passes.
+  #
+  # Security: forks are excluded in the claude job's `if:`, so this
+  # only grants base-repo secrets to same-repo PRs from authors who
+  # already have push access. The `actions/checkout` step below
+  # explicitly pins to the PR head SHA so the review actually sees the
+  # PR's diff.
+  pull_request_target:
     types:
     - opened
     - synchronize
@@ -55,29 +69,22 @@ on:
     types:
     - opened
     - assigned
-  # Used ONLY by the notify-fork-pr job below — the claude job's `if:`
-  # has no pull_request_target clause, so it stays skipped on this event.
-  # Restricted to `opened` so we comment once per fork PR, not on every push.
-  pull_request_target:
-    types:
-    - opened
 
 jobs:
   claude:
     # Only trusted authors can trigger @claude interactions.
-    # Auto-review on pull_request events is unrestricted — except on:
+    # Auto-review on pull_request_target events is unrestricted — except on:
     #   - drafts (should not burn CI time)
     #   - dependabot PRs (claude-code-action's allowed_bots gate hard-fails
     #     on dependabot[bot]; nothing useful to review on dep bumps anyway)
-    #   - fork PRs (GitHub downgrades id-token: write to read-only on fork
-    #     pull_request events, so the action can't mint an OIDC token and
-    #     the run errors out; maintainers can still trigger review on a
-    #     fork PR via @claude in an issue_comment, which runs in the base
-    #     repo's context with full permissions)
+    #   - fork PRs (pull_request_target on a fork would expose base-repo
+    #     secrets to fork-supplied code; not worth the risk for auto-review.
+    #     Maintainers can still trigger review on a fork PR via @claude in
+    #     an issue_comment, which runs in the base repo's context safely)
     # Explicit @claude mentions on a draft still fire via
     # issue_comment / review_comment / review and are allowed.
     if: >-
-      (github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request_target' &&
        github.event.pull_request.draft != true &&
        github.event.pull_request.user.login != 'dependabot[bot]' &&
        github.event.pull_request.head.repo.fork != true) ||
@@ -119,6 +126,15 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
+        # pull_request_target defaults to the base ref; pin to the PR
+        # head SHA so the review sees the PR's actual diff. Pinning
+        # the immutable SHA at job start (vs. the head ref name) is
+        # a TOCTOU guard — prevents a force-push mid-job from
+        # swapping in different code than the `if:` gate evaluated
+        # against. Falls through to the default (main) for
+        # comment-triggered events where head.sha is unset; the
+        # agent calls `gh pr checkout` itself when it needs PR code.
+        ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 1
         persist-credentials: false
 
@@ -287,8 +303,12 @@ jobs:
   # the comment body is hardcoded and we only read the PR number from the
   # event payload.
   notify-fork-pr:
+    # pull_request_target now also fires on `synchronize` for the claude
+    # job above; gate this notice to `opened` only so we don't re-comment
+    # on every push to a fork PR.
     if: >-
       github.event_name == 'pull_request_target' &&
+      github.event.action == 'opened' &&
       github.event.pull_request.head.repo.fork == true
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,9 @@ run-name: >-
     || github.event_name == 'issues'
       && format('Issue #{0}',
          github.event.issue.number)
+    || github.event_name == 'pull_request_target'
+      && format('Notify fork PR #{0}',
+         github.event.pull_request.number)
     || format('PR #{0} comment',
        github.event.issue.number
        || github.event.pull_request.number)
@@ -52,6 +55,12 @@ on:
     types:
     - opened
     - assigned
+  # Used ONLY by the notify-fork-pr job below — the claude job's `if:`
+  # has no pull_request_target clause, so it stays skipped on this event.
+  # Restricted to `opened` so we comment once per fork PR, not on every push.
+  pull_request_target:
+    types:
+    - opened
 
 jobs:
   claude:
@@ -269,3 +278,28 @@ jobs:
         EXEC_FILE: >-
           ${{ steps.claude.outputs.execution_file }}
       run: python3 .github/usage-summary.py
+
+  # Posts a one-time explanatory comment on fork PRs, since the claude job
+  # above skips them (GitHub downgrades id-token: write to read-only on fork
+  # pull_request events, breaking OIDC). Runs on pull_request_target so it
+  # has the base repo's GITHUB_TOKEN with pull-requests: write — safe because
+  # we never check out the fork SHA or execute any fork-supplied content;
+  # the comment body is hardcoded and we only read the PR number from the
+  # event payload.
+  notify-fork-pr:
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.fork == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+    steps:
+    - name: Comment on fork PR
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+        # yamllint disable-line rule:line-length
+        BODY: "Thanks for the contribution! Automated Claude review is disabled on fork PRs because GitHub Actions restricts the OIDC token on them. A maintainer can trigger a review by commenting `@claude please review` once they have had a chance to look at the PR."
+      run: gh pr comment "$PR" --repo "$REPO" --body "$BODY"


### PR DESCRIPTION
## Summary

Several independent fixes to the Claude Code workflow, surfaced from the same investigation of recent failures.

**1. Switch `pull_request` → `pull_request_target`.** `claude-code-action`'s anti-tampering validator hard-fails any run where the calling workflow file diverges from the default branch — i.e. every PR that touches `claude.yml` itself (dependabot bumps, maintainer tweaks like this very PR). Recent example: [#1580 run](https://github.com/aio-libs/aiobotocore/actions/runs/25196525529). `pull_request_target` runs in the base repo's context, so the workflow file used IS main's and the validator passes.

Forks are still excluded in the `if:`, which is critical: with `pull_request_target` the job runs with full base secrets (`ANTHROPIC_API_KEY`, write `GITHUB_TOKEN`, etc.), and `uv sync` / the prompt template / plugin marketplace / `usage-summary.py` are all loaded from the PR's checkout. Letting fork code through would be the canonical pull_request_target privilege escalation antipattern. Maintainer-triggered review on fork PRs via `@claude` in `issue_comment` continues to work — it runs from main's workflow with no fork code execution.

`actions/checkout` pins to `github.event.pull_request.head.sha` (not the ref name) so a force-push mid-job can't swap in different code than the `if:` gate evaluated against.

**2. Skip dependabot PRs.** `claude-code-action`'s `allowed_bots: "claude[bot]"` gate hard-fails any run initiated by `dependabot[bot]` with `Workflow initiated by non-human actor: dependabot (type: Bot)`. Recent example: [#1581 run](https://github.com/aio-libs/aiobotocore/actions/runs/25196625746). Nothing useful to review on a dep bump anyway.

**3. Skip fork PRs in auto-review (with explanatory notice).** Auto-review on fork PRs has been broken (OIDC token unavailable) and remains undesirable for the security reasons above. Adds a tiny `notify-fork-pr` job that fires on `pull_request_target: [opened]` for fork PRs only, posting a single comment so external contributors know to ask a maintainer to trigger review with `@claude`. Safe `pull_request_target` use: no checkout, no fork code executed, hardcoded body, only the PR number is read from the event payload. Gated to `opened` to avoid re-commenting on every push.

**4. Stop posting duplicate top-level comments on `@claude` mentions.** `claude.yml` enables `use_sticky_comment: true` + `track_progress: true`, so `claude-code-action` already posts the agent's final assistant message as a top-level PR comment. The prompt's Cleanup section then ran `complete-run --summary=…` *on top*, producing two top-level comments per run for `issue_comment` and `pull_request_review` events. Concrete example on PR #1579: comment [4358756424](https://github.com/aio-libs/aiobotocore/pull/1579#issuecomment-4358756424) from the sticky, comment [4358767006](https://github.com/aio-libs/aiobotocore/pull/1579#issuecomment-4358767006) from `complete-run`, near-identical content.

Updated `.github/claude-review-prompt.md` Cleanup section: pass `--skip-reply` on `issue_comment` and `pull_request_review`, since the sticky comment is the canonical reply on those paths. `pull_request_review_comment` (inline-thread reply) and `issues` (no PR sticky) keep posting because they're on different surfaces.

## Test plan

- [ ] Land this; confirm next dependabot PR shows the claude job as skipped, not failed.
- [ ] Confirm next fork PR shows the claude job as skipped and a comment from the `notify-fork-pr` job appears once.
- [ ] Confirm `@claude please review` from a maintainer on a fork PR still triggers the workflow via `issue_comment` and produces a single top-level review comment (not two).
- [ ] Confirm same-repo non-bot PRs (including ones that modify `claude.yml`) still auto-review.

## Caveat

`pull_request_target` + `claude-code-action`'s `prompt:` parameter is not the documented happy path. Earlier research surfaced [issue #621](https://github.com/anthropics/claude-code-action/issues/621) about review comments not posting under `pull_request_target` in some configurations. If we hit that, revert the trigger change and accept the validation failure on workflow-touching PRs (workaround: maintainer comments `@claude` to trigger review from main's workflow via `issue_comment`).
