### PR TITLE
fix: ensure concurrency-safe session management in `HTTPSession`

### DIFF
--- a/aiobotocore/httpsession.py
+++ b/aiobotocore/httpsession.py
@@ -83,6 +83,7 @@ class AIOHTTPSession:
 
         # TODO: handle socket_options
         # keep track of sessions by proxy url (if any)
+        self._sessions_lock = asyncio.Lock()
         self._sessions: dict[str | None, aiohttp.ClientSession] | None = None
         self._verify = verify
         self._proxy_config = ProxyConfiguration(
@@ -128,10 +129,11 @@ class AIOHTTPSession:
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         assert self._sessions is not None, 'Session was never entered'
-        self._sessions.clear()
-        await self._exit_stack.aclose()
-        # Make _sessions unusable once context is exited
-        self._sessions = None
+        async with self._sessions_lock:
+            self._sessions.clear()
+            await self._exit_stack.aclose()
+            # Make _sessions unusable once context is exited
+            self._sessions = None
 
     def _get_ssl_context(self):
         return create_urllib3_context()
@@ -222,17 +224,19 @@ class AIOHTTPSession:
 
     async def _get_session(self, proxy_url):
         if not (session := self._sessions.get(proxy_url)):
-            connector = await self._create_connector(proxy_url)
-            self._sessions[proxy_url] = (
-                session
-            ) = await self._exit_stack.enter_async_context(
-                aiohttp.ClientSession(
-                    connector=connector,
-                    timeout=self._timeout,
-                    skip_auto_headers={'CONTENT-TYPE'},
-                    auto_decompress=False,
-                ),
-            )
+            async with self._sessions_lock:
+                if not (session := self._sessions.get(proxy_url)):
+                    connector = await self._create_connector(proxy_url)
+                    self._sessions[proxy_url] = (
+                        session
+                    ) = await self._exit_stack.enter_async_context(
+                        aiohttp.ClientSession(
+                            connector=connector,
+                            timeout=self._timeout,
+                            skip_auto_headers={'CONTENT-TYPE'},
+                            auto_decompress=False,
+                        ),
+                    )
 
         return session
 


### PR DESCRIPTION
### Description of Change

Ensure concurrency-safe session management in `HTTPSession`.

### Assumptions

None

### Checklist for All Submissions

* [x] If this is resolving an issue (needed so future developers can
  determine if change is still necessary and under what conditions)
  (can be provided via link to issue with these details): closes #1695
  * [ ] Detailed description of issue
  * [ ] Alternative methods considered (if any)
  * [ ] How issue is being resolved
  * [ ] How issue can be reproduced
* [ ] If this is providing a new feature (can be provided via link to issue with these details):
  * [ ] Detailed description of new feature
  * [ ] Why needed
  * [ ] Alternatives methods considered (if any)

### Checklist when updating botocore and/or aiohttp versions

* [ ] I have read and followed [CONTRIBUTING.rst](https://github.com/aio-libs/aiobotocore/blob/main/CONTRIBUTING.rst#how-to-upgrade-botocore)
* [ ] I have updated test_patches.py where/if appropriate (also check if no changes necessary)
* [ ] I have added URL to diff: <https://github.com/boto/botocore/compare/>[CURRENT_BOTO_VERSION_TAG]...[NEW_BOTO_VERSION_TAG]
