### PR TITLE
ci: trim botocore-sync token cost (rtk) and drop internal changes from CHANGES.rst

### DIFF
--- a/.github/botocore-sync-prompt.md
+++ b/.github/botocore-sync-prompt.md
@@ -62,6 +62,30 @@ re-discover these:
   Do NOT run `uv sync` or `uv pip install botocore==…` again unless a step explicitly
   needs a different version.
 
+## Test efficiency (IMPORTANT — this run is on Opus; output is billed as context)
+
+Verbose test output is the single largest token cost of this job. `make mototest` runs with
+`-vv --log-cli-level=DEBUG`, so one full run emits tens of thousands of lines — and every line
+re-enters your context. Follow these rules:
+
+- **Wrap every test/validation command in `rtk test`** (pre-installed on `PATH`). It runs the
+  command and shows only failures, collapsing a passing run to a one-line summary (~99% fewer
+  lines). Examples:
+
+  ```text
+  rtk test uv run --no-sync pytest tests/test_patches.py -x -v
+  rtk test uv run --no-sync pytest tests/botocore_tests/path/test_foo.py -x
+  rtk test make mototest
+  ```
+
+  On failure rtk still surfaces the failing tests and tracebacks — that's all you need to act.
+- **Iterate on targeted tests, not the whole suite.** While fixing a port, run only the files
+  you changed (`$AFFECTED_AIOBOTOCORE_FILES` and their mirrors) plus `tests/test_patches.py`.
+- **Run the full `make mototest` at most once**, as a final gate before finalizing — not
+  repeatedly. The PR you open runs the full suite across the whole Python × backend matrix in
+  CI; that, not a local loop, is the comprehensive check. You only need enough local signal to
+  be confident the commit is sound.
+
 ## Configuration
 
 - ENABLE_BUMP: $ENABLE_BUMP (if false, bumps create a feedback issue instead of attempting code changes)
@@ -274,10 +298,10 @@ minor-bump port would be insufficient. A human decides the approach.
 ### Run hash tests as a sanity check
 
 The venv already has botocore $LATEST_BOTOCORE installed (see "Pre-set-up environment"
-above) — run the tests directly:
+above) — run the tests directly (via `rtk test`, see "Test efficiency" above):
 
 ```text
-uv run --no-sync pytest tests/test_patches.py -x -v 2>&1
+rtk test uv run --no-sync pytest tests/test_patches.py -x -v
 ```
 
 Hashes are a SIGNAL that helps confirm the classifier's decision — they catch changes to code we already patch.
@@ -379,7 +403,10 @@ If you complete all tasks, go to Step 6. If you run out of turns or time, go to 
 
 ## Step 6: Validate
 
-Run `uv run pytest tests/test_patches.py -x -v`. Fix remaining failures. Repeat until passing.
+Run `rtk test uv run --no-sync pytest tests/test_patches.py -x -v`. Fix remaining failures.
+Repeat until passing. Per "Test efficiency" above: run targeted tests while iterating, and run
+the full `rtk test make mototest` at most once as the final gate — the PR's CI matrix is the
+comprehensive check, not a local re-run loop.
 
 **For port PRs only** — run `/aiobotocore-bot:pyright-delta`. It creates an isolated worktree at
 `origin/main`, runs pyright there for the baseline, removes the worktree, then runs pyright with your

--- a/.github/claude-review-prompt.md
+++ b/.github/claude-review-prompt.md
@@ -259,10 +259,12 @@ sticky body remains the progress checklist with a finalized `**Outcome:**` line.
 
 Python, uv, and all dev dependencies are pre-installed.
 
-- Run tests: `uv run pytest <path> -sv`
+- Run tests via `rtk test` (pre-installed on PATH): `rtk test uv run pytest <path>`. It shows
+  only failures, collapsing a passing run to a one-line summary — keeps verbose pytest output
+  out of your context. On failure it still surfaces the failing tests and tracebacks.
 - Run pre-commit: `uv run pre-commit run --all --show-diff-on-failure`
 - Do NOT use `pip install` — all deps are available via `uv run`
