### PR TITLE
fix(draft-release): commit to the release branch, not main

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -136,9 +136,12 @@ jobs:
         # The file-ops MCP server commits to a branch fixed at server
         # startup from CLAUDE_BRANCH; there is no per-call branch arg. In
         # agent mode this defaults to GITHUB_REF_NAME (``main``), whose
-        # branch protection rejects the commit. Run-scoped so a failed
-        # run's leftover branch is never committed on top of.
-        CLAUDE_BRANCH: claude/release-${{ github.run_id }}
+        # branch protection rejects the commit. Scoped per *attempt* so a
+        # failed attempt's leftover branch is never committed on top of —
+        # file-ops reuses an existing ref, and run_id alone is stable
+        # across re-runs.
+        # yamllint disable-line rule:line-length
+        CLAUDE_BRANCH: claude/release-${{ github.run_id }}-${{ github.run_attempt }}
       with:
         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
         use_commit_signing: true
@@ -175,7 +178,8 @@ jobs:
       if: ${{ !inputs.dry_run }}
       env:
         GH_TOKEN: ${{ github.token }}
-        BRANCH: claude/release-${{ github.run_id }}
+        # yamllint disable-line rule:line-length
+        BRANCH: claude/release-${{ github.run_id }}-${{ github.run_attempt }}
       run: |
         url=$(gh pr list --head "$BRANCH" --base main --state open \
           --json url --jq '.[0].url // empty')

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -132,6 +132,13 @@ jobs:
     # yamllint disable-line rule:line-length
     - uses: anthropics/claude-code-action@536f2c32a39763739000b0e1ac69ca2647d97ce9  # v1.0.170
       id: claude
+      env:
+        # The file-ops MCP server commits to a branch fixed at server
+        # startup from CLAUDE_BRANCH; there is no per-call branch arg. In
+        # agent mode this defaults to GITHUB_REF_NAME (``main``), whose
+        # branch protection rejects the commit. Run-scoped so a failed
+        # run's leftover branch is never committed on top of.
+        CLAUDE_BRANCH: claude/release-${{ github.run_id }}
       with:
         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
         use_commit_signing: true
@@ -161,3 +168,21 @@ jobs:
             }
           }
         # yamllint enable rule:line-length
+
+    # The agent can abort mid-run (e.g. a blocked commit path) and still
+    # exit 0, leaving a green run that drafted nothing. Assert the PR.
+    - name: Verify the release PR was opened
+      if: ${{ !inputs.dry_run }}
+      env:
+        GH_TOKEN: ${{ github.token }}
+        BRANCH: claude/release-${{ github.run_id }}
+      run: |
+        url=$(gh pr list --head "$BRANCH" --base main --state open \
+          --json url --jq '.[0].url // empty')
+        if [ -z "$url" ]; then
+          echo "::error::No release PR was opened from $BRANCH. The agent" \
+            "aborted without drafting a release — check its final message" \
+            "in the step above."
+          exit 1
+        fi
+        echo "Release PR: $url" >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,8 +89,10 @@ not apply to humans editing the repo directly.
   the merge queue / pull request"). So: **set `CLAUDE_BRANCH: claude/<name>` in the step's `env:`**
   (see `draft-release.yml`). Don't pre-create the ref — the tool creates the branch off
   `BASE_BRANCH` on first commit. Conversely it *reuses* the branch if it already exists, so
-  prefer a run-scoped name (`claude/release-${{ github.run_id }}`) over one a failed run could
-  have left behind with commits on it.
+  prefer a name scoped per *attempt* —
+  `claude/release-${{ github.run_id }}-${{ github.run_attempt }}` — over one a failed attempt
+  could have left behind with commits on it. `run_id` alone is not enough: it stays the same
+  across re-runs, so a retry would land on the failed attempt's branch.
   Do **not** fall back to `git push` — workflow checkouts use `persist-credentials: false`, so it
   fails with "could not read Username", and a runner-side `git commit` is unsigned (no key on the
   runner), which blocks the merge.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,17 +81,26 @@ not apply to humans editing the repo directly.
   produces unsigned commits that block PR merges.
 - **Branches:** always use the `claude/` prefix for branches created by the bot. Never push to
   `main` — it is protected.
