### PR TITLE
fix: credential_process on Windows + Selector event loop (closes #1415)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changes
 -------
 
+3.7.1 (2026-05-08)
+^^^^^^^^^^^^^^^^^^
+* fall back to synchronous ``subprocess.run`` (via ``asyncio.to_thread``) for
+  ``credential_process`` when the running event loop does not implement
+  subprocess transports — notably ``asyncio.SelectorEventLoop`` on Windows
+  (closes #1415)
+
 3.7.0 (2026-05-08)
 ^^^^^^^^^^^^^^^^^^
 * add ``AioSession.warm_up_loader_caches()`` and ``warm_up_loader_caches`` option in ``AioConfig`` to pre-populate

--- a/aiobotocore/__init__.py
+++ b/aiobotocore/__init__.py
@@ -1,3 +1,3 @@
 """Async client for AWS services, wrapping botocore with aiohttp/httpx."""
 
-__version__ = '3.7.0'
+__version__ = '3.7.1'

--- a/aiobotocore/credentials.py
+++ b/aiobotocore/credentials.py
@@ -552,6 +552,13 @@ class AioAssumeRoleWithWebIdentityCredentialFetcher(
         return assume_role_kwargs
 
 
+def _run_credential_process_sync(process_list):
+    # Synchronous fallback for event loops that don't implement
+    # subprocess transports. Caller runs this via ``asyncio.to_thread``.
+    p = subprocess.run(process_list, capture_output=True, check=False)
+    return p.stdout, p.stderr, p.returncode
+
+
 class AioProcessProvider(ProcessProvider):
     def __init__(self, *args, popen=asyncio.create_subprocess_exec, **kwargs):
         super().__init__(*args, **kwargs, popen=popen)
@@ -583,11 +590,23 @@ class AioProcessProvider(ProcessProvider):
         # We're not using shell=True, so we need to pass the
         # command and all arguments as a list.
         process_list = compat_shell_split(credential_process)
-        p = await self._popen(
-            *process_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
-        stdout, stderr = await p.communicate()
-        if p.returncode != 0:
+        try:
+            p = await self._popen(
+                *process_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
+            stdout, stderr = await p.communicate()
+            returncode = p.returncode
+        except NotImplementedError:
+            # Some event loops don't implement subprocess transports —
+            # notably ``asyncio.SelectorEventLoop`` on Windows, which
+            # users select when integrating with libraries that don't
+            # support the Proactor loop (e.g. ``psycopg``). Fall back
+            # to running the credential process synchronously in a
+            # worker thread so the loop stays unblocked. (#1415)
+            stdout, stderr, returncode = await asyncio.to_thread(
+                _run_credential_process_sync, process_list
+            )
+        if returncode != 0:
             raise CredentialRetrievalError(
                 provider=self.METHOD, error_msg=stderr.decode('utf-8')
             )

--- a/tests/botocore_tests/unit/test_credentials.py
+++ b/tests/botocore_tests/unit/test_credentials.py
@@ -1670,6 +1670,47 @@ def process_provider():
     return _f
 
 
+async def test_processprovider_falls_back_to_sync_when_subprocess_unsupported(
+    process_provider, mocker
+):
+    # Regression for #1415: ``asyncio.SelectorEventLoop`` on Windows raises
+    # ``NotImplementedError`` from ``loop.subprocess_exec``. Verify the
+    # provider catches this and runs the credential process synchronously
+    # in a worker thread instead of bubbling the error to the caller.
+    config = {'profiles': {'default': {'credential_process': 'my-process'}}}
+    stdout = json.dumps(
+        {
+            'Version': 1,
+            'AccessKeyId': 'foo',
+            'SecretAccessKey': 'bar',
+            'SessionToken': 'baz',
+            'Expiration': '2999-01-01T00:00:00Z',
+        }
+    ).encode('utf-8')
+
+    async def popen_raises_not_implemented(*args, **kwargs):
+        # Mimic SelectorEventLoop on Windows.
+        raise NotImplementedError
+
+    completed = mocker.Mock(stdout=stdout, stderr=b'', returncode=0)
+    sync_run = mocker.patch(
+        'aiobotocore.credentials.subprocess.run', return_value=completed
+    )
+
+    _, provider = process_provider(loaded_config=config)
+    provider._popen = popen_raises_not_implemented
+
+    creds = await provider.load()
+    assert creds is not None
+    frozen = await creds.get_frozen_credentials()
+    assert frozen.access_key == 'foo'
+    assert frozen.secret_key == 'bar'
+    assert frozen.token == 'baz'
+    sync_run.assert_called_once_with(
+        ['my-process'], capture_output=True, check=False
+    )
+
+
 async def test_processprovider_can_retrieve_account_id(process_provider):
     config = {'profiles': {'default': {'credential_process': 'my-process'}}}
     invoked_process = mock.AsyncMock()


### PR DESCRIPTION
## Summary

Apps that mix aiobotocore with libraries that require ``asyncio.WindowsSelectorEventLoopPolicy`` (e.g. ``psycopg``, which doesn't support the Proactor loop) currently fail at credential resolution time if ``~/.aws/config`` has a ``credential_process`` set:

```
File ".../aiobotocore/credentials.py", line 586, in _retrieve_credentials_using
  p = await self._popen(...)
File ".../asyncio/base_events.py", line 1798, in subprocess_exec
  transport = await self._make_subprocess_transport(...)
NotImplementedError
```

The Selector loop on Windows doesn't implement subprocess transports.

Closes #1415.

## Reproduction (verified locally)

`~/.aws/config`:
```
[default]
credential_process = python /path/to/fake_cred_process.py
```

```python
import asyncio, aiobotocore.session
asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())

async def main():
    session = aiobotocore.session.AioSession()
    creds = await session.get_credentials()  # raised NotImplementedError before this PR
    frozen = await creds.get_frozen_credentials()
    print(frozen.access_key)

asyncio.run(main())
```

Before: ``NotImplementedError`` at ``loop.subprocess_exec``. After: prints the access key.

## Fix

Catch ``NotImplementedError`` around the existing ``await self._popen(...)`` call and fall back to ``subprocess.run`` dispatched via ``asyncio.to_thread``. The event loop stays unblocked while the credential process executes; the rest of the flow (JSON parsing, refreshable-credentials wiring) is unchanged.

The fallback is duck-typed on ``NotImplementedError`` rather than ``sys.platform == 'win32'`` — any custom or constrained loop that lacks subprocess transports gets the same behavior.

## Test plan

- [x] New regression test ``test_processprovider_falls_back_to_sync_when_subprocess_unsupported`` in ``tests/botocore_tests/unit/test_credentials.py`` mocks ``_popen`` to raise ``NotImplementedError``, mocks ``subprocess.run`` for the fallback, and verifies credentials are returned end-to-end.
- [x] Existing 9 ``processprovider`` tests continue to pass.
- [x] Pre-commit clean.
- [x] Manual repro on Windows: ``WindowsSelectorEventLoopPolicy`` + ``credential_process`` succeeds with the fix; fails on ``main`` without it.