-- Do NOT search for uv/pytest — they are on PATH
+- Do NOT search for uv/pytest/rtk — they are on PATH
 - To read botocore source, use Read on the installed files — do NOT use `inspect.getsource()` in Bash
 
 ### Test directory structure

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -437,16 +437,26 @@ jobs:
     # suite, whose `mototest` target uses `-vv --log-cli-level=DEBUG` and
     # dumps tens of thousands of lines per run — billed as input tokens
     # every time. The prompt instructs the agent to wrap test commands in
-    # `rtk test`. Download the static musl binary straight from the releases
-    # CDN (no GitHub API → no rate-limit hit, same rationale as bun below).
-    # We deliberately do NOT run `rtk init` — the agent invokes `rtk`
-    # explicitly per command, never via a global shell hook.
+    # `rtk test`. We deliberately do NOT run `rtk init` — the agent invokes
+    # `rtk` explicitly per command, never via a global shell hook.
+    #
+    # rtk is a Rust CLI (Homebrew / GitHub releases), not a PyPI package, so
+    # it can't be a uv/pyproject dev dependency. Pin the version + verify the
+    # sha256 of the static musl binary for a reproducible install, fetched
+    # straight from the releases CDN (no GitHub API → no rate-limit hit, same
+    # rationale as bun below). To bump: change RTK_VERSION and update
+    # RTK_SHA256 from the release's checksums.txt.
     - name: Install rtk (token-compacting command wrapper)
+      env:
+        RTK_VERSION: v0.42.3
+        RTK_SHA256: 5df764a633709cb85d248258d085d24ec95faa8bca0e6835a93cd57cadc4eb9e
       run: |
         mkdir -p "$HOME/.local/bin"
         # yamllint disable-line rule:line-length
-        curl -fsSL https://github.com/rtk-ai/rtk/releases/latest/download/rtk-x86_64-unknown-linux-musl.tar.gz \
-          | tar -xz -C "$HOME/.local/bin" rtk
+        url="https://github.com/rtk-ai/rtk/releases/download/${RTK_VERSION}/rtk-x86_64-unknown-linux-musl.tar.gz"
+        curl -fsSL "$url" -o /tmp/rtk.tar.gz
+        echo "${RTK_SHA256}  /tmp/rtk.tar.gz" | sha256sum -c -
+        tar -xzf /tmp/rtk.tar.gz -C "$HOME/.local/bin" rtk
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
     # Pre-install the target botocore version so the agent can immediately

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -431,6 +431,24 @@ jobs:
     - name: Install dependencies
       run: uv sync --frozen
 
+    # rtk compacts verbose command output (collapsing a passing pytest run
+    # to a one-line summary, ~99% fewer lines) before it reaches the agent's
+    # context. The sync job runs on Opus and validates with the full test
+    # suite, whose `mototest` target uses `-vv --log-cli-level=DEBUG` and
+    # dumps tens of thousands of lines per run — billed as input tokens
+    # every time. The prompt instructs the agent to wrap test commands in
+    # `rtk test`. Download the static musl binary straight from the releases
+    # CDN (no GitHub API → no rate-limit hit, same rationale as bun below).
+    # We deliberately do NOT run `rtk init` — the agent invokes `rtk`
+    # explicitly per command, never via a global shell hook.
+    - name: Install rtk (token-compacting command wrapper)
+      run: |
+        mkdir -p "$HOME/.local/bin"
+        # yamllint disable-line rule:line-length
+        curl -fsSL https://github.com/rtk-ai/rtk/releases/latest/download/rtk-x86_64-unknown-linux-musl.tar.gz \
+          | tar -xz -C "$HOME/.local/bin" rtk
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
     # Pre-install the target botocore version so the agent can immediately
     # inspect the new source (for hash refresh + diff context) without a
     # discovery + install round-trip. `uv pip install` is idempotent and

--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -451,13 +451,14 @@ jobs:
         RTK_VERSION: v0.42.3
         RTK_SHA256: 5df764a633709cb85d248258d085d24ec95faa8bca0e6835a93cd57cadc4eb9e
       run: |
-        mkdir -p "$HOME/.local/bin"
         # yamllint disable-line rule:line-length
         url="https://github.com/rtk-ai/rtk/releases/download/${RTK_VERSION}/rtk-x86_64-unknown-linux-musl.tar.gz"
         curl -fsSL "$url" -o /tmp/rtk.tar.gz
         echo "${RTK_SHA256}  /tmp/rtk.tar.gz" | sha256sum -c -
