### PR TITLE
ci: run zizmor from the released action, not the preview workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -162,6 +162,8 @@ jobs:
     permissions:
       security-events: write
 
+    # No tag to name: upstream ships no tags or releases, so this is main@4656001
+    # (2026-04-14). Dependabot can't track a bare SHA -- bump this one by hand.
     uses: zizmorcore/workflow/.github/workflows/reusable-zizmor.yml@465600191822382e76d26abf77772f21262ecdb6
 
   check:  # This job does nothing and is only used for the branch protection

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -157,14 +157,25 @@ jobs:
         fail_ci_if_error: true
         run_command: send-notifications
 
+  # The upstream action, not zizmorcore/workflow: that reusable workflow is
+  # branded an early preview, appears nowhere in zizmor's docs, and ships no
+  # tags -- so Dependabot has no version to track and its pin rots silently,
+  # which is how it ended up three deprecated actions behind.
   zizmor:
     name: 🌈 zizmor
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
     permissions:
-      security-events: write
-
-    # No tag to name: upstream ships no tags or releases, so this is main@4656001
-    # (2026-04-14). Dependabot can't track a bare SHA -- bump this one by hand.
-    uses: zizmorcore/workflow/.github/workflows/reusable-zizmor.yml@465600191822382e76d26abf77772f21262ecdb6
+      security-events: write  # upload the SARIF to the security tab
+      contents: read
+      actions: read
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      with:
+        persist-credentials: false
+    # Uploads SARIF under category `zizmor` itself (advanced-security defaults
+    # to true), so this needs no upload step of its own.
+    - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054  # v0.6.2
 
   check:  # This job does nothing and is only used for the branch protection
     if: always()

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -162,7 +162,7 @@ jobs:
     permissions:
       security-events: write
 
-    uses: zizmorcore/workflow/.github/workflows/reusable-zizmor.yml@3bb5e95068d0f44b6d2f3f7e91379bed1d2f96a8
+    uses: zizmorcore/workflow/.github/workflows/reusable-zizmor.yml@465600191822382e76d26abf77772f21262ecdb6
 
   check:  # This job does nothing and is only used for the branch protection
     if: always()


### PR DESCRIPTION
Clears the Node 20 deprecation warnings and the CodeQL v3 deprecation notice —
by fixing the reason they appeared rather than bumping past them.

## Where the warnings came from

Not from our workflows. Ours already pin `actions/checkout` v7.0.1 and
`setup-uv` v9.0.0, and reference the CodeQL action nowhere. All three came from
inside `zizmorcore/workflow`, the only third-party reusable workflow we call:

| action | at our pin |
|-|-|
| `actions/checkout` | `v4` (Node 20) |
| `astral-sh/setup-uv` | `d4b2f3b` v5.4.2 (Node 20) |
| `github/codeql-action/upload-sarif` | `v3` (retired December 2026) |

## Why not just bump the pin

Because it would rot again, silently. `zizmorcore/workflow` publishes **no tags
and no releases** — `gh api repos/zizmorcore/workflow/git/refs` returns exactly
one ref, `refs/heads/main`. Dependabot's `github-actions` ecosystem resolves
updates from tags, so a bare SHA gives it nothing to compare against and it
never proposes an update. There is no Dependabot setting that changes this. Our
pin sat on an April commit until these warnings surfaced it.

It is also not the integration upstream intends anyone to use. The repo
describes itself as **"[EARLY PREVIEW] An experimental reusable workflow for
zizmor"**, and [zizmor's docs](https://docs.zizmor.sh/integrations/) do not
mention it at all.

## What this does instead

Uses [`zizmorcore/zizmor-action`](https://github.com/zizmorcore/zizmor-action),
the integration those docs actually recommend:

* **Released, so Dependabot tracks it.** v0.6.2 shipped 2026-08-01, on a
  regular cadence.
* **Already on `upload-sarif` v4.37.3** internally, so the CodeQL deprecation is
  retired for good and future bumps arrive through its releases.
* **Same behaviour.** `advanced-security` defaults to `"true"`, so it uploads
  SARIF under category `zizmor` exactly as before; no separate upload step.
* **Parameterized** (`persona`, `min-severity`, `config`, `version`) if we ever
  want to tune the audit.

Inlining the job also makes its permissions explicit — the old call declared
only `security-events: write` and inherited `contents: read` / `actions: read`
invisibly from the reusable workflow.

## Test plan

- [x] All pre-commit hooks pass.
- [x] `uvx zizmor --persona=regular .github/workflows/ci-cd.yml` → no findings.
- [ ] The 🌈 zizmor job on this PR runs green, still uploads SARIF to the
      security tab under category `zizmor`, and carries no Node 20 annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
