### PR TITLE
ci(botocore-sync): pre-install target botocore + bump max-turns to 150

### DIFF
--- a/.github/botocore-sync-prompt.md
+++ b/.github/botocore-sync-prompt.md
@@ -29,6 +29,39 @@ existing aiobotocore mirror (those are out of scope per `port-tests` skill rules
 If `$CLASSIFIER_VERDICT` is empty (rare — only when the classify job failed entirely),
 re-run the classifier yourself in Step 3 as a fallback.
 
+## Pre-set-up environment
+
+The workflow has already prepared everything you need — do NOT re-clone, re-install, or
+re-discover these:
+
+- **aiobotocore checkout** at `$PWD` with full git history (`fetch-depth: 0`), so
+  `git diff origin/main` and `git log` work without further fetches.
+- **botocore bare clone** at `/tmp/botocore` (all tags + branches). Use it for source
+  diffs between versions without cloning your own copy:
+
+  ```text
+  git -C /tmp/botocore diff $LAST_SUPPORTED..$LATEST_BOTOCORE -- botocore/
+  git -C /tmp/botocore show $LATEST_BOTOCORE:botocore/path/file.py
+  ```
+
+- **Python venv at `.venv/`** with botocore **$LATEST_BOTOCORE** already installed.
+  The workflow ran:
+
+  ```text
+  uv sync --frozen
+  uv pip install "botocore==$LATEST_BOTOCORE"
+  ```
+
+  Prefer `uv run --no-sync` for Python invocations so the lockfile walk is skipped.
+  The installed botocore source is at:
+
+  ```text
+  .venv/lib/python3.12/site-packages/botocore/
+  ```
+
+  Do NOT run `uv sync` or `uv pip install botocore==…` again unless a step explicitly
+  needs a different version.
+
 ## Configuration
 
 - ENABLE_BUMP: $ENABLE_BUMP (if false, bumps create a feedback issue instead of attempting code changes)
@@ -240,10 +273,11 @@ minor-bump port would be insufficient. A human decides the approach.
 
 ### Run hash tests as a sanity check
 
+The venv already has botocore $LATEST_BOTOCORE installed (see "Pre-set-up environment"
+above) — run the tests directly:
+
 ```text
-uv sync --all-extras
-uv pip install "botocore==$LATEST_BOTOCORE"
-uv run pytest tests/test_patches.py -x -v 2>&1
+uv run --no-sync pytest tests/test_patches.py -x -v 2>&1
 ```
 
 Hashes are a SIGNAL that helps confirm the classifier's decision — they catch changes to code we already patch.

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -431,6 +431,15 @@ jobs:
     - name: Install dependencies
       run: uv sync --frozen
 
+    # Pre-install the target botocore version so the agent can immediately
+    # inspect the new source (for hash refresh + diff context) without a
+    # discovery + install round-trip. `uv pip install` is idempotent and
+    # fast when the version is already cached.
+    - name: Install target botocore
+      env:
+        LATEST_BOTOCORE: ${{ needs.detect.outputs.latest_botocore }}
+      run: uv pip install "botocore==$LATEST_BOTOCORE"
+
     - name: Cache botocore repo
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
       with:
@@ -517,7 +526,7 @@ jobs:
         # Opus, matching the prior single-job behavior.
         claude_args: |
           --dangerously-skip-permissions
-          --max-turns 100
+          --max-turns 150
           --model ${{ needs.classify.outputs.verdict == 'no-port' && 'sonnet' || 'opus' }}
           --plugin-dir plugins/aiobotocore-bot
         # yamllint disable rule:line-length


### PR DESCRIPTION
## Summary

Triggered by investigating [run #26038100413](https://github.com/aio-libs/aiobotocore/actions/runs/26038100413), which reported `error_max_turns` even though PR #1606 was successfully created at turn 99. The 100th turn went to a final `TodoWrite` call and the agent never got to emit a stop message — a false failure.

The 1.43.0 → 1.43.9 jump (9-version catch-up with the `NEW_RETRIES_ENABLED` overhaul) used exactly 100 turns. Three changes give breathing room and remove some legitimately wasted turns:

- **Pre-install target botocore** in the `sync` job right after `uv sync --frozen`. The agent no longer needs the `uv pip install "botocore==$LATEST"` + `python3` vs `uv run python3` discovery dance (~3 turns saved).
- **Document the pre-set-up environment** at the top of `botocore-sync-prompt.md`:
  - aiobotocore checkout with full git history (`fetch-depth: 0`)
  - `/tmp/botocore` bare clone — this mention was lost from the prompt during a recent rewrite, which is why last run's agent re-cloned its own at `/tmp/botocore-diff` (~3 turns)
  - venv with target botocore pre-installed, and the exact source path for hash inspection
- **Bump `--max-turns` 100 → 150** for safety margin on catch-up runs. Nightly single-version bumps use ~30–50 turns, so this is purely a tail-case buffer; the `classify` job (Sonnet, read-only) stays at 30.

## Test plan

- [ ] Next scheduled botocore-sync run (or a manual `workflow_dispatch` with a known target) completes within the budget
- [ ] Agent uses `/tmp/botocore` for diffs (no new `/tmp/botocore-diff` or similar clone in the run log)
- [ ] Agent does not re-run `uv pip install botocore==…` for the target version (already installed by the workflow)