-        tar -xzf /tmp/rtk.tar.gz -C "$HOME/.local/bin" rtk
-        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        # Install to /usr/local/bin (already on PATH) instead of writing
+        # $GITHUB_PATH — avoids zizmor's github-env code-execution finding.
+        sudo tar -xzf /tmp/rtk.tar.gz -C /usr/local/bin rtk
+        rtk --version
 
     # Pre-install the target botocore version so the agent can immediately
     # inspect the new source (for hash refresh + diff context) without a

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -174,6 +174,31 @@ jobs:
     - name: Install dependencies
       run: uv sync --frozen
 
+    # rtk compacts verbose command output (a passing pytest run collapses to
+    # a one-line summary) so test output stays out of the agent's context on
+    # @claude / implement paths that run the suite. The prompt instructs the
+    # agent to wrap test commands in `rtk test`. We deliberately do NOT run
+    # `rtk init` — the agent invokes `rtk` explicitly per command.
+    #
+    # rtk is a Rust CLI (Homebrew / GitHub releases), not a PyPI package, so
+    # it can't be a uv/pyproject dev dependency. Pin the version + verify the
+    # sha256 of the static musl binary, fetched from the releases CDN (no
+    # GitHub API → no rate-limit hit, same rationale as bun below). To bump:
+    # change RTK_VERSION and update RTK_SHA256 from the release checksums.txt.
+    # Keep this in sync with the identical step in botocore-sync.yml.
+    - name: Install rtk (token-compacting command wrapper)
+      env:
+        RTK_VERSION: v0.42.3
+        RTK_SHA256: 5df764a633709cb85d248258d085d24ec95faa8bca0e6835a93cd57cadc4eb9e
+      run: |
+        mkdir -p "$HOME/.local/bin"
+        # yamllint disable-line rule:line-length
+        url="https://github.com/rtk-ai/rtk/releases/download/${RTK_VERSION}/rtk-x86_64-unknown-linux-musl.tar.gz"
+        curl -fsSL "$url" -o /tmp/rtk.tar.gz
+        echo "${RTK_SHA256}  /tmp/rtk.tar.gz" | sha256sum -c -
+        tar -xzf /tmp/rtk.tar.gz -C "$HOME/.local/bin" rtk
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
     # Pre-install bun and hand its path to claude-code-action so the
     # action's bundled setup-bun step (which would otherwise resolve a
     # `1.3.6` pin via the GitHub tags API and get 403 rate-limited on

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -191,13 +191,14 @@ jobs:
         RTK_VERSION: v0.42.3
         RTK_SHA256: 5df764a633709cb85d248258d085d24ec95faa8bca0e6835a93cd57cadc4eb9e
       run: |
-        mkdir -p "$HOME/.local/bin"
         # yamllint disable-line rule:line-length
         url="https://github.com/rtk-ai/rtk/releases/download/${RTK_VERSION}/rtk-x86_64-unknown-linux-musl.tar.gz"
         curl -fsSL "$url" -o /tmp/rtk.tar.gz
         echo "${RTK_SHA256}  /tmp/rtk.tar.gz" | sha256sum -c -
-        tar -xzf /tmp/rtk.tar.gz -C "$HOME/.local/bin" rtk
-        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        # Install to /usr/local/bin (already on PATH) instead of writing
+        # $GITHUB_PATH — avoids zizmor's github-env code-execution finding.
+        sudo tar -xzf /tmp/rtk.tar.gz -C /usr/local/bin rtk
+        rtk --version
 
     # Pre-install bun and hand its path to claude-code-action so the
     # action's bundled setup-bun step (which would otherwise resolve a

--- a/plugins/aiobotocore-bot/skills/draft-release/SKILL.md
+++ b/plugins/aiobotocore-bot/skills/draft-release/SKILL.md
@@ -287,8 +287,27 @@ include the deviation in the PR body so the maintainer can confirm.
 
 Use the existing repo style (``^^^^`` underline, single bulleted list per
 release). Generate **one bullet per PR** in this order: breaking, then
