### PR TITLE
ci: run pre-commit once instead of in every test matrix job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -40,6 +40,11 @@ jobs:
   build:
     uses: ./.github/workflows/reusable-build.yml
 
+  lint:
+    uses: ./.github/workflows/reusable-lint.yml
+    with:
+      enable-cache: ${{ github.ref_type == 'tag' && 'false' || 'auto' }}
+
   test:
     name: test${{ '' }}  # zizmor: ignore[obfuscation] nest jobs under the same sidebar category
     strategy:
@@ -53,7 +58,6 @@ jobs:
         - 3.14
         os:
         - ubuntu-24.04
-        - ubuntu-24.04-arm
         with-awscrt:
         - false
         no-httpx:
@@ -61,6 +65,13 @@ jobs:
         experimental:
         - false
         include:
+        # aiobotocore is pure Python, so arch only exercises the C-extension
+        # deps' aarch64 wheels -- one run covers that for every interpreter.
+        - python-version: 3.14  # add an arm64 run
+          os: ubuntu-24.04-arm
+          with-awscrt: false
+          no-httpx: false
+          experimental: false
         - python-version: 3.14  # add a no-httpx run
           os: ubuntu-24.04
           with-awscrt: false
@@ -111,6 +122,7 @@ jobs:
     if: always()
     needs:
     - build
+    - lint
     - test
     - zizmor
     runs-on: ubuntu-24.04

--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -1,0 +1,51 @@
+---
+name: Reusable lint
+
+permissions: {}
+
+on:
+  workflow_call:
+    inputs:
+      enable-cache:
+        type: string
+        required: true
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  lint:
+    name: Run pre-commit hooks
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    env:
+      UV_FROZEN: 1
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      with:
+        persist-credentials: false
+        submodules: true
+    - name: Install uv
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+      with:
+        # Pin uv so setup-uv skips the GitHub release-list API lookup
+        # that otherwise resolves pyproject.toml's required-version
+        # range. See claude.yml for the full reasoning.
+        version: '0.11.12'
+        enable-cache: ${{ inputs.enable-cache }}
+    # Cache pre-commit's per-hook environments. Without this, the job
+    # re-clones every hook repo (ruff, yamllint, rumdl, sphinx-lint,
+    # check-jsonschema, ...) and rebuilds their venvs. Restore-keys lets
+    # a partial hit salvage most of the cache when a single hook bumps.
+    - name: Cache pre-commit hook envs
+      # yamllint disable-line rule:line-length
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+        restore-keys: pre-commit-${{ runner.os }}-
+    - name: Run pre-commit hooks
+      run: |
+        uv run make pre-commit

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -69,25 +69,10 @@ jobs:
         path: .venv
         # yamllint disable-line rule:line-length
         key: venv-${{ runner.os }}-py${{ inputs.python-version }}-${{ inputs.with-awscrt && 'awscrt-' || '' }}${{ hashFiles('uv.lock', 'pyproject.toml') }}
-    # Cache pre-commit's per-hook environments. Without this, every
-    # matrix job re-clones every hook repo (ruff, yamllint, rumdl,
-    # sphinx-lint, check-jsonschema, ...) and rebuilds their venvs.
-    # Restore-keys lets a partial hit salvage most of the cache when
-    # a single hook bumps.
-    - name: Cache pre-commit hook envs
-      # yamllint disable-line rule:line-length
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-      with:
-        path: ~/.cache/pre-commit
-        key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
-        restore-keys: pre-commit-${{ runner.os }}-
     - name: Install awscrt
       if: ${{ inputs.with-awscrt }}
       run: |
         uv sync --group awscrt
-    - name: Run pre-commit hooks
-      run: |
-        uv run make pre-commit
     - name: Run unittests
       if: ${{ ! inputs.no-httpx }}
       env:


### PR DESCRIPTION
### Description of Change

Every one of the 12 test matrix jobs spent ~26s running the full pre-commit suite (ruff, yamllint, rumdl, sphinx-lint, check-jsonschema, uv-lock) before its tests. Lint output cannot vary by interpreter or CPU arch — the hooks run in their own pinned environments — so 11 of those runs were redundant, and each one sat on the critical path of the job it prefixed. This hoists pre-commit into a single `lint` job and trims the ARM matrix leg from five interpreters to one.

aiobotocore ships `py3-none-any` with no compiled code, so arch coverage only exercises whether the C-extension *dependencies* (aiohttp, yarl, propcache, multidict) publish working aarch64 wheels — a property one job establishes as well as five. The 3.10–3.14, `no-httpx` and `with-awscrt` legs are untouched, since those each exercise genuinely different code paths.

Measured, comparing a pre-change run ([29550163156](https://github.com/aio-libs/aiobotocore/actions/runs/29550163156)) against this PR's run ([29553845720](https://github.com/aio-libs/aiobotocore/actions/runs/29553845720)) — both green, summing actual job durations:

| | before | after |
|-|-|-|
| test matrix jobs | 12 | 8 |
| total CI jobs | 16 | 13 |
| runner time per PR | 34 min | 19 min |
| slowest single job | 247s | 228s |

Wall clock is bounded by the slowest test job either way, so it barely moves — the win is runner time (−43%), and every test job now starts its tests ~26s sooner.

Resulting matrix:

```
Python 3.10-3.14 on ubuntu-24.04     (5)
Python 3.14 on ubuntu-24.04-arm      (1)  <- was 5
Python 3.14 no-httpx / with-awscrt   (2)  unchanged
```

### Assumptions

* **The ARM legs were for dependency-wheel coverage, not per-interpreter arch coverage.** They were added deliberately (fb76993, de-experimentalized in df1ef64), so this is the call worth a second opinion — if the intent was to catch an interpreter-specific aarch64 issue, the leg should stay at five. The pre-commit dedup stands on its own regardless.
* Lint lives in `reusable-lint.yml` rather than inline in `ci-cd.yml` because that file also holds `pypi-publish`, and zizmor's `cache-poisoning` audit (high) flags cache steps sharing a file with a publishing trigger. An inline job was my first attempt and it failed the audit; this mirrors how `build`/`test` are already structured, rather than silencing the finding with an ignore comment.
* `mototest` never depended on the `pre-commit` make target, so removing the step doesn't change what the test jobs run.

Verified: `uv run make pre-commit` and `zizmor` pass locally on all three workflows; the matrix was expanded programmatically against GitHub's include-merge rule to confirm all three `include:` entries still spawn separate jobs (none silently merges into a base combination); and CI on this branch scheduled exactly the intended 13 jobs, all green.

### Checklist for All Submissions

* [x] If this is resolving an issue: N/A — CI-only change, no user-visible behavior.
* [x] If this is providing a new feature: N/A.

### Checklist when updating botocore and/or aiohttp versions

N/A — no dependency changes.
