### PR TITLE
ci: bump codecov-action v6.0.1→v6.0.2 to fix dead PGP key URL (unblocks merge queue)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Notify Codecov that all coverage reports have been uploaded
       if: >-
         !cancelled()
-      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v6.0.2
       with:
         fail_ci_if_error: true
         run_command: send-notifications

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -102,7 +102,7 @@ jobs:
       run: |
         uv run make mototest
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v6.0.2
       with:
         files: ./coverage.xml
         # yamllint disable-line rule:line-length


### PR DESCRIPTION
## Problem

The merge queue is stuck: every \`merge_group\` CI run fails, blocking PR #1624 (Release v3.7.1) at the head of the queue and everything behind it. The tests themselves pass — the failure is in the **"Upload coverage to Codecov"** step of every test job:

\`\`\`
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0
==> Verifying GPG signature integrity
gpg: Can't check signature: No public key
==> Could not verify signature. Please contact Codecov if problem continues
##[error]Process completed with exit code 1.
\`\`\`

## Root cause

\`codecov/codecov-action@v6.0.1\` imports Codecov's uploader signing key from the **\`codecovsecurity\`** keybase account, which now returns **HTTP 404** ("SELF-SIGNED PUBLIC KEY NOT FOUND"). Codecov migrated their key hosting to the **\`codecovsecops\`** keybase account. With zero keys imported, the uploader's own GPG signature self-check fails, and \`fail_ci_if_error: true\` turns that into a job failure on every matrix entry.

This is a Codecov-side change that broke \`v6.0.1\` in place (first failing run ~2026-06-06 16:00 UTC). The signing key itself is unchanged (fingerprint \`2703 4E7F…ED779869\`) — only its hosting account moved.

## Fix

Bump \`codecov/codecov-action\` **v6.0.1 → v6.0.2** in \`ci-cd.yml\` and \`reusable-test.yml\`. v6.0.2 (an exact copy of v7.0.0, so no major-version behavior change) fetches the key from the live \`codecovsecops\` account. Verified the new endpoint returns a valid PGP key (HTTP 200). No other integration change is needed — same \`CODECOV_TOKEN\`, same reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)