### PR TITLE
ci: add sphinx-lint pre-commit hook (closes #1560)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,11 @@ repos:
   rev: e25bab4ecdcb2d86aaf956ad89f9ccda55e226ab  # v0.1.74
   hooks:
   - id: rumdl
+- repo: https://github.com/sphinx-contrib/sphinx-lint
+  # yamllint disable-line rule:line-length
+  rev: c883505f64b59c3c5c9375191e4ad9f98e727ccd  # v1.0.2
+  hooks:
+  - id: sphinx-lint
 - repo: https://github.com/python-jsonschema/check-jsonschema
   # yamllint disable-line rule:line-length
   rev: ba8f7ac0e0c0d25bae15b628b634316e7d201db5  # 0.36.1


### PR DESCRIPTION
## Summary

Adds ``sphinx-contrib/sphinx-lint`` v1.0.2 as a pre-commit hook. Resolves the deferred decision in #1560.

Closes #1560.

## Why sphinx-lint and not rstcheck

From the evaluation in #1560:

| Tool | Caught the duplicate-target bug from #1559 | Noise on this repo | Adoption |
|-|-|-|-|
| ``sphinx-lint`` | No (semantic-issues miss) | None — clean ``No problems found`` | High (CPython, scrapy, trio) |
| ``rstcheck`` | Yes | High — needs ``--ignore-directives`` / ``--ignore-roles`` / ``--ignore-messages`` tuning | Medium |

``sphinx-lint`` is the zero-config / zero-noise option. It catches role typos, malformed directives, leaked markup, missing literal spaces, and similar style/semantic issues. It does *not* catch every class of RST bug — duplicate-target style issues from #1559 still fall to the Claude review or PR review. Adding ``rstcheck`` on top would catch more but costs ongoing tuning; the cost/benefit doesn't justify it given the historical rate of RST bugs (~1 in 8 years).

## Configuration

sphinx-lint has **no config-file support** — no ``[tool.sphinx-lint]`` in ``pyproject.toml``, no ``.sphinxlintrc``, no ``setup.cfg`` integration. CLI flags only. Verified by reading ``sphinxlint/cli.py`` upstream. So the ``args:`` field in ``.pre-commit-config.yaml`` is the canonical configuration point in this ecosystem; this PR uses defaults (which pass cleanly across the existing RST). ``--enable=all`` was rejected because it adds an 80-char line-length check that conflicts with the repo's wider-line conventions.

## Test plan

- [x] ``uv run pre-commit run --all`` passes locally — sphinx-lint reports no findings on the existing RST files.