### PR TITLE
chore(release): consolidate unreleased 3.6.1/3.7.0/3.7.1 into 3.7.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,22 +1,16 @@
 Changes
 -------
 
-3.7.1 (2026-05-08)
-^^^^^^^^^^^^^^^^^^
-* fall back to synchronous ``subprocess.run`` (via ``asyncio.to_thread``) for
-  ``credential_process`` when the running event loop does not implement
-  subprocess transports — notably ``asyncio.SelectorEventLoop`` on Windows
-  (closes #1415)
-
 3.7.0 (2026-05-08)
 ^^^^^^^^^^^^^^^^^^
 * add ``AioSession.warm_up_loader_caches()`` and ``warm_up_loader_caches`` option in ``AioConfig`` to pre-populate
   botocore loader caches off the event loop, avoiding blocking file I/O on first client/waiter/paginator use
   (closes #1199)
-
-3.6.1 (2026-05-01)
-^^^^^^^^^^^^^^^^^^
 * fix race condition in ``AioAssumeRoleProvider._visited_profiles`` causing false ``InfiniteLoopConfigError`` under concurrent async usage
+* fall back to synchronous ``subprocess.run`` (via ``asyncio.to_thread``) for
+  ``credential_process`` when the running event loop does not implement
+  subprocess transports — notably ``asyncio.SelectorEventLoop`` on Windows
+  (closes #1415)
 
 3.6.0 (2026-04-30)
 ^^^^^^^^^^^^^^^^^^

--- a/aiobotocore/__init__.py
+++ b/aiobotocore/__init__.py
@@ -1,3 +1,3 @@
 """Async client for AWS services, wrapping botocore with aiohttp/httpx."""
 
-__version__ = '3.7.1'
+__version__ = '3.7.0'


### PR DESCRIPTION
## Summary

The latest released version on PyPI is **3.6.0**. The `3.6.1`, `3.7.0`, and `3.7.1` entries currently on `main` are all unreleased, so there's no reason to keep them as separate version headers — they will all ship together in the next release.

Per @jakob-keller's review feedback on #1588 ([comment](https://github.com/aio-libs/aiobotocore/pull/1588#discussion_r2174923459) / [comment](https://github.com/aio-libs/aiobotocore/pull/1588#discussion_r2174924398)), this PR folds the three unreleased entries into a single `3.7.0` entry and rolls `__version__` back to `3.7.0`. The minor bump is driven by the `warm_up_loader_caches` feature; the other two bullets are bug fixes.

## Changes

- `CHANGES.rst`: collapse `3.6.1` + `3.7.0` + `3.7.1` into one `3.7.0` block (3 bullets).
- `aiobotocore/__init__.py`: `__version__ = '3.7.1'` → `'3.7.0'`.

No code changes — this is purely a versioning/changelog cleanup ahead of the next release.

## Test plan

- [x] `uv run pre-commit run --all --show-diff-on-failure` passes
- [ ] CI green