### PR TITLE
chore: bump eval model pins to Opus 4.8 / Sonnet 5 and refresh stale cost rationales

### DIFF
--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -165,9 +165,9 @@ jobs:
         PYEOF
 
   # Classify the diff with Sonnet before deciding which model to use for the
-  # actual sync. The classifier is mechanical (diff-walking + registry lookups)
-  # — Sonnet handles it for ~$0.10 per run versus ~$1+ if we ran the same step
-  # inside the Opus sync. Outputs `verdict` so `sync` below can pick the model:
+  # actual sync. The classifier is mechanical (diff-walking + registry lookups),
+  # so Sonnet handles it without spending Opus rates inside the sync job.
+  # Outputs `verdict` so `sync` below can pick the model:
   # no-port → Sonnet (cheap), anything else → Opus (full reasoning).
   classify:
     needs: detect
@@ -549,7 +549,7 @@ jobs:
         plugins: aiobotocore-bot@aiobotocore
         prompt: ${{ steps.prompt.outputs.PROMPT }}
         # Model is conditional on the classify job's verdict:
-        # - no-port → Sonnet (mechanical bump+PR; ~5× cheaper output)
+        # - no-port → Sonnet (mechanical bump+PR; cheaper output)
         # - everything else → Opus (real porting work, ambiguity, escalation)
         # When `verdict` is empty (classify failed/skipped) the fallback is
         # Opus, matching the prior single-job behavior.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -295,14 +295,12 @@ jobs:
         # auto-discover user-scope plugins reliably — the Skill tool returns
         # "Unknown skill: aiobotocore-bot:*" without this flag. Tracked upstream
         # at anthropics/claude-code-action#1145.
-        # Sonnet for default PR-review and @claude responses. Code review
-        # is well within Sonnet's range -- diff-walk + project-rules check
-        # against CLAUDE.md is largely mechanical, the same shape as the
-        # botocore-sync classifier that already runs on Sonnet at ~$0.10
-        # per run vs ~$1+ for Opus. PR-review traffic is high (every push
-        # to every open PR triggers a run) so the cost gap compounds.
-        # Escalate to Opus selectively if a specific @claude task needs
-        # it -- a follow-up could route based on prompt content / labels.
+        # Sonnet for default PR-review and @claude responses: diff-walk +
+        # project-rules check against CLAUDE.md is largely mechanical, and
+        # PR-review traffic is the highest-volume Claude job here (every push
+        # to every open PR triggers a run), so the per-run gap compounds.
+        # TODO: the gap is now ~1.67x on output, not the ~10x this split was
+        # sized against -- revisit the routing: aio-libs/aiobotocore#1660
         claude_args: |
           --dangerously-skip-permissions
           --plugin-dir plugins/aiobotocore-bot

--- a/plugins/aiobotocore-bot/evals/README.md
+++ b/plugins/aiobotocore-bot/evals/README.md
@@ -125,7 +125,7 @@ Options:
 - `--runs N` — runs per case; majority vote decides pass/fail (default 3)
 - `--limit N` — max scenarios to evaluate (default 8)
 - `--case N` — only evaluate specific PR number (repeatable)
-- `--model <id>` — Anthropic model ID (default `claude-opus-4-7`)
+- `--model <id>` — Anthropic model ID (default: `DEFAULT_MODEL` in `_common.py`; `--help` prints it)
 - `--json-out <path>` — write per-run results as JSON
 
 ### What it checks
@@ -199,7 +199,7 @@ Options:
 
 - `--runs N` — runs per case; majority vote decides pass/fail (default 3)
 - `--case N` — only evaluate specific PR number (repeatable)
-- `--model <id>` — Anthropic model ID (default `claude-opus-4-7`)
+- `--model <id>` — Anthropic model ID (default: `DEFAULT_MODEL` in `_common.py`; `--help` prints it)
 - `--json-out <path>` — write per-run results as JSON
 
 ### When to run

--- a/plugins/aiobotocore-bot/evals/_common.py
+++ b/plugins/aiobotocore-bot/evals/_common.py
@@ -22,31 +22,25 @@ import anthropic
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 AIOBOTOCORE_DIR = REPO_ROOT / "aiobotocore"
-# Opus 4.7 at default effort. The recent Opus 4.5+ pricing drop
-# (to $5/$25 per M input/output, down from $15/$75) narrowed the gap
-# to Sonnet+thinking to ~25%, so the accuracy advantage makes Opus the
-# better cost/quality point. Baseline Opus eval was 8/8 without
-# thinking; Sonnet+thinking was 7/8. Default across eval, sync, and
-# reviewer workflows. Switch back to Sonnet if Opus ever underperforms
-# on the regression suite.
-DEFAULT_MODEL = "claude-opus-4-7"
+# Opus at default effort: 8/8 on the regression suite vs 7/8 Sonnet+thinking.
+DEFAULT_MODEL = "claude-opus-4-8"
 
 UPPER_RE = re.compile(r'"botocore\s*>=\s*[\d.]+\s*,\s*<\s*([\d.]+)"')
 LOWER_RE = re.compile(r'"botocore\s*>=\s*([\d.]+)\s*,')
 
 # Per-million-token pricing (USD) for models we actually run the evals
 # against. From https://platform.claude.com/docs/en/about-claude/pricing
