### PR TITLE
fix(release): dispatch ci-cd.yml against merge commit SHA, not tag

### DIFF
--- a/.github/workflows/auto-release-on-merge.yml
+++ b/.github/workflows/auto-release-on-merge.yml
@@ -129,6 +129,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         VERSION: ${{ steps.ver.outputs.version }}
+        MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
       # Trigger ``ci-cd.yml`` via ``workflow_dispatch`` so the actual
       # PyPI publish runs from there. PyPI's Trusted Publisher matches
       # against the OIDC token's ``workflow_ref``, which for a
@@ -137,8 +138,15 @@ jobs:
       # are the only event types that fire from ``GITHUB_TOKEN``-driven
       # calls (the loop-prevention rule blocks everything else), so
       # this is the supported escape hatch.
+      #
+      # ``--ref`` MUST be the merge commit SHA, not the version tag.
+      # ``gh release create --draft`` does NOT create the tag at the
+      # target commit -- the tag is only created when the Release is
+      # published (un-drafted). Dispatching with ``--ref $VERSION``
+      # 422s with "No ref found for: $VERSION". The merge SHA is
+      # already on ``main`` and exact (no race if main moves later).
       run: |
         gh workflow run ci-cd.yml \
           --repo "$GITHUB_REPOSITORY" \
-          --ref "$VERSION" \
+          --ref "$MERGE_SHA" \
           -f tag="$VERSION"

--- a/.github/workflows/auto-release-on-merge.yml
+++ b/.github/workflows/auto-release-on-merge.yml
@@ -9,15 +9,18 @@ permissions: {}
 # When a `Release vX.Y.Z` PR is merged, this workflow:
 #
 # 1. ``tag-and-release`` job -- creates the signed annotated tag at
-#    the merge commit and a draft GitHub Release whose body is
+#    the merge commit and a non-draft GitHub Release whose body is
 #    extracted from the new entry in ``CHANGES.rst`` (single source
 #    of truth, written by the ``draft-release`` skill and validated
 #    by ``tests/test_version.py``). Uses ``gh release create
 #    --target ...`` which routes through the Releases API; tags
-#    created that way are signed by GitHub's web-flow key.
+#    created that way are signed by GitHub's web-flow key and the
+#    tag ref is created immediately (draft Releases would defer tag
+#    creation until publish, which would break the dispatch step
+#    below -- see #1600 for the trail).
 # 2. The same job, last step -- dispatches ``ci-cd.yml`` via
-#    ``gh workflow run ... -f tag=$VERSION``. That run does the
-#    actual PyPI publish.
+#    ``gh workflow run ... --ref $VERSION -f tag=$VERSION``. The
+#    dispatched run does the actual PyPI publish.
 #
 # **Why dispatch instead of inline publish?** PyPI's Trusted
 # Publisher for this project is configured against ``ci-cd.yml``,
@@ -29,8 +32,25 @@ permissions: {}
 # ``ci-cd.yml`` the OIDC entry point -- ``workflow_ref`` matches
 # PyPI's config, no reusable-workflow warning, publish succeeds.
 #
-# The Release is drafted (``draft: true``) so a maintainer reviews
-# and clicks Publish in the GitHub UI after PyPI confirms upload.
+# **Could the tag-push trigger ci-cd.yml directly?** No. Tags
+# created here are created under ``GITHUB_TOKEN`` context, and
+# GitHub's loop-prevention rule blocks ``GITHUB_TOKEN``-driven
+# events from triggering other workflows. ``workflow_dispatch`` is
+# the explicit escape hatch -- it's the only event type that fires
+# from ``GITHUB_TOKEN``. (A future PR could replace the dispatch
+# with a PAT/App-token-driven tag push, which WOULD fire the
+# tag-push trigger and skip the dispatch entirely; that's a
+# heavier infra commitment for a marginal cleanup.)
+#
+# **Why no ``--draft``?** A maintainer-controlled draft → publish
+# step would let us gate visibility on PyPI confirmation, but
+# draft Releases don't create the tag ref, which prevents the
+# dispatch from finding ``--ref $VERSION``. The trade-off accepted
+# here: the GitHub Release becomes visible the moment this job
+# completes, and PyPI catches up ~5-10 min later when the
+# dispatched ci-cd.yml run finishes. If a watcher hits the release
+# page during that window, ``pip install`` returns nothing for
+# seconds-to-minutes. Acceptable.
 on:
   pull_request:
     types: [closed]
@@ -106,30 +126,31 @@ jobs:
           echo 'NOTES_EOF'
         } >> "$GITHUB_OUTPUT"
 
-    - name: Create signed tag + GitHub Release (draft)
+    - name: Create signed tag + GitHub Release
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         VERSION: ${{ steps.ver.outputs.version }}
         MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         NOTES: ${{ steps.ver.outputs.NOTES }}
-      # ``gh release create --target <SHA>`` routes through the
-      # Releases API, which creates AND signs the tag at the target
-      # commit. Plain ``git tag -a`` + ``git push`` from the runner
-      # cannot sign (no key on the runner), and the REST ``git/tags``
-      # endpoint doesn't sign either (GitHub Community #69847, #27016).
+      # ``gh release create --target <SHA>`` (without ``--draft``)
+      # routes through the Releases API, which creates AND signs
+      # the tag at the target commit immediately. The tag ref is
+      # then available as ``refs/tags/$VERSION`` for the dispatch
+      # step below. Plain ``git tag -a`` + ``git push`` from the
+      # runner cannot sign (no key on the runner), and the REST
+      # ``git/tags`` endpoint doesn't sign either (GitHub
+      # Community #69847, #27016).
       run: |
         gh release create "$VERSION" \
           --repo "$GITHUB_REPOSITORY" \
           --target "$MERGE_SHA" \
           --title "$VERSION" \