-feature, then bugfix, then doc, then contrib, then misc. Within each
-bucket, preserve merge order.
+feature, then bugfix, then doc, then misc. Within each bucket, preserve
+merge order.
+
+**Omit the ``contrib`` bucket from ``CHANGES.rst`` entirely.** The shipped
+changelog is user-facing only — ``ci:``/``chore:``/``test:`` PRs (anything
+that landed solely in the ``contrib`` bucket and no user-facing bucket) are
+internal churn a ``pip install`` user can't act on. They still appear in the
+release-PR body breakdown (Step 7's **Contributor-facing** section) and in
+git history, so the trail is preserved; they just don't earn a changelog
+bullet. A PR that carried both a user-facing signal and a contrib signal
+(e.g. a ``feat:`` that also touched ``.github/``) still gets its bullet via
+the user-facing bucket — only contrib-*only* PRs drop out.
+
+**Empty-changelog guard.** If excluding ``contrib`` leaves the release with
+*no* bullets at all (the whole window was ``ci:``/``chore:``/``test:`` —
+the contrib-only PATCH case from Step 4b), don't write an empty entry.
+Emit a single summary bullet — ``* internal maintenance release (CI/test/
+chore only — see the release PR for the per-PR breakdown) (#NNNN, #PPPP)``
+citing the window's PRs — so the ``^^^^`` underline always has a body
+beneath it and ``scripts/changelog.py extract`` produces non-empty release
+notes.
 
 Each bullet:
 
@@ -484,9 +503,12 @@ Otherwise:
   the window. If a PR's content can't be summarized confidently,
   reference it as ``* miscellaneous improvements (#NNNN)`` rather than
   fabricating detail.
-- **Never silently skip a non-trivial PR.** Dependabot/sync-bot bumps
-  can collapse; everything else gets a bullet even if it's just
-  ``* internal cleanup (#NNNN)``.
+- **Never silently skip a non-trivial user-facing PR.** Dependabot/sync-bot
+  bumps can collapse; every other PR with a user-facing signal gets a
+  bullet. Contrib-only PRs (``ci:``/``chore:``/``test:``) are the one
+  deliberate omission from ``CHANGES.rst`` (see Step 5) — they're not
+  "skipped" but routed to the PR-body breakdown, so the audit trail stays
+  intact without polluting the user changelog.
 - **Verify the underline length.** ``[ "${#HEADER}" -eq "${#UNDERLINE}" ]``
   before writing — abort with a clear error if mismatched.
 - **Don't merge.** This skill opens the PR. The maintainer reviews,


### PR DESCRIPTION
## Problem

The weekly `botocore-sync` job is the repo's largest Claude-token cost, and it's been climbing — recent `sync` runs hit ~112 turns / **\$8.74**, up from ~\$0.35 a few weeks earlier. Investigation of the 06-08 run showed the turns themselves were legitimate porting work, but the **cost is dominated by verbose test output re-entering the Opus context**:

- The agent ran the full `make mototest` suite (~2290 tests) **~5 times** plus several large partial runs.
- `make mototest` runs `pytest -vv ... --log-cli-level=DEBUG` — tens of thousands of lines per run, every one billed as Opus input tokens.

## Fix

Compact test output with [`rtk`](https://www.rtk-ai.app/) before it reaches the model, in both AI workflows that run tests:

**`botocore-sync` (the big one — Opus):**
1. **Install `rtk`** in the `sync` job — pinned to `v0.42.3` and **sha256-verified** (rtk is a Rust CLI via Homebrew/GitHub releases, not a PyPI package, so it can't be a uv/pyproject dev dependency; pin + checksum gives the same reproducibility). Fetched from the releases CDN, same no-API rationale as the existing bun install. No `rtk init` — the agent calls `rtk` explicitly.
2. **Prompt: wrap test commands in `rtk test`** — shows only failures, collapsing a passing run to a one-line summary (~99% fewer lines).
3. **Prompt: iterate on targeted tests, run the full suite at most once** as a final gate — the PR's CI matrix (Python × backend) is the comprehensive check, not a local re-run loop.

**`claude` PR-review/@claude bot (Sonnet — smaller win, for consistency):**
4. Same pinned + sha256-verified `rtk` install step, and the review prompt now runs tests via `rtk test`. This bot runs the suite only on the implement/@claude paths, so the saving is smaller, but it keeps verbose output out of context there too.

No change to *what* gets ported/reviewed, or to the Opus/Sonnet gating (which is working correctly).

## Expected effect

Should pull expensive (port-required) sync weeks from ~\$6–9 toward ~\$2–4. No effect on cheap `no-port` weeks (already Sonnet, ~\$0.34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)