### PR TITLE
fix(draft-release): provision uv + Python in workflow

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -78,6 +78,31 @@ jobs:
       with:
         bun-version: '1.3.6'
 
+    # Provision uv + Python so the agent can run ``uv run pre-commit
+    # run --all`` after writing CHANGES.rst + __init__.py, per the
+    # project's CLAUDE.md "Run before committing" rule. Without this
+    # the agent's pre-commit step fails with ``uv: command not found``
+    # and it tries to commit an unverified change. Mirrors the
+    # botocore-sync workflow's setup-uv step.
+    - name: Set up uv + Python
+      # yamllint disable-line rule:line-length
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+      with:
+        version: '0.11.7'
+        python-version: '3.12'
+        enable-cache: auto
+
+    - name: Cache .venv
+      # yamllint disable-line rule:line-length
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+      with:
+        path: .venv
+        # yamllint disable-line rule:line-length
+        key: venv-${{ runner.os }}-py3.12-${{ hashFiles('uv.lock', 'pyproject.toml') }}
+
+    - name: Install dev dependencies (for pre-commit, ruff, etc.)
+      run: uv sync --frozen
+
     - name: Read prompt
       id: prompt
       env:

--- a/plugins/aiobotocore-bot/skills/draft-release/SKILL.md
+++ b/plugins/aiobotocore-bot/skills/draft-release/SKILL.md
@@ -65,12 +65,27 @@ For each remaining PR, also capture:
   where ``BREAKING CHANGE:`` footers surface when the PR title doesn't
   carry them. Merge-commit-merged PRs have a trivial ``Merge pull
   request #N`` message; scan the PR body directly in that case.
-- **Changed files** -- the ``files`` field above; you need it for both
-  doc/contrib bucketing and for detecting dependency-spec bumps.
-- **pyproject.toml diff if touched** -- ``gh api repos/$REPO/pulls/$N/files``
-  (or ``git show <mergeCommit> -- pyproject.toml``) to get the actual
-  before/after text of the ``botocore`` (and ``boto3`` / ``aiohttp``)
-  dependency lines. See Step 3, "Dependency-bound transitions".
+- **Changed files** -- the ``files`` field above; you need it for
+  doc/contrib bucketing and to identify which PRs land in the
+  ``dep-bump`` bucket (PRs whose ``files`` includes ``pyproject.toml``).
+
+**Net pyproject.toml transition** -- compute once for the whole window,
+not per PR (avoids an N+1 API call pattern):
+
+```bash
+git diff "$FROM..$TO" -- pyproject.toml > /tmp/pyproject.diff
+```
+
+Parse the before/after lower bound (the version after ``>=``) of
+``botocore`` and ``aiohttp`` from this single diff and label the net
+transition (major / minor / patch / range-only) per the rules in
+Step 3. The bump rule keys off this net transition. Per-PR
+classification of "did this PR touch pyproject.toml" comes from the
+``files`` field above; per-PR transition labels (for the breakdown)
+can be inferred from the per-PR slice ``git show <mergeCommit> --
+pyproject.toml`` if needed -- but if the window has many small bumps,
+collapse them in the body to one bullet citing the net transition
+rather than listing each.
 
 **Direct commits.** Also walk ``git log --no-merges $FROM..$TO`` for
 commits not associated with a PR. Branch protection should make this a


### PR DESCRIPTION
First live run of `draft-release.yml` on `main` failed with `uv: command not found`. The agent followed `CLAUDE.md`'s "Run before committing: uv run pre-commit run --all" rule but the workflow had no setup-uv step — so the agent burned turns trying to install uv ad-hoc before the user cancelled it.

Two commits on this branch:

## `ab2cba1` — provision uv in the workflow

Mirrors the setup-uv + venv-cache + `uv sync --frozen` pattern from `botocore-sync.yml` (same Python 3.12, same uv pin 0.11.7). Adds three steps after the existing setup-bun, before the prompt step.

Audit of the rest of `.github/workflows/`:

| Workflow | uv needed? | Has setup-uv? |
|-|-|-|
| `claude.yml` | yes | already |
| `botocore-sync.yml` | yes | already |
| `evals.yml` | yes | already |
| `reusable-build.yml` | yes | already |
| `reusable-test.yml` | yes | already |
| **`draft-release.yml`** | yes | **fixed here** |
| `ci-cd.yml` | no (orchestration only) | n/a |
| `auto-release-on-merge.yml` | no (uses `python3 scripts/changelog.py`, stdlib only) | n/a |
| `reusable-publish.yml` | no (artifact + pypi only) | n/a |

So `draft-release.yml` was the only gap.

## `c789fb4` — one `git diff` for net pyproject transition

The `draft-release` SKILL's Step 2 used to instruct the agent to fetch each PR's `pyproject.toml` diff via `gh api repos/$REPO/pulls/$N/files` — N+1 API calls for a window of N PRs. The bump rule only cares about the **net** transition across the whole window, which one `git diff $FROM..$TO -- pyproject.toml` answers directly.

Per-PR identification of "did this PR touch pyproject.toml" still comes from the `files` field already in `gh pr list --json`, so the breakdown's dep-bump bucket can list affected PRs without extra API calls. The skill now collapses many small bumps clustered on the same dep into one body bullet citing the net transition.

## Test plan

- [x] Pre-commit clean.
- [ ] Re-trigger `Draft Release` workflow after this lands; verify the agent's pre-commit step succeeds and a release PR is opened.