-- **Creating a new branch from a workflow:** the MCP commit tool needs the target branch to
-  *already exist on the remote* before it will write to it; without an explicit `branch:` arg it
-  defaults to the repo's default branch (`main`) and immediately gets blocked by branch protection
-  ("Changes must be made through the merge queue / pull request"). The correct sequence is:
-  1. Create the remote ref via the GitHub API:
-     `gh api repos/$REPO/git/refs -f ref=refs/heads/claude/<name> -f sha=<base_sha>`
-     (where `<base_sha>` is the SHA you want the branch to start from, typically `origin/main`).
-  2. Call `mcp__github_file_ops__commit_files` with `branch: claude/<name>` explicitly set.
-  Do **not** try `git push` — workflow checkouts use `persist-credentials: false`, so plain
-  `git push` fails with "could not read Username". The MCP tool is the only path that
-  authenticates correctly and produces signed commits.
+- **Committing to a branch from a workflow:** `mcp__github_file_ops__commit_files` takes only
+  `files` and `message`. It has **no branch argument** — passing `branch:` or `ref:` is silently
+  ignored. The target comes from the `CLAUDE_BRANCH` env var on the action step, read once when
+  the MCP server starts. Unset, it falls back to `GITHUB_REF_NAME`, so a `workflow_dispatch` run
+  on `main` commits to `main` and is rejected by branch protection ("Changes must be made through
+  the merge queue / pull request"). So: **set `CLAUDE_BRANCH: claude/<name>` in the step's `env:`**
+  (see `draft-release.yml`). Don't pre-create the ref — the tool creates the branch off
+  `BASE_BRANCH` on first commit. Conversely it *reuses* the branch if it already exists, so
+  prefer a run-scoped name (`claude/release-${{ github.run_id }}`) over one a failed run could
+  have left behind with commits on it.
+  Do **not** fall back to `git push` — workflow checkouts use `persist-credentials: false`, so it
+  fails with "could not read Username", and a runner-side `git commit` is unsigned (no key on the
+  runner), which blocks the merge.
+- **What actually signs a bot commit:** GitHub signs any commit created through its API with the
+  workflow token's identity. `commit_files` is a thin wrapper over `POST /git/blobs`,
+  `POST /git/trees`, `POST /git/commits`, `PATCH /git/refs/heads/<branch>` — there is no signing
+  key or GPG step in it. So the MCP tool is the *convenient* path, not a magic one: the same four
+  `gh api` calls produce an identically verified commit (that fallback drafted v3.7.1 — commit
+  `cc8814f6`, `verified: true`). Prefer the MCP tool; if it's ever blocked, the `gh api` git-data
+  route is a legitimate escape hatch. Only `git push` is off-limits.
 - **Pre-commit setup:** before committing, run `uv run pre-commit install` once, then
   `uv run pre-commit run --all --show-diff-on-failure` before pushing. If pre-commit modifies
   files, stage them and commit again (as a new commit — do not amend).

--- a/plugins/aiobotocore-bot/skills/draft-release/SKILL.md
+++ b/plugins/aiobotocore-bot/skills/draft-release/SKILL.md
@@ -356,11 +356,13 @@ reasoning to stdout and exit. Don't commit, don't push, don't open a PR.
 
 Otherwise:
 
-1. Create branch ``claude/release-X.Y.Z`` from ``$TO`` (typically ``origin/main``).
-   The ``claude/`` prefix matches the convention in ``CLAUDE.md`` for
-   bot-created branches; ``auto-release-on-merge.yml`` keys off the PR
-   title (``Release v...``), not the branch name, so the branch name is
-   purely informational.
+1. Don't create a branch. ``mcp__github_file_ops__commit_files`` commits to
+   the branch the workflow pins via ``CLAUDE_BRANCH``
+   (``claude/release-<run-id>``) and creates it off ``main`` on first
+   commit. The branch has no per-call override — passing ``branch`` or
+   ``ref`` to the tool is silently ignored — so never hand-roll a ref.
+   ``auto-release-on-merge.yml`` keys off the PR title (``Release v...``),
+   not the branch name, so the name is purely informational.
 2. Commit the two file changes via ``mcp__github_file_ops__commit_files``
    (signing required) with message:
 
@@ -372,7 +374,16 @@ Otherwise:
    merged PRs in the release window.
    ```
 
-3. Open the PR. **Title MUST start with ``Release v``** (the auto-tag
+3. Open the PR with an explicit ``--head "$CLAUDE_BRANCH"`` — the runner
+   stays checked out on ``main``, so an inferred head resolves to
+   ``main`` and the create fails:
+
+   ```text
+   gh pr create --base main --head "$CLAUDE_BRANCH" \
+     --title "Release vX.Y.Z" --body "<body>"
+   ```
+
+   **Title MUST start with ``Release v``** (the auto-tag
    workflow keys off this prefix). Use ``Release vX.Y.Z``. The body
    does NOT duplicate the verbatim changelog (that lives in
    ``CHANGES.rst``, which the auto-release workflow extracts for the

--- a/plugins/aiobotocore-bot/skills/draft-release/SKILL.md
+++ b/plugins/aiobotocore-bot/skills/draft-release/SKILL.md
@@ -358,7 +358,7 @@ Otherwise:
 
 1. Don't create a branch. ``mcp__github_file_ops__commit_files`` commits to
    the branch the workflow pins via ``CLAUDE_BRANCH``
-   (``claude/release-<run-id>``) and creates it off ``main`` on first
+   (``claude/release-<run-id>-<attempt>``) and creates it off ``main`` on first
    commit. The branch has no per-call override — passing ``branch`` or
    ``ref`` to the tool is silently ignored — so never hand-roll a ref.
    ``auto-release-on-merge.yml`` keys off the PR title (``Release v...``),


### PR DESCRIPTION
### Description of Change

The `Draft Release` workflow has been silently broken since v3.7.1: [run 29548268161](https://github.com/aio-libs/aiobotocore/actions/runs/29548268161/job/87785150787) reported success but opened no PR. `mcp__github_file_ops__commit_files` resolves its target branch **once at MCP-server startup** from `CLAUDE_BRANCH`; in agent mode that falls back to `GITHUB_REF_NAME`, so a `workflow_dispatch` run on `main` had the tool committing to `main` — rejected by branch protection (`Changes must be made through a pull request` / merge queue / `codecov/patch`). The tool has **no per-call branch argument**, so the agent's attempts to pass `branch:` / `ref:` were silently ignored, and it aborted after writing a correct changelog. The action still exited 0, so the run went green.

This sets `CLAUDE_BRANCH: claude/release-<run-id>` on the action step — the supported escape hatch (`src/modes/agent/index.ts`: `claudeBranch || GITHUB_HEAD_REF || GITHUB_REF_NAME || defaultBranch`). The MCP tool still does the commit, signed, as intended. It also adds a guard step that fails the job when no release PR was opened, so this can't fail silently again.

Not caused by the recent `claude-code-action` bump — the June 6 run hit the identical 422 on v1.0.152 and only produced a PR because that agent improvised a `gh api` fallback.

### Corrections to CLAUDE.md

Three documented claims were wrong and had actively misled the bot into aborting:

1. *"the MCP commit tool needs the target branch to already exist"* — no: `getOrCreateBranchRef` creates it off `BASE_BRANCH` on 404. It **reuses** an existing ref, which is why the release branch is now run-scoped: a stale branch from a failed run would otherwise be committed on top of.
2. *"call `commit_files` with `branch:` explicitly set"* — there is no such parameter. The documented workaround could never have worked.
3. *"the MCP tool is the only path that ... produces signed commits"* — it has no signing step. It is a thin wrapper over `POST /git/{blobs,trees,commits}` + `PATCH /git/refs`; GitHub signs any API-created commit with the token's identity. The v3.7.1 draft was made by hand-rolling those same calls and its commit (`cc8814f6`) is `verified: true`. `git push` remains banned — that one genuinely is unsigned.

### Assumptions

The release branch name is informational: `auto-release-on-merge.yml` keys off the PR title (`Release v...`), not the branch, so dropping the version from the branch name in favour of the run id is safe. This is stated in the skill's own step 7.

### Checklist for All Submissions

* [x] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [x] Detailed description of issue
  * [x] Alternative methods considered (if any) — the `gh api` git-data fallback (works, but hand-rolls what the MCP tool already does); `CLAUDE_BRANCH` is the supported path
  * [x] How issue is being resolved
  * [x] How issue can be reproduced — dispatch `Draft Release` on `main`; before this change `commit_files` targets `main` and 422s
* [ ] If this is providing a new feature — N/A, bug fix

### Verification

- `uv run pre-commit run` passes on all three files, including workflow-schema validation.
- `$CLAUDE_BRANCH` reaches the agent's Bash: `parse-sdk-options.ts` builds SDK env as `{ ...process.env }`.
- The guard's `gh pr list --head` was tested both ways — resolves #1624 by head branch, returns empty for a nonexistent one.
- Latent bug fixed alongside: the skill never spelled out `gh pr create`, and the runner stays on `main`, so an inferred head resolves to `main` and fails. Now explicitly `--head "$CLAUDE_BRANCH"`.

The end-to-end proof is a real dispatch after merge; `dry_run` deliberately skips the commit path, so it cannot exercise this.