### PR TITLE
feat: prefer httpx2 over httpx for the optional httpx backend

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -60,8 +60,8 @@ jobs:
         - ubuntu-24.04
         with-awscrt:
         - false
-        no-httpx:
-        - false
+        httpx-extra:  # preferred backend on the main matrix
+        - httpx2
         experimental:
         - false
         include:
@@ -70,17 +70,22 @@ jobs:
         - python-version: 3.14  # add an arm64 run
           os: ubuntu-24.04-arm
           with-awscrt: false
-          no-httpx: false
+          httpx-extra: httpx2
           experimental: false
         - python-version: 3.14  # add a no-httpx run
           os: ubuntu-24.04
           with-awscrt: false
-          no-httpx: true
+          httpx-extra: ''
+          experimental: false
+        - python-version: 3.14  # add a legacy-httpx (deprecated fallback) run
+          os: ubuntu-24.04
+          with-awscrt: false
+          httpx-extra: httpx
           experimental: false
         - python-version: 3.14  # add a with-awscrt run
           os: ubuntu-24.04
           with-awscrt: true
-          no-httpx: false
+          httpx-extra: httpx2
           experimental: false
       fail-fast: false
     uses: ./.github/workflows/reusable-test.yml
@@ -90,7 +95,7 @@ jobs:
       continue-on-error: ${{ matrix.experimental }}
       enable-cache: ${{ github.ref_type == 'tag' && 'false' || 'auto' }}
       with-awscrt: ${{ matrix.with-awscrt }}
-      no-httpx: ${{ matrix.no-httpx }}
+      httpx-extra: ${{ matrix.httpx-extra }}
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -20,8 +20,10 @@ on:
       with-awscrt:
         type: boolean
         required: true
-      no-httpx:
-        type: boolean
+      httpx-extra:
+        # Which httpx backend extra to install and test: 'httpx2' (preferred),
+        # 'httpx' (deprecated legacy fallback), or '' (no httpx backend).
+        type: string
         required: true
     secrets:
       codecov-token:
@@ -34,7 +36,7 @@ jobs:
   test:
     name: Test Python ${{ inputs.python-version }} on ${{ inputs.os }}${{
       inputs.with-awscrt && ' with-awscrt' || '' }}${{
-      inputs.no-httpx && ' no-httpx' || '' }}
+      inputs.httpx-extra && format(' {0}', inputs.httpx-extra) || ' no-httpx' }}
 
     runs-on: ${{ inputs.os }}
     continue-on-error: ${{ inputs.continue-on-error }}
@@ -74,24 +76,20 @@ jobs:
       run: |
         uv sync --group awscrt
     - name: Run unittests
-      if: ${{ ! inputs.no-httpx }}
       env:
         COLOR: 'yes'
+        HTTP_BACKEND: ${{ inputs.httpx-extra && 'all' || 'aiohttp' }}
+        # Passed via env (not interpolated into the run: script) to avoid
+        # template-injection; empty means no httpx extra (aiohttp only).
+        HTTPX_EXTRA: ${{ inputs.httpx-extra }}
       run: |
-        uv run --extra=httpx make mototest
-    - name: Run unittests without httpx installed
-      if: ${{ inputs.no-httpx }}
-      env:
-        COLOR: 'yes'
-        HTTP_BACKEND: 'aiohttp'
-      run: |
-        uv run make mototest
+        uv run ${HTTPX_EXTRA:+--extra=$HTTPX_EXTRA} make mototest
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v6.0.2
       with:
         files: ./coverage.xml
         # yamllint disable-line rule:line-length
-        flags: unittests,os-${{ inputs.os }},python-${{ inputs.python-version }}${{ inputs.with-awscrt && ',with-awscrt' || '' }}${{ inputs.no-httpx && ',no-httpx' || '' }}  # optional
+        flags: unittests,os-${{ inputs.os }},python-${{ inputs.python-version }}${{ inputs.with-awscrt && ',with-awscrt' || '' }}${{ inputs.httpx-extra && format(',{0}', inputs.httpx-extra) || ',no-httpx' }}  # optional
         name: codecov-umbrella  # optional
         fail_ci_if_error: true  # optional (default = false)
         verbose: true  # optional (default = false)

--- a/aiobotocore/_endpoint_helpers.py
+++ b/aiobotocore/_endpoint_helpers.py
@@ -4,10 +4,7 @@ import aiohttp.http_exceptions
 import botocore.retryhandler
 import wrapt
 