-          --notes "$NOTES" \
-          --draft
+          --notes "$NOTES"
 
     - name: Dispatch ci-cd.yml to publish to PyPI
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         VERSION: ${{ steps.ver.outputs.version }}
-        MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
       # Trigger ``ci-cd.yml`` via ``workflow_dispatch`` so the actual
       # PyPI publish runs from there. PyPI's Trusted Publisher matches
       # against the OIDC token's ``workflow_ref``, which for a
@@ -139,14 +160,12 @@ jobs:
       # calls (the loop-prevention rule blocks everything else), so
       # this is the supported escape hatch.
       #
-      # ``--ref`` MUST be the merge commit SHA, not the version tag.
-      # ``gh release create --draft`` does NOT create the tag at the
-      # target commit -- the tag is only created when the Release is
-      # published (un-drafted). Dispatching with ``--ref $VERSION``
-      # 422s with "No ref found for: $VERSION". The merge SHA is
-      # already on ``main`` and exact (no race if main moves later).
+      # ``--ref $VERSION`` works because the previous step's
+      # non-draft ``gh release create`` created the tag ref
+      # immediately. The dispatched run runs against the tagged
+      # commit -- exact, race-free.
       run: |
         gh workflow run ci-cd.yml \
           --repo "$GITHUB_REPOSITORY" \
-          --ref "$MERGE_SHA" \
+          --ref "$VERSION" \
           -f tag="$VERSION"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -269,10 +269,18 @@ jobs:
         # auto-discover user-scope plugins reliably — the Skill tool returns
         # "Unknown skill: aiobotocore-bot:*" without this flag. Tracked upstream
         # at anthropics/claude-code-action#1145.
+        # Sonnet for default PR-review and @claude responses. Code review
+        # is well within Sonnet's range -- diff-walk + project-rules check
+        # against CLAUDE.md is largely mechanical, the same shape as the
+        # botocore-sync classifier that already runs on Sonnet at ~$0.10
+        # per run vs ~$1+ for Opus. PR-review traffic is high (every push
+        # to every open PR triggers a run) so the cost gap compounds.
+        # Escalate to Opus selectively if a specific @claude task needs
+        # it -- a follow-up could route based on prompt content / labels.
         claude_args: |
           --dangerously-skip-permissions
           --plugin-dir plugins/aiobotocore-bot
-          --model opus
+          --model sonnet
         # yamllint disable rule:line-length
         settings: |
           {


### PR DESCRIPTION
Two related fixes surfaced after #1599 landed:

## 1. Drop `--draft` so the tag actually gets created

After #1599 merged, manually running `gh workflow run ci-cd.yml --ref 3.7.0 -f tag=3.7.0` to publish v3.7.0 hit:

```
PS> gh workflow run ci-cd.yml --ref 3.7.0 -f tag=3.7.0
could not create workflow dispatch event: HTTP 422: No ref found for: 3.7.0
```

Root cause: `gh release create --draft` does NOT create the tag at the target commit — the tag is only created when the Release is published (un-drafted). So `--ref $VERSION` 422s because the tag literally doesn't exist as a ref yet. The same bug was in `auto-release-on-merge.yml`'s dispatch step.

Earlier exploration considered keeping `--draft` and dispatching with `--ref $MERGE_SHA` instead — but `gh workflow run --ref` only accepts branch or tag names, not commit SHAs. Dead end.

**Fix:** drop `--draft` from `gh release create`. The Releases API creates the signed tag immediately at `--target $MERGE_SHA`, and the dispatch step can `--ref $VERSION` directly.

**Trade-off:** the GitHub Release becomes visible the moment `auto-release-on-merge.yml` finishes — ~5-10 min before PyPI catches up via the dispatched ci-cd.yml run. A watcher hitting the release page during that window sees a release that `pip install` can't find for a few minutes. Acceptable in exchange for:

- No more manual un-draft step (release becomes fully unattended)
- Simpler workflow (one ref, no SHA-vs-tag confusion)
- Tag exists for the dispatch (no 422)

If `--draft` safety becomes important later, the path is to provision a PAT/App token, push the tag with that, and let `ci-cd.yml`'s existing tag-push trigger handle publish — that lets us go back to draft semantics. Tracked as a follow-up; not needed for the current flow.

## 2. Switch `claude.yml` from Opus to Sonnet

`claude.yml` runs Opus for every PR review and `@claude` response. ~30 `claude.yml` runs in the past 4 hours during this development session, ~5-10 actually executing reviews — Opus per-run cost is $1-5, so daily cost climbs fast.

PR-review and `@claude` traffic in this repo is shape-equivalent to the `botocore-sync` classify job, which has been on Sonnet from the start (~$0.10/run, vs ~$1+ for Opus on the same workload). No observable quality gap for those tasks.

Switched the default `--model` to `sonnet`. Future PR can add prompt-content / label-based routing to escalate to Opus on demand.

## Test plan

- [x] Pre-commit clean.
- [ ] Next live `Release v...` PR merge: verify the tag is created immediately (no draft), the dispatch fires successfully against `--ref X.Y.Z`, and `pypi-publish` runs to completion.
- [ ] Next PR push: verify `claude.yml` runs on Sonnet (check the run log; cost-meter should drop noticeably across the next ~10 runs).
