### PR TITLE
fix(draft-release): fail when the agent never runs

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -172,8 +172,24 @@ jobs:
           }
         # yamllint enable rule:line-length
 
-    # The agent can abort mid-run (e.g. a blocked commit path) and still
-    # exit 0, leaving a green run that drafted nothing. Assert the PR.
+    # The action exits 0 even when it self-skips without running the
+    # agent (e.g. workflow validation on a PR that edits this file), so
+    # a dry run reports success having done nothing. No execution file
+    # means no agent. Covers dry runs, which never open a PR to check.
+    - name: Verify the agent ran
+      env:
+        EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
+      run: |
+        if [ -z "$EXECUTION_FILE" ]; then
+          echo "::error::The agent never ran — the action produced no" \
+            "execution file. Check the step above for a skip reason."
+          exit 1
+        fi
+
+    # Independent of what the agent claims: confirm the PR is really
+    # there. The agent can abort in prose and still finish its turn
+    # cleanly (subtype=success, is_error=false), so its own report is
+    # not a reliable signal — the PR existing is.
     - name: Verify the release PR was opened
       if: ${{ !inputs.dry_run }}
       env:


### PR DESCRIPTION
### Description of Change

Follow-up to #1662. The dry run against that branch ([run 29549658313](https://github.com/aio-libs/aiobotocore/actions/runs/29549658313)) reported success having done nothing — zero assistant messages. `claude-code-action` self-skips when the workflow file differs from the copy on the default branch (anti-tampering: otherwise any branch could edit a workflow to reach `ANTHROPIC_API_KEY`), logs `Exiting due to workflow validation skip`, exits 0, and sets no `execution_file`. #1662's guard is `if: !inputs.dry_run`, so nothing caught it.

This asserts the action produced an execution file. No file means the agent never ran, which is never a success in either mode — and it's the one check that covers dry runs, since they never open a PR to look for.

Together the two guards now cover both observed silent successes:

| Failure | Caught by |
|-|-|
| Action self-skips, agent never runs (dry or real) | `Verify the agent ran` (this PR) |
| Agent runs, aborts without opening a PR (real) | `Verify the release PR was opened` (#1662) |

### Assumptions

The agent's own report is deliberately not used as the signal. The v3.8.0 abort finished its turn cleanly — the SDK recorded `subtype: "success"`, `is_error: false`, and the abort existed only as prose — so the action's status can't distinguish "drafted a release" from "explained why it couldn't". The PR existing is the reliable signal; this PR only adds the weaker "did the agent run at all" check, which is exactly what the dry-run path needs.

A dry run whose agent runs but then aborts still goes green. That's a deliberate gap: the remaining alternative was parsing `execution_file` for the prompt's mandated outcome line, which is a lot of machinery for a preview mode whose output you're reading anyway.

### Checklist for All Submissions

* [x] If this is resolving an issue (needed so future developers can determine if change is still necessary and under what conditions) (can be provided via link to issue with these details):
  * [x] Detailed description of issue
  * [x] Alternative methods considered (if any) — parsing `execution_file` for the prompt's outcome line (rejected as disproportionate, see Assumptions)
  * [x] How issue is being resolved
  * [x] How issue can be reproduced — open a PR that edits `draft-release.yml` and dispatch it from that branch; the action skips and the job goes green
* [ ] If this is providing a new feature — N/A, bug fix

### Verification

The fix in #1662 is confirmed working in production: [run 29549923152](https://github.com/aio-libs/aiobotocore/actions/runs/29549923152) opened #1663 from `claude/release-29549923152-1` (note the attempt suffix), commit `65b618cb` by `claude[bot]`, `verified: true` — the MCP tool committing to the release branch, signed, exactly as intended.

This PR's own guard cannot be exercised pre-merge for the same reason it exists: the action will skip on this PR too, since it edits the workflow.