-# as of 2026-04-19. Update when Anthropic publishes new rates.
+# as of 2026-07-16. Update when Anthropic publishes new rates.
 # `cache_write_5m` is the short-duration write price; `cache_read` is
 # any cache-hit read. Thinking tokens bill as `output`.
 MODEL_PRICING: dict[str, dict[str, float]] = {
-    "claude-opus-4-7": {
+    "claude-opus-4-8": {
         "input": 5.0,
         "output": 25.0,
         "cache_write_5m": 6.25,
         "cache_read": 0.50,
     },
-    "claude-sonnet-4-6": {
+    "claude-sonnet-5": {
         "input": 3.0,
         "output": 15.0,
         "cache_write_5m": 3.75,

--- a/plugins/aiobotocore-bot/evals/check_async_need.py
+++ b/plugins/aiobotocore-bot/evals/check_async_need.py
@@ -241,7 +241,9 @@ async def main() -> int:
         "--limit", type=int, default=8, help="Max historical PRs to evaluate"
     )
     parser.add_argument(
-        "--model", default=DEFAULT_MODEL, help="Anthropic model to use"
+        "--model",
+        default=DEFAULT_MODEL,
+        help="Anthropic model to use (default: %(default)s)",
     )
     parser.add_argument(
         "--case",

--- a/plugins/aiobotocore-bot/evals/check_override_drift.py
+++ b/plugins/aiobotocore-bot/evals/check_override_drift.py
@@ -148,7 +148,9 @@ async def main() -> int:
         help="Only evaluate these PR numbers (repeatable)",
     )
     parser.add_argument(
-        "--model", default=DEFAULT_MODEL, help="Anthropic model to use"
+        "--model",
+        default=DEFAULT_MODEL,
+        help="Anthropic model to use (default: %(default)s)",
     )
     parser.add_argument(
         "--json-out", type=Path, help="Write full per-run results here"


### PR DESCRIPTION
### Description of Change

The eval harness pinned `claude-opus-4-7` and priced `claude-sonnet-4-6`, both a generation behind, and the comments justifying our Sonnet-vs-Opus split still assumed Opus was \$15/\$75.

**Model pins.** `DEFAULT_MODEL` moves to `claude-opus-4-8` and `MODEL_PRICING` swaps Sonnet 4.6 → Sonnet 5. Opus 4.8 ships at the same \$5/\$25 as 4.7 with no breaking API changes — the eval code passes no `thinking`, `temperature`, or `budget_tokens`, so this is an ID swap. The `sonnet` alias the workflows already pass resolves to Sonnet 5, so the pricing table now matches what actually runs.

**Stale cost rationales.** Three comments claimed a ~5–10x Opus premium ("~\$0.10 per run vs ~\$1+", "~5× cheaper output"). Opus 4.8 is \$5/\$25 against Sonnet 5's \$3/\$15 — about 1.67x on output. The claims are removed rather than re-stated with new numbers, since hardcoded prices are what went stale in the first place. **No workflow behaviour changes**: all four Claude jobs pass the `sonnet`/`opus` family aliases, which track the current latest on their own.

`_common.py` also claimed Opus was the "default across eval, sync, and reviewer workflows", which was never true — the reviewer runs Sonnet and sync only escalates on a non-`no-port` verdict. That comment went stale precisely because it described other files, so it is deleted rather than corrected.

**Single source for the pin.** The eval README restated the default model in two places, which is what forced repeat edits on every bump. It now points at `DEFAULT_MODEL`, and argparse prints the live value via `%(default)s`. The model name now appears in exactly one line of one file.

Whether the PR-review job should itself move to Opus is a separate judgement call, tracked in #1660.

### Assumptions

- **The 8/8 regression baseline still holds on Opus 4.8 — not yet verified.** 4.7 → 4.8 has no breaking API changes, but 4.8 does behave differently (more narration, more conservative about reaching for tools). These evals force structured tool output via `tool_choice`, so the risk is low but real. Worth a `workflow_dispatch` run of `evals.yml` before merge.
- Sonnet 5 is priced at its standard \$3/\$15 rather than the introductory \$2/\$10 running through 2026-08-31. This overstates eval cost slightly for now, but is correct from September onward and needs no follow-up edit.
- `claude-opus-4-7` / `claude-sonnet-4-6` are dropped from `MODEL_PRICING` rather than kept alongside the new entries, matching the table's stated scope ("models we actually run the evals against"). An A/B run against 4.7 would print `(pricing unknown)`, which the existing code already handles gracefully.

### Checklist for All Submissions

* [x] If this is resolving an issue (needed so future developers can
  determine if change is still necessary and under what conditions)
  (can be provided via link to issue with these details):
  * [x] Detailed description of issue
  * [x] Alternative methods considered (if any)
  * [x] How issue is being resolved
  * [x] How issue can be reproduced

Alternatives considered for keeping the pin current automatically: the Anthropic API has no floating alias (`claude-opus-4-8` is already the alias form vs. a dated snapshot; there is no `claude-opus-latest`), and resolving the newest model at runtime via `client.models.list()` was rejected — a floating model would make the eval baseline meaningless and turn every Anthropic release into a mystery regression. Collapsing the pin to one edit site was preferred instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)