### PR TITLE
ci: smoke-test built wheel and sdist after build (closes #1169)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -93,11 +93,55 @@ jobs:
 
     uses: zizmorcore/workflow/.github/workflows/reusable-zizmor.yml@3bb5e95068d0f44b6d2f3f7e91379bed1d2f96a8
 
+  test-dist:
+    name: Smoke-test ${{ matrix.dist-kind }} dist
+    needs:
+    - build
+    strategy:
+      matrix:
+        dist-kind: [wheel, sdist]
+      fail-fast: false
+    runs-on: ubuntu-24.04
+    timeout-minutes: 3
+    steps:
+    - name: Download distribution 📦
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Install uv
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+      with:
+        version: '0.11.7'
+        python-version: '3.14'
+    # Install the built artifact into a fresh Python with no project source
+    # checked out — verifies the dist is self-contained (MANIFEST is correct,
+    # all required modules ship, dependencies resolve, ``import aiobotocore``
+    # works on a clean env). twine check --strict (in build) covers metadata
+    # validity; this complements it with a real install + import test.
+    - name: Install ${{ matrix.dist-kind }} and verify import
+      env:
+        DIST_KIND: ${{ matrix.dist-kind }}
+      run: |
+        case "$DIST_KIND" in
+          wheel) artifact=(dist/*.whl) ;;
+          sdist) artifact=(dist/*.tar.gz) ;;
+        esac
+        uv venv smoke-env
+        uv pip install --python smoke-env "${artifact[0]}[httpx]"
+        uv run --no-project --python smoke-env python -c \
+          "import aiobotocore; print('aiobotocore', aiobotocore.__version__); \
+           import aiobotocore.session, aiobotocore.client, aiobotocore.config, \
+                  aiobotocore.endpoint, aiobotocore.httpsession, \
+                  aiobotocore.httpxsession, aiobotocore.credentials, \
+                  aiobotocore.response"
+
   check:  # This job does nothing and is only used for the branch protection
     if: always()
     needs:
     - build
     - test
+    - test-dist
     - zizmor
     runs-on: ubuntu-24.04
     timeout-minutes: 5

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -114,6 +114,13 @@ jobs:
       with:
         version: '0.11.7'
         python-version: '3.14'
+        # Disable cache: this job runs after `actions/download-artifact`
+        # pulls a freshly-built dist into the workspace, and the smoke
+        # test installs that artifact into a one-shot venv. Caching the
+        # uv install/wheel cache here would let a poisoned cache from a
+        # prior run influence the install (zizmor cache-poisoning #49)
+        # without saving meaningful time on a one-package install.
+        enable-cache: false
     # Install the built artifact into a fresh Python with no project source
     # checked out — verifies the dist is self-contained (MANIFEST is correct,
     # all required modules ship, dependencies resolve, ``import aiobotocore``


### PR DESCRIPTION
## Summary

Adds a ``test-dist`` matrix job (wheel, sdist) that depends on ``build`` and verifies the produced artifact installs into a fresh Python env and imports cleanly. The job is wired into the ``check`` aggregator so branch protection gates on it.

Closes #1169.

## What this catches that current CI doesn't

| Existing | What it catches |
|-|-|
| ``twine check --strict`` (in ``build``) | metadata validity, README rendering |
| Test matrix (``test``) | functional behavior, but installs from source via ``uv sync`` so an editable install — never actually exercises the built wheel/sdist |

This new job catches the gap:

- **MANIFEST issues** — required modules missing from the sdist
- **pyproject.toml dependency mistakes** — package installs from source via uv but the wheel can't resolve its declared dependencies on a clean env
- **Missing data files** — anything referenced at import time but not packaged
- **Conditional imports** — ``aiobotocore.httpxsession`` requires the ``[httpx]`` extra; smoke test uses it to verify the extra resolves

## What this is NOT

@webknjaz's original framing in #1169 was broader: *"the tests should depend on building the dists"* — i.e., make the entire test matrix install from the dist artifact instead of editable source. That's a meaningful CI restructure (changes coverage paths, requires test files outside the source tree, breaks editable-install dev ergonomics). This PR is the smoke-test-sized increment; happy to file a follow-up for the full restructure if there's interest.

## Implementation notes

- Both wheel and sdist as a matrix (fail-fast: false) so each is exercised independently.
- Uses ``uv venv`` + ``uv pip install`` for env creation rather than ``actions/setup-python`` to match the rest of the repo's tooling (every other job uses ``astral-sh/setup-uv``).
- Pinned to the same SHA-and-comment-version pattern as other actions in this workflow.
- 3-minute timeout (build-and-import is fast).
- Imports the public submodules explicitly (``aiobotocore.session``, ``client``, ``config``, ``endpoint``, ``httpsession``, ``httpxsession``, ``credentials``, ``response``) — so an accidentally missing module surfaces in the smoke test rather than at user import time.

## Test plan

- [x] Pre-commit clean locally (yamllint, GitHub Actions schema validation, line-length).
- [x] Local validation: built wheel + sdist via ``uv build``, installed wheel into fresh ``uv venv``, all listed imports succeed.
- [ ] CI run on this PR will exercise the new job against a real GitHub-built dist artifact.