### PR TITLE
docs(CLAUDE.md): canonical branch-creation pattern for Claude workflows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,17 @@ not apply to humans editing the repo directly.
   produces unsigned commits that block PR merges.
 - **Branches:** always use the `claude/` prefix for branches created by the bot. Never push to
   `main` — it is protected.
+- **Creating a new branch from a workflow:** the MCP commit tool needs the target branch to
+  *already exist on the remote* before it will write to it; without an explicit `branch:` arg it
+  defaults to the repo's default branch (`main`) and immediately gets blocked by branch protection
+  ("Changes must be made through the merge queue / pull request"). The correct sequence is:
+  1. Create the remote ref via the GitHub API:
+     `gh api repos/$REPO/git/refs -f ref=refs/heads/claude/<name> -f sha=<base_sha>`
+     (where `<base_sha>` is the SHA you want the branch to start from, typically `origin/main`).
+  2. Call `mcp__github_file_ops__commit_files` with `branch: claude/<name>` explicitly set.
+  Do **not** try `git push` — workflow checkouts use `persist-credentials: false`, so plain
+  `git push` fails with "could not read Username". The MCP tool is the only path that
+  authenticates correctly and produces signed commits.
 - **Pre-commit setup:** before committing, run `uv run pre-commit install` once, then
   `uv run pre-commit run --all --show-diff-on-failure` before pushing. If pre-commit modifies
   files, stage them and commit again (as a new commit — do not amend).


### PR DESCRIPTION
The `draft-release` skill's first live run (#1595) had the agent rediscover the right way to create a remote branch from a Claude-driven workflow, burning output tokens on trial and error before succeeding:

```
mcp__github_file_ops__commit_files (no branch arg)
  -> commit defaulted to `main`
  -> 422: "Changes must be made through the merge queue"

git push -u origin claude/release-3.7.0
  -> fatal: could not read Username for 'https://github.com'
     (workflow checkout has persist-credentials: false)

[agent eventually tries `gh api .../git/refs` to create the branch
 first, then mcp__github_file_ops__commit_files with branch=...,
 which works]
```

This same sequence will apply to **every** Claude-driven workflow that needs to create a new branch (`claude.yml`, `botocore-sync.yml`, `draft-release.yml`, future skills). Putting the canonical sequence in `CLAUDE.md`'s "AI workflow conventions" section so each workflow doesn't have to re-derive it.

## What's added

A new bullet under "AI workflow conventions":

> **Creating a new branch from a workflow:** the MCP commit tool needs the target branch to *already exist on the remote* before it will write to it; without an explicit `branch:` arg it defaults to the repo's default branch (`main`) and immediately gets blocked by branch protection ("Changes must be made through the merge queue / pull request"). The correct sequence is:
>
> 1. Create the remote ref via the GitHub API:
>    `gh api repos/$REPO/git/refs -f ref=refs/heads/claude/<name> -f sha=<base_sha>`
>    (where `<base_sha>` is the SHA you want the branch to start from, typically `origin/main`).
> 2. Call `mcp__github_file_ops__commit_files` with `branch: claude/<name>` explicitly set.
>
> Do **not** try `git push` — workflow checkouts use `persist-credentials: false`, so plain `git push` fails with "could not read Username". The MCP tool is the only path that authenticates correctly and produces signed commits.

Documentation only — no code change.