### PR TITLE
Revert pull_request → pull_request_target switch (App token 401)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -4,16 +4,15 @@ name: Claude Code
 run-name: >-
   Claude:
   ${{
-    github.event_name == 'pull_request_target'
-      && github.event.pull_request.head.repo.fork
-      && format('Notify fork PR #{0}',
-         github.event.pull_request.number)
-    || github.event_name == 'pull_request_target'
+    github.event_name == 'pull_request'
       && format('Review PR #{0}',
          github.event.pull_request.number)
     || github.event_name == 'issues'
       && format('Issue #{0}',
          github.event.issue.number)
+    || github.event_name == 'pull_request_target'
+      && format('Notify fork PR #{0}',
+         github.event.pull_request.number)
     || format('PR #{0} comment',
        github.event.issue.number
        || github.event.pull_request.number)
@@ -36,23 +35,10 @@ permissions: {}
 concurrency:
   # yamllint disable-line rule:line-length
   group: claude-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
-  # Use pull_request_target instead of pull_request so the action runs
-  # against main's version of THIS workflow file. claude-code-action's
-  # anti-tampering validator hard-fails any run where the calling
-  # workflow file diverges from the default branch — i.e. every PR
-  # that touches claude.yml itself (dependabot bumps, maintainer
-  # tweaks). pull_request_target runs in the base repo's context, so
-  # the workflow file used IS main's and the validator passes.
-  #
-  # Security: forks are excluded in the claude job's `if:`, so this
-  # only grants base-repo secrets to same-repo PRs from authors who
-  # already have push access. The `actions/checkout` step below
-  # explicitly pins to the PR head SHA so the review actually sees the
-  # PR's diff.
-  pull_request_target:
+  pull_request:
     types:
     - opened
     - synchronize
@@ -69,22 +55,29 @@ on:
     types:
     - opened
     - assigned
+  # Used ONLY by the notify-fork-pr job below — the claude job's `if:`
+  # has no pull_request_target clause, so it stays skipped on this event.
+  # Restricted to `opened` so we comment once per fork PR, not on every push.
+  pull_request_target:
+    types:
+    - opened
 
 jobs:
   claude:
     # Only trusted authors can trigger @claude interactions.
-    # Auto-review on pull_request_target events is unrestricted — except on:
+    # Auto-review on pull_request events is unrestricted — except on:
     #   - drafts (should not burn CI time)
     #   - dependabot PRs (claude-code-action's allowed_bots gate hard-fails
     #     on dependabot[bot]; nothing useful to review on dep bumps anyway)
-    #   - fork PRs (pull_request_target on a fork would expose base-repo
-    #     secrets to fork-supplied code; not worth the risk for auto-review.
-    #     Maintainers can still trigger review on a fork PR via @claude in
-    #     an issue_comment, which runs in the base repo's context safely)
+    #   - fork PRs (GitHub downgrades id-token: write to read-only on fork
+    #     pull_request events, so the action can't mint an OIDC token and
+    #     the run errors out; maintainers can still trigger review on a
+    #     fork PR via @claude in an issue_comment, which runs in the base
+    #     repo's context with full permissions)
     # Explicit @claude mentions on a draft still fire via
     # issue_comment / review_comment / review and are allowed.
     if: >-
-      (github.event_name == 'pull_request_target' &&
+      (github.event_name == 'pull_request' &&
        github.event.pull_request.draft != true &&
        github.event.pull_request.user.login != 'dependabot[bot]' &&
        github.event.pull_request.head.repo.fork != true) ||
@@ -126,15 +119,6 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
-        # pull_request_target defaults to the base ref; pin to the PR
-        # head SHA so the review sees the PR's actual diff. Pinning
-        # the immutable SHA at job start (vs. the head ref name) is
-        # a TOCTOU guard — prevents a force-push mid-job from
-        # swapping in different code than the `if:` gate evaluated
-        # against. Falls through to the default (main) for
-        # comment-triggered events where head.sha is unset; the
-        # agent calls `gh pr checkout` itself when it needs PR code.
-        ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 1
         persist-credentials: false
 
@@ -303,12 +287,8 @@ jobs:
   # the comment body is hardcoded and we only read the PR number from the
   # event payload.
   notify-fork-pr:
-    # pull_request_target now also fires on `synchronize` for the claude
-    # job above; gate this notice to `opened` only so we don't re-comment
-    # on every push to a fork PR.
     if: >-
       github.event_name == 'pull_request_target' &&
-      github.event.action == 'opened' &&
       github.event.pull_request.head.repo.fork == true
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,6 +38,14 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
+  # Don't "fix" the workflow-validation 401 on PRs that modify claude.yml
+  # by switching this to pull_request_target. It tempts because it'd run
+  # the workflow against main's file (passing the validator) — but the
+  # Claude Code GitHub App's OIDC exchange endpoint refuses tokens whose
+  # event_name claim is `pull_request_target`, so the action 401s at
+  # startup on EVERY run with `App token exchange failed: 401 Unauthorized
+  # - Invalid OIDC token`. Worse than the validator failure it works
+  # around. See #1583 for the post-mortem.
   pull_request:
     types:
     - opened


### PR DESCRIPTION
## Summary

Reverts the `pull_request → pull_request_target` switch from #1582 (commit 549d977). The other #1582 changes (dependabot/fork skip in `if:`, `notify-fork-pr` job, prompt `--skip-reply` dedup) stay.

## Why

`pull_request_target` was supposed to bypass `claude-code-action`'s workflow-validation check on PRs that modify `claude.yml`. It does — but it trips a different guard upstream that's worse. The first `pull_request_target` run on this branch ([run 25210824644](https://github.com/aio-libs/aiobotocore/actions/runs/25210824644/job/73920933734?pr=1583)) failed at action startup with:

```
Requesting OIDC token...
OIDC token successfully obtained
Exchanging OIDC token for app token...
App token exchange failed: 401 Unauthorized - Invalid OIDC token
```

The action exchanges the workflow's OIDC token for a Claude Code GitHub App token at every startup (used for `use_commit_signing: true`'s signed-commit path). Anthropic's exchange endpoint rejects OIDC tokens whose `event_name` claim is `pull_request_target` — a sensible guard on their end, since `pull_request_target` is the canonical privilege-escalation vector. The action then fails the run.

Net effect: every same-repo PR push would 401 at startup. That's strictly worse than the original validation-failure behavior, which only hit the rare class of PRs that actually edit `claude.yml`.

## Aftermath

PRs that touch `claude.yml` go back to producing the documented "this is normal, ignore it" red X on the auto-review. Maintainer workaround stays the same: comment `@claude please review` on the PR — `issue_comment` runs from main's workflow with normal auth, so the validation passes and the review proceeds.

## Test plan

- [ ] Land. Confirm same-repo PR pushes start auto-reviewing again (validate by pushing a no-op commit to an existing same-repo PR after merge).
- [ ] Confirm the dependabot/fork-skip + notify-fork-pr + prompt dedup behaviors from #1582 are still in effect.
