### PR TITLE
ci: cache pre-commit hook envs across all workflows

### DIFF
--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -205,6 +205,17 @@ jobs:
         # yamllint disable-line rule:line-length
         key: venv-${{ runner.os }}-py3.12-${{ hashFiles('uv.lock', 'pyproject.toml') }}
 
+    # Cache pre-commit's per-hook environments. Without this every
+    # workflow run re-clones every hook repo (ruff, yamllint, rumdl,
+    # sphinx-lint, check-jsonschema, ...) and rebuilds their venvs.
+    - name: Cache pre-commit hook envs
+      # yamllint disable-line rule:line-length
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+        restore-keys: pre-commit-${{ runner.os }}-
+
     - name: Install dependencies
       run: uv sync --frozen
 
@@ -406,6 +417,16 @@ jobs:
         path: .venv
         # yamllint disable-line rule:line-length
         key: venv-${{ runner.os }}-py3.12-${{ hashFiles('uv.lock', 'pyproject.toml') }}
+
+    # Cache pre-commit's per-hook environments (same rationale as the
+    # classify job above).
+    - name: Cache pre-commit hook envs
+      # yamllint disable-line rule:line-length
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+        restore-keys: pre-commit-${{ runner.os }}-
 
     - name: Install dependencies
       run: uv sync --frozen

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -159,6 +159,18 @@ jobs:
         # yamllint disable-line rule:line-length
         key: venv-${{ runner.os }}-py3.12-${{ hashFiles('uv.lock', 'pyproject.toml') }}
 
+    # Cache pre-commit's per-hook environments. Without this the
+    # agent's pre-commit run re-clones every hook repo (ruff,
+    # yamllint, rumdl, sphinx-lint, check-jsonschema, ...) and
+    # rebuilds their venvs every workflow run.
+    - name: Cache pre-commit hook envs
+      # yamllint disable-line rule:line-length
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+        restore-keys: pre-commit-${{ runner.os }}-
+
     - name: Install dependencies
       run: uv sync --frozen
 

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -100,6 +100,18 @@ jobs:
         # yamllint disable-line rule:line-length
         key: venv-${{ runner.os }}-py3.12-${{ hashFiles('uv.lock', 'pyproject.toml') }}
 
+    # Cache pre-commit's per-hook environments so the agent's
+    # ``uv run pre-commit run --all`` doesn't re-clone every hook repo
+    # (ruff, yamllint, rumdl, sphinx-lint, check-jsonschema, ...) on
+    # each workflow run.
+    - name: Cache pre-commit hook envs
+      # yamllint disable-line rule:line-length
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+        restore-keys: pre-commit-${{ runner.os }}-
+
     - name: Install dev dependencies (for pre-commit, ruff, etc.)
       run: uv sync --frozen
 

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -57,6 +57,30 @@ jobs:
         version: '0.11.7'
         python-version: ${{ inputs.python-version }}
         enable-cache: ${{ inputs.enable-cache }}
+    # ``setup-uv`` above caches uv's wheel-download cache; this caches
+    # the rendered ``.venv`` so ``uv sync`` skips the venv re-link on a
+    # hot path. Keyed on lockfile + pyproject so any dep change
+    # invalidates; awscrt is part of the key because that path syncs an
+    # extra group.
+    - name: Cache .venv
+      # yamllint disable-line rule:line-length
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+      with:
+        path: .venv
+        # yamllint disable-line rule:line-length
+        key: venv-${{ runner.os }}-py${{ inputs.python-version }}-${{ inputs.with-awscrt && 'awscrt-' || '' }}${{ hashFiles('uv.lock', 'pyproject.toml') }}
+    # Cache pre-commit's per-hook environments. Without this, every
+    # matrix job re-clones every hook repo (ruff, yamllint, rumdl,
+    # sphinx-lint, check-jsonschema, ...) and rebuilds their venvs.
+    # Restore-keys lets a partial hit salvage most of the cache when
+    # a single hook bumps.
+    - name: Cache pre-commit hook envs
+      # yamllint disable-line rule:line-length
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+        restore-keys: pre-commit-${{ runner.os }}-
     - name: Install awscrt
       if: ${{ inputs.with-awscrt }}
       run: |


### PR DESCRIPTION
The user observed CI re-downloading pre-commit hook environments on every run. Audit confirmed: setup-uv caches uv's wheel cache, and most workflows cache `.venv`, but **no workflow caches `~/.cache/pre-commit/`** — pre-commit's per-hook environments (each hook is a separate cloned repo with its own venv).

Worst case: `reusable-test.yml`'s 12-job matrix re-clones every hook repo (ruff, yamllint, rumdl, sphinx-lint, check-jsonschema, github-workflows-require-timeout, etc.) and rebuilds their venvs **on every job, every run**. Easy ~30s per job × 12 jobs = ~6 min of pure overhead per CI run.

## Fix

Add `actions/cache` step on `~/.cache/pre-commit` to every workflow that runs pre-commit, keyed on `hashFiles('.pre-commit-config.yaml')` with a `restore-keys` fallback (so a single hook version bump only invalidates the changed hook, not the whole cache).

| Workflow | What's cached now | Added |
|-|-|-|
| `reusable-test.yml` | uv download cache only | **`.venv` cache (was missing!) + pre-commit cache** |
| `claude.yml` | uv + `.venv` | pre-commit cache |
| `botocore-sync.yml` (classify + sync jobs) | uv + `.venv` + botocore-clone | pre-commit cache (×2 — both jobs) |
| `draft-release.yml` | uv + `.venv` (just landed in #1594) | pre-commit cache |

## Bonus: `reusable-test.yml` was missing `.venv` cache entirely

While auditing I noticed `reusable-test.yml` doesn't cache `.venv` at all — every test matrix job runs `uv sync` from cold (well, from uv's cache, but still re-links the venv). Added `.venv` cache there too, keyed on `uv.lock + pyproject.toml + python-version + with-awscrt` so each matrix cell has its own.

## Test plan

- [x] Pre-commit clean (yamllint, GitHub Actions schema validation).
- [ ] First run on this PR: cache miss → normal time. Second run: cache hit → pre-commit step should be near-instant.

## Why didn't we have this already

Looking at git history this is a long-standing gap; nobody noticed because hook init runs in parallel with other steps so it's not a step-level bottleneck, just a runtime tax. Once you have a 12-job matrix the overhead becomes visible.