### PR TITLE
docs(ai-workflows): require sticky-comment checklist finalize

### DIFF
--- a/.github/claude-review-prompt.md
+++ b/.github/claude-review-prompt.md
@@ -36,6 +36,35 @@ See `CLAUDE.md` §"AI workflow conventions" for signed-commit rules, pre-commit 
 naming (`claude/` prefix), versioning/changelog rules, and the `tests/test_patches.py` hash
 requirement. This prompt does not restate them.
 
+## Progress checklist (sticky comment)
+
+`claude.yml` enables `use_sticky_comment: true`. The sticky comment body is whatever you last
+set via `mcp__github_comment__update_claude_comment` — claude-code-action does not tick boxes
+on its own. If you write a checklist on turn 1 and never call the tool again, the run ends
+with stale boxes even after `stop_reason: end_turn` fires, which looks like a failed run to
+reviewers.
+
+Required cadence for every event:
+
+1. **Seed:** early in the run, call the tool once with a short checklist of the phases for
+   this event (for `pull_request`: gather context → run `review-pr` → check author / address
+   feedback → run `complete-run`; for other events, the equivalent phases from their
+   dispatch section).
+2. **Tick as you go:** re-call the tool after each phase completes to flip `[ ]` → `[x]`.
+   Update per item, not batched at the end.
+3. **Finalize before exit:** after `complete-run` returns, do one final update. Every box
+   ticked or marked skipped with a one-line reason; change the heading from "Review in
+   progress" to "Review complete" (or "Run complete" for non-review events); append
+   `**Outcome:** <one line>` summarizing what actually happened (e.g. "no findings ≥ 80",
+   "posted N inline comments", "pushed fix in <sha>").
+4. **Early-exit paths:** if the run bails (gate said no-op, fork PR with nothing to do,
+   errored before any phase ran), the final body is a single `**Status:** <reason>` —
+   never leave a stale "in progress" body.
+
+The auto-appended `**Claude finished … in Xs**` header on `end_turn` does NOT finalize the
+body for you. A stale "in progress" body under a "finished" header is the worst possible
+visible state.
+
 ## Dispatch by EVENT
 
 Pick exactly ONE section below based on $EVENT_NAME. Do not run actions from other sections.
@@ -216,12 +245,15 @@ Invocations by event:
 - `pull_request` (review path): `/aiobotocore-bot:complete-run --event=pull_request --number=$NUMBER --skip-reply`
   — `review-pr` already posted its own review comment; we only need the reaction swap.
 
-When `--skip-reply` is set, your assistant-message output IS the user-visible reply (it lands in the sticky
-comment), so write it as the actual response to the reviewer — not as an internal status update.
+For `--skip-reply` paths the sticky comment IS the user-visible reply, so its final body (set per
+"Progress checklist (sticky comment)" above) must read as the actual response to the reviewer —
+not as an internal status update. Say what you changed (with commit SHAs or file paths), what you
+decided NOT to do (and why), and any follow-up asks for the reviewer. The sticky body is set
+exclusively by your `mcp__github_comment__update_claude_comment` calls; the action does NOT
+auto-paste your final assistant message into it.
 
-The reply body (whether posted by `complete-run` or surfaced via the sticky comment) should say what you
-changed (with commit SHAs or file paths), what you decided NOT to do (and why), and any follow-up asks for
-the reviewer.
+For `--summary` paths, `complete-run` posts a separate top-level reply with the summary text; the
+sticky body remains the progress checklist with a finalized `**Outcome:**` line.
 
 ## Environment
 


### PR DESCRIPTION
### Description of Change

The Claude Code workflow's sticky comment on PR #1606 ended in an inconsistent visible state: the
auto-appended header read **"Claude finished … in 1m 46s"** but the body still showed
`### Review in progress` with three of four checklist boxes unticked. The workflow itself ran
clean — model returned `stop_reason: end_turn`, all 25 steps green, `num_turns: 21`,
`is_error: false` — so this is purely a sticky-comment finalization bug, not a runtime failure.

Root cause, confirmed from the run's execution log: `claude-code-action` does **not** tick boxes
or finalize the sticky comment on `end_turn`. The body is set exclusively by the model's
`mcp__github_comment__update_claude_comment` calls. The run called the tool exactly once on
turn 3 to seed a 4-item checklist with only the first item checked, then ran the rest of the work
(`review-pr`, `check-override-drift`, file reads) without ever calling the tool again. The action
stapled its "Claude finished" header on top, leaving the contradiction visible.

This PR adds a new `## Progress checklist (sticky comment)` section to the prompt mandating a
seed → tick-as-you-go → finalize-before-exit cadence, with an explicit early-exit body for no-op
paths. It also rewrites a misleading sentence in `## Cleanup` that previously claimed
*"your assistant-message output IS the user-visible reply (it lands in the sticky comment)"* —
empirically false in v1.0.101 of the action and not corrected by the v1.0.117 bump; assistant
text never auto-pastes into the sticky body.

This is documentation only — touches `.github/claude-review-prompt.md` only, no code or skill
changes. The first `pull_request` event after merge is itself the validation: the sticky should
end with `### Review complete` and a finalized `**Outcome:**` line.

### Assumptions

- The empirical evidence from PR #1606's run log (`mcp__github_comment__update_claude_comment`
  called once on turn 3, never again) is representative of how `claude-code-action` v1.0.x
  handles the sticky body — the action does not auto-sync the model's final assistant text
  into the sticky.

### Checklist for All Submissions

* [x] If this is resolving an issue:
  * [x] Detailed description of issue — sticky comment ends in inconsistent "finished + in
    progress" state (see body above; PR #1606 is the repro).
  * [x] Alternative methods considered — three were weighed:
    (a) drop the checklist entirely and use a one-line status,
    (b) move responsibility to `complete-run` and overwrite the sticky from the skill,
    (c) keep checklist, mandate update cadence in the prompt.
    (c) was chosen because the model already had to call the update tool to seed the checklist;
    we just need it to keep calling. (a) loses mid-run progress visibility; (b) requires
    extending `complete-run`'s `allowed-tools` and obscures the rule from the model's
    main-loop context.
  * [x] How issue is being resolved — prompt rules force a final sticky update before exit.
  * [x] How issue can be reproduced — re-trigger the Claude review on any PR pre-merge:
    look at the sticky comment body once the job completes.