-try:
-    import httpx
-except ImportError:
-    httpx = None
+from aiobotocore._httpx import httpx
 
 # Monkey patching: We need to insert the aiohttp exception equivalents
 # The only other way to do this would be to have another config file :(

--- a/aiobotocore/_httpx.py
+++ b/aiobotocore/_httpx.py
@@ -1,0 +1,11 @@
+"""Centralised import of the optional httpx backend dependency.
+
+Kept in a dedicated module with no intra-package imports so that low-level
+modules (e.g. ``_endpoint_helpers``, which is itself imported by
+``httpxsession``) can share it without creating an import cycle.
+"""
+
+try:
+    import httpx
+except ImportError:
+    httpx = None

--- a/aiobotocore/_httpx.py
+++ b/aiobotocore/_httpx.py
@@ -1,11 +1,28 @@
-"""Centralised import of the optional httpx backend dependency.
+"""Resolution of the optional httpx backend dependency.
 
-Kept in a dedicated module with no intra-package imports so that low-level
-modules (e.g. ``_endpoint_helpers``, which is itself imported by
-``httpxsession``) can share it without creating an import cycle.
+aiobotocore's httpx backend prefers httpx2 -- Pydantic's maintained,
+API-compatible fork of httpx -- and falls back to the original ``httpx``
+package when httpx2 is not installed. The legacy ``httpx`` fallback is
+deprecated; ``HttpxSession`` emits a ``DeprecationWarning`` when it is used.
+The warning is deferred to backend use (rather than raised here at import)
+so aiohttp-only users who merely happen to have ``httpx`` installed are not
+warned.
+
+This mirrors the compatibility shim used by authlib's httpx integration. It
+is kept free of intra-package imports so that low-level modules (e.g.
+``_endpoint_helpers``, which is itself imported by ``httpxsession``) can share
+it without creating an import cycle.
 """
 
 try:
-    import httpx
+    import httpx2 as httpx
+
+    HTTPX_IS_LEGACY = False
 except ImportError:
-    httpx = None
+    try:
+        import httpx
+
+        HTTPX_IS_LEGACY = True
+    except ImportError:
+        httpx = None
+        HTTPX_IS_LEGACY = False

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -14,15 +14,11 @@ from botocore.endpoint import (
 )
 from botocore.hooks import first_non_none_response
 
+from aiobotocore._httpx import httpx
 from aiobotocore.httpchecksum import handle_checksum_body
 from aiobotocore.httpsession import AIOHTTPSession
 from aiobotocore.parsers import AioResponseParserFactory
 from aiobotocore.response import AioHttpxStreamingBody, AioStreamingBody
-
-try:
-    import httpx
-except ImportError:
-    httpx = None
 
 DEFAULT_HTTP_SESSION_CLS = AIOHTTPSession
 

--- a/aiobotocore/httpchecksum.py
+++ b/aiobotocore/httpchecksum.py
@@ -12,12 +12,8 @@ from botocore.httpchecksum import (
 )
 
 from aiobotocore._helpers import resolve_awaitable
+from aiobotocore._httpx import httpx
 from aiobotocore.response import AioHttpxStreamingBody, AioStreamingBody
-
-try:
-    import httpx
-except ImportError:
-    httpx = None
 
 
 class AioAwsChunkedWrapper(AwsChunkedWrapper):

--- a/aiobotocore/httpxsession.py
+++ b/aiobotocore/httpxsession.py
@@ -28,13 +28,9 @@ from multidict import CIMultiDict
 
 import aiobotocore.awsrequest
 from aiobotocore._endpoint_helpers import _text
+from aiobotocore._httpx import httpx
 
 from ._constants import DEFAULT_KEEPALIVE_TIMEOUT
-
-try:
-    import httpx
-except ImportError:
-    httpx = None
 
 if TYPE_CHECKING:
     from ssl import SSLContext

--- a/aiobotocore/httpxsession.py
+++ b/aiobotocore/httpxsession.py
@@ -5,6 +5,7 @@ import io
 import os
 import socket
 import ssl
+import warnings
 from collections.abc import AsyncIterable, Iterable
 from concurrent.futures import CancelledError
 from typing import TYPE_CHECKING, Any, cast
@@ -28,12 +29,17 @@ from multidict import CIMultiDict
 
 import aiobotocore.awsrequest
 from aiobotocore._endpoint_helpers import _text
-from aiobotocore._httpx import httpx
+from aiobotocore._httpx import HTTPX_IS_LEGACY, httpx
 
 from ._constants import DEFAULT_KEEPALIVE_TIMEOUT
 
 if TYPE_CHECKING:
     from ssl import SSLContext
+
+# Emit the legacy-httpx deprecation warning at most once per process. aiobotocore
+# builds a fresh HttpxSession per client, and under a warning filter of 'always'
+# an unguarded warning would fire on every instance.
+_LEGACY_HTTPX_WARNED = False
 
 
 class HttpxSession:
@@ -50,7 +56,18 @@ class HttpxSession:
     ):
         if httpx is None:  # pragma: no cover
             raise RuntimeError(
-                "Using HttpxSession requires httpx to be installed"
+                "Using HttpxSession requires httpx2 (or httpx) to be installed"
+            )
+        global _LEGACY_HTTPX_WARNED
+        if HTTPX_IS_LEGACY and not _LEGACY_HTTPX_WARNED:
+            _LEGACY_HTTPX_WARNED = True
+            warnings.warn(
+                "aiobotocore's httpx backend now prefers httpx2, Pydantic's "
+                "maintained fork of httpx. The legacy 'httpx' package is "
+                "deprecated as a backend; install httpx2 (e.g. "
+                "aiobotocore[httpx2]) to migrate.",
+                DeprecationWarning,
+                stacklevel=2,
             )
         if proxies or proxies_config:
             raise NotImplementedError(

--- a/docs/override-patterns.md
+++ b/docs/override-patterns.md
@@ -84,7 +84,10 @@ HTTP layer:
   (aiobotocore/endpoint.py:68)
 - `AioEndpoint._send()` calls `await self.http_session.send()`
 - `AIOHTTPSession` (aiobotocore/httpsession.py) wraps aiohttp
-- `HttpxSession` (aiobotocore/httpxsession.py) wraps httpx
+- `HttpxSession` (aiobotocore/httpxsession.py) wraps httpx. It prefers httpx2
+  (Pydantic's maintained fork; `aiobotocore[httpx2]`) and falls back to the
+  legacy `httpx` package (`aiobotocore[httpx]`), which is deprecated and warns
+  when used. `aiobotocore/_httpx.py` centralises this resolution.
 - `AioConfig.http_session_cls` selects which HTTP backend to use
 
 The HTTP session is created during `AioEndpointCreator.create_endpoint()`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,12 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Recommended httpx backend: httpx2 is Pydantic's maintained fork of httpx.
+httpx2 = [
+    "httpx2 >= 2.0, < 3.0.0"
+]
+# Deprecated: the httpx backend now prefers httpx2. This extra installs the
+# legacy httpx package, which emits a DeprecationWarning when used as a backend.
 httpx = [
     "httpx >= 0.25.1, < 0.29"
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,12 +14,8 @@ import aiohttp
 import anyio
 import pytest
 
-try:
-    import httpx
-except ImportError:
-    httpx = None
-
 import aiobotocore.session
+from aiobotocore._httpx import httpx
 from aiobotocore.config import AioConfig
 from aiobotocore.httpsession import AIOHTTPSession
 from aiobotocore.httpxsession import HttpxSession

--- a/tests/test_basic_s3.py
+++ b/tests/test_basic_s3.py
@@ -6,15 +6,11 @@ from inspect import iscoroutine
 
 import aioitertools
 import botocore.retries.adaptive
-
-try:
-    import httpx
-except ImportError:
-    httpx = None
 import pytest
 
 import aiobotocore.retries.adaptive
 from aiobotocore import httpsession
+from aiobotocore._httpx import httpx
 from aiobotocore.response import StreamingBody
 
 

--- a/tests/test_httpx_compat.py
+++ b/tests/test_httpx_compat.py
@@ -1,0 +1,71 @@
+"""Tests for the httpx / httpx2 backend resolution (aiobotocore._httpx).
+
+The httpx backend prefers httpx2 and falls back to the legacy httpx package,
+which is deprecated. Mirrors authlib's httpx compat tests.
+"""
+
+import importlib
+import sys
+import warnings
+
+import pytest
+
+from aiobotocore import _httpx
+from aiobotocore.httpxsession import HttpxSession
+
+pytestmark = pytest.mark.skipif(
+    _httpx.httpx is None,
+    reason="requires an httpx backend (httpx2 or httpx) to be installed",
+)
+
+
+def test_prefers_httpx2_when_available():
+    httpx2 = pytest.importorskip("httpx2")
+    reloaded = importlib.reload(_httpx)
+    try:
+        assert reloaded.httpx is httpx2
+        assert reloaded.HTTPX_IS_LEGACY is False
+    finally:
+        importlib.reload(_httpx)
+
+
+def test_falls_back_to_legacy_httpx(monkeypatch):
+    legacy_httpx = pytest.importorskip("httpx")
+    # Setting the entry to None makes ``import httpx2`` raise ImportError,
+    # forcing the shim down its legacy-httpx fallback branch.
+    monkeypatch.setitem(sys.modules, "httpx2", None)
+    try:
+        reloaded = importlib.reload(_httpx)
+        assert reloaded.httpx is legacy_httpx
+        assert reloaded.HTTPX_IS_LEGACY is True
+    finally:
+        monkeypatch.undo()
+        importlib.reload(_httpx)
+
+
+def test_httpxsession_warns_when_using_legacy_httpx(monkeypatch):
+    monkeypatch.setattr("aiobotocore.httpxsession.HTTPX_IS_LEGACY", True)
+    monkeypatch.setattr("aiobotocore.httpxsession._LEGACY_HTTPX_WARNED", False)
+    with pytest.warns(DeprecationWarning, match="httpx2"):
+        HttpxSession()
+
+
+def test_httpxsession_warns_only_once_for_many_instances(monkeypatch):
+    monkeypatch.setattr("aiobotocore.httpxsession.HTTPX_IS_LEGACY", True)
+    monkeypatch.setattr("aiobotocore.httpxsession._LEGACY_HTTPX_WARNED", False)
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        for _ in range(3):
+            HttpxSession()
+    deprecations = [
+        r for r in records if issubclass(r.category, DeprecationWarning)
+    ]
+    assert len(deprecations) == 1
+
+
+def test_httpxsession_does_not_warn_on_httpx2(monkeypatch, recwarn):
+    monkeypatch.setattr("aiobotocore.httpxsession.HTTPX_IS_LEGACY", False)
+    HttpxSession()
+    assert not any(
+        issubclass(w.category, DeprecationWarning) for w in recwarn.list
+    )

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -5,11 +5,6 @@ import zipfile
 
 # Third Party
 import botocore.client
-
-try:
-    import httpx
-except ImportError:
-    httpx = None
 import pytest
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -25,6 +25,9 @@ dependencies = [
 httpx = [
     { name = "httpx" },
 ]
+httpx2 = [
+    { name = "httpx2" },
+]
 
 [package.dev-dependencies]
 awscrt = [
@@ -60,13 +63,14 @@ requires-dist = [
     { name = "aioitertools", specifier = ">=0.5.1,<1.0.0" },
     { name = "botocore", specifier = ">=1.43.3,<1.43.57" },
     { name = "httpx", marker = "extra == 'httpx'", specifier = ">=0.25.1,<0.29" },
+    { name = "httpx2", marker = "extra == 'httpx2'", specifier = ">=2.0,<3.0.0" },
     { name = "jmespath", specifier = ">=0.7.1,<2.0.0" },
     { name = "multidict", specifier = ">=6.0.0,<7.0.0" },
     { name = "python-dateutil", specifier = ">=2.1,<3.0.0" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.14.0,<5.0.0" },
     { name = "wrapt", specifier = ">=1.10.10,<3.0.0" },
 ]
-provides-extras = ["httpx"]
+provides-extras = ["httpx2", "httpx"]
 
 [package.metadata.requires-dev]
 awscrt = [{ name = "botocore", extras = ["crt"] }]
@@ -881,7 +885,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1089,6 +1093,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/fe/6a3f9f1a8bb8733326140737446aaf72fddb8b54b8f202302f5c84960613/httpcore2-2.7.0.tar.gz", hash = "sha256:6dc0fedf329a52a990930a5579edfebaea81118ea700ea0dd7de2b5e5be49efc", size = 65593, upload-time = "2026-07-14T20:40:01.111Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/6c/62e2e279e63fc4f7a5ee841ef13175a8bbc613f258e9dcc186e9de803a42/httpcore2-2.7.0-py3-none-any.whl", hash = "sha256:1452f589fe23f55b44546cd884294c41a29330af902bc0b71a761fd52d18f92b", size = 81506, upload-time = "2026-07-14T20:39:58.053Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1104,6 +1121,22 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx2"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/4a/129b2e21b90ac2985d3928d96792bccc39bc6dfe796c5eee2d8ec06d4105/httpx2-2.7.0.tar.gz", hash = "sha256:8b30709aed5c8465b0dd3b95c09ce301c8f79e7e7a2d00ab0af551e0d0375b07", size = 94487, upload-time = "2026-07-14T20:40:02.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/b8/c341bba6411bdfda786020343c47a75ef472f6085caf82391b142b1a3ad9/httpx2-2.7.0-py3-none-any.whl", hash = "sha256:ed2a2719c696789e09493bd8e2bec3d8bd925cc6e26b68389ec25ade132f7bf4", size = 90234, upload-time = "2026-07-14T20:39:59.531Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.19"
 source = { registry = "https://pypi.org/simple" }
@@ -1114,11 +1147,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -2675,23 +2708,23 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.11'" },
-    { name = "babel", marker = "python_full_version < '3.11'" },
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "imagesize", marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "requests", marker = "python_full_version < '3.11'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+    { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -2706,23 +2739,23 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version == '3.11.*'" },
-    { name = "babel", marker = "python_full_version == '3.11.*'" },
-    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "imagesize", marker = "python_full_version == '3.11.*'" },
-    { name = "jinja2", marker = "python_full_version == '3.11.*'" },
-    { name = "packaging", marker = "python_full_version == '3.11.*'" },
-    { name = "pygments", marker = "python_full_version == '3.11.*'" },
-    { name = "requests", marker = "python_full_version == '3.11.*'" },
-    { name = "roman-numerals", marker = "python_full_version == '3.11.*'" },
-    { name = "snowballstemmer", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.11.*'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -2737,23 +2770,23 @@ resolution-markers = [
     "python_full_version >= '3.12'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.12'" },
-    { name = "babel", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "imagesize", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [
@@ -2963,6 +2996,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The optional httpx HTTP backend now prefers [httpx2](https://github.com/pydantic/httpx2)
— Pydantic's maintained, API-compatible fork of httpx — and falls back to the
original `httpx` package, which becomes a deprecated backend. There is **no new
public API**: selecting the backend with `AioConfig(http_session_cls=HttpxSession)`
is unchanged and transparently uses httpx2 when it is installed. A new
`aiobotocore[httpx2]` extra opts in; the existing `aiobotocore[httpx]` extra keeps
working but installs the deprecated fallback and emits a `DeprecationWarning` when
the backend is used.

## Motivation

The original [encode/httpx](https://github.com/encode/httpx) has seen little
maintenance activity, and Pydantic has taken over stewardship under the `httpx2`
package name (same API, same design — the migration is essentially `import httpx2`).
This gives httpx-backend users a maintained path forward, including timely security
updates, without forcing a migration.

## What changed

- **New `aiobotocore._httpx` shim** centralises optional-httpx resolution: it imports
  `httpx2` and falls back to `httpx`, mirroring authlib's `_compat.py` approach. Every
  module that touches httpx (`httpxsession`, `endpoint`, `httpchecksum`,
  `_endpoint_helpers`) now imports `httpx` from it instead of its own `try: import httpx`.
- **`HttpxSession`** transparently uses whichever package resolved. When that is the
  legacy `httpx`, it emits a `DeprecationWarning` — deferred to backend instantiation
  (not raised at import, so aiohttp-only users who merely have `httpx` installed are
  never warned) and guarded to fire at most once per process.
- **Packaging:** new `aiobotocore[httpx2]` extra (`httpx2 >= 2.0, < 3.0.0`); the
  `aiobotocore[httpx]` extra is retained for the deprecated fallback.
- **CI:** the per-cell `no-httpx` toggle is generalised into an `httpx-extra` input and
  the suite runs against three configurations — httpx2 (main matrix), legacy httpx (one
  cell, covering the fallback path and the deprecation warning), and no httpx installed.

## Backward compatibility

- No breaking changes: `http_session_cls=HttpxSession` and the `[httpx]` extra keep working.
- httpx-backend users should switch to `aiobotocore[httpx2]` to silence the deprecation.

## Testing

- Full suite green on both backend resolutions (httpx2 and legacy httpx) and the
  no-httpx configuration.
- New `tests/test_httpx_compat.py` covers the preference, the legacy fallback, and the
  once-per-process deprecation warning.
- `test_patches` hash validation and pre-commit pass.

Structured as two commits: a behaviour-preserving refactor that centralises the import,
then the httpx2 preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
