### PR TITLE
ci: suppress the zizmor dangerous-triggers finding on claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -340,6 +340,7 @@ jobs:
   # event payload.
   notify-fork-pr:
     if: >-
+      github.repository == 'aio-libs/aiobotocore' &&
       github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.fork == true
     runs-on: ubuntu-latest

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,7 +37,7 @@ concurrency:
   group: claude-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-on:
+on:  # zizmor: ignore[dangerous-triggers] see notify-fork-pr: fork code is never checked out
   # Don't "fix" the workflow-validation 401 on PRs that modify claude.yml
   # by switching this to pull_request_target. It tempts because it'd run
   # the workflow against main's file (passing the validator) — but the


### PR DESCRIPTION
Closes the open code-scanning alert
[#48](https://github.com/aio-libs/aiobotocore/security/code-scanning/48)
(`zizmor/dangerous-triggers`, high).

The rule fires on the whole `on:` block because it contains
`pull_request_target`. It is a blanket heuristic — "pull_request_target is
almost always used insecurely" — and this is one of the cases where it is not.

The only job gated on that event is `notify-fork-pr`, which posts a fixed
string on newly opened fork PRs:

* **No checkout.** There is no `actions/checkout` step, so the fork SHA is
  never fetched, let alone executed. That is the actual danger the rule exists
  to catch.
* **Narrow permissions.** `pull-requests: write` and nothing else.
* **No template injection.** The body is a hardcoded literal; the PR number
  and repo name reach the shell through `env:` as `$PR` / `$REPO` rather than
  being interpolated into the `run:` script.
* **Scoped to `opened` on forks**, so it comments once per fork PR.

Suppressed inline rather than dismissed in the GitHub UI so the reasoning sits
next to the trigger, where the next person to edit this block will see it —
the file already carries a comment explaining why `pull_request` must *not*
become `pull_request_target` (#1583), and this keeps that context together.
It also matches the existing `# zizmor: ignore[...]` comments in `ci-cd.yml`
and `reusable-build.yml`.

## Test plan

- [x] `uvx zizmor --persona=regular .github/workflows/claude.yml` → "No findings
      to report" (1 ignored), down from 1 high.
- [x] Whole-directory sweep clean: `uvx zizmor --persona=regular .github/workflows/`
      → no findings, 2 ignored.
- [x] Line is 92 chars, inside the 120 yamllint limit; all pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Follow-up (c0cc291):** added a repository guard to `notify-fork-pr`, which is
also on zizmor's own remediation list for `pull_request_target`:

```yaml
    if: >-
      github.repository == 'aio-libs/aiobotocore' &&
      github.event_name == 'pull_request_target' &&
      github.event.pull_request.head.repo.fork == true
```

Without it, a fork of aiobotocore runs this job on its own fork PRs and spends
the fork's token posting a comment about an automated review that only exists
upstream.

### Why not `workflow_run`?

That is the canonical "more secure" pattern, but it buys nothing here. Its
purpose is isolating *execution of untrusted code* in an unprivileged workflow
and handing results to a privileged one via artifacts. This job executes nothing
untrusted and the comment body is a static literal, so the two-workflow version
would add a second file plus artifact plumbing to transport an integer — same
trust boundary, more machinery. GitHub's own guidance calls `pull_request_target`
"a logical shortcut" for exactly this case:

> If your workflow scenario simply requires commenting on the PR, but does not
> require a check out of the modified code, using `pull_request_target` is a
> logical shortcut.

— [Preventing pwn requests